### PR TITLE
fix(ssg): RHICOMPL-1168 provides no remediation for rsyslog_remote_loghost

### DIFF
--- a/src/connectors/compliance/mock.js
+++ b/src/connectors/compliance/mock.js
@@ -68,6 +68,10 @@ const DATA = Object.freeze({
 
     'xccdf_org.ssgproject.content_rule_disable_host_auth': {
         title: 'Disable Host-Based Authentication'
+    },
+
+    'xccdf_org.ssgproject.content_rule_rsyslog_remote_loghost': {
+        title: 'Ensure Logs Sent To Remote Host'
     }
 });
 

--- a/src/connectors/ssg/mock.js
+++ b/src/connectors/ssg/mock.js
@@ -31,6 +31,8 @@ module.exports = new class extends Connector {
                 return read('standard', 'service_autofs_disabled');
             case 'rhel7|standard|service_rsyslog_enabled':
                 return read('standard', 'service_rsyslog_enabled');
+            case 'rhel7|standard|rsyslog_remote_loghost':
+                return read('standard', 'rsyslog_remote_loghost');
             case 'rhel7|ospp42|mount_option_dev_shm_nodev':
                 return read('ospp42', 'mount_option_dev_shm_nodev');
             case 'rhel7|C2S|disable_host_auth':

--- a/src/connectors/ssg/mock/standard/rsyslog_remote_loghost.yml
+++ b/src/connectors/ssg/mock/standard/rsyslog_remote_loghost.yml
@@ -1,0 +1,32 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# complexity = low
+# strategy = restrict
+# reboot = false
+# disruption = low
+- name: Ensure Logs Sent To Remote Host
+  hosts: '@@HOSTS@@'
+  become: true
+  vars:
+    rsyslog_remote_loghost_address: logcollector
+  tags:
+    - CCE-27343-3
+    - DISA-STIG-RHEL-07-031000
+    - NIST-800-53-AU-3(2)
+    - NIST-800-53-AU-4(1)
+    - NIST-800-53-AU-9
+    - low_complexity
+    - low_disruption
+    - medium_severity
+    - no_reboot_needed
+    - restrict_strategy
+    - rsyslog_remote_loghost
+  tasks:
+
+    - name: Set rsyslog remote loghost
+      lineinfile:
+        dest: /etc/rsyslog.conf
+        regexp: ^\*\.\*
+        line: '*.* @@{{ rsyslog_remote_loghost_address }}'
+        create: true
+      when: ansible_virtualization_role != "guest" or ansible_virtualization_type
+        != "docker"

--- a/src/generator/__snapshots__/ssg.integration.js.snap
+++ b/src/generator/__snapshots__/ssg.integration.js.snap
@@ -426,3 +426,94 @@ exports[`generates a simple playbook with uppercase profile name 1`] = `
       command: insights-client
       changed_when: false"
 `;
+
+exports[`ignores rsyslog_remote_loghost rules for compliance remediations 1`] = `
+"---
+# Red Hat Insights has recommended one or more actions for you, a system administrator, to review and if you
+# deem appropriate, deploy on your systems running Red Hat software. Based on the analysis, we have automatically
+# generated an Ansible Playbook for you. Please review and test the recommended actions and the Playbook as
+# they may contain configuration changes, updates, reboots and/or other changes to your systems. Red Hat is not
+# responsible for any adverse outcomes related to these recommendations or Playbooks.
+
+# Disable Prelinking
+# Identifier: (ssg:rhel7|pci-dss|xccdf_org.ssgproject.content_rule_disable_prelink,fix)
+# Version: NORMALIZED_PLACEHOLDER
+- name: Disable Prelinking
+  hosts: '68799a02-8be9-11e8-9eb6-529269fb1459.example.com'
+  become: true
+  tags:
+    - CCE-27078-5
+    - CJIS-5.10.1.3
+    - NIST-800-171-3.13.11
+    - NIST-800-53-CM-6(3)
+    - NIST-800-53-CM-6(d)
+    - NIST-800-53-IA-7
+    - NIST-800-53-SC-13
+    - NIST-800-53-SC-28
+    - NIST-800-53-SI-7
+    - PCI-DSS-Req-11.5
+    - disable_prelink
+    - low_complexity
+    - low_disruption
+    - medium_severity
+    - no_reboot_needed
+    - restrict_strategy
+  tasks:
+    - name: Does prelink file exist
+      stat:
+        path: /etc/sysconfig/prelink
+      register: prelink_exists
+      notify: insights_reboot_handler
+    - name: disable prelinking
+      lineinfile:
+        path: /etc/sysconfig/prelink
+        regexp: ^PRELINKING=
+        line: PRELINKING=no
+      when: prelink_exists.stat.exists
+      notify: insights_reboot_handler
+  handlers:
+    - name: insights_reboot_handler
+      set_fact:
+        insights_needs_reboot: true
+
+
+# Reboots a system if any of the preceeding plays sets the 'insights_needs_reboot' variable to true.
+# The variable can be overridden to suppress this behavior.
+- name: Reboot system (if applicable)
+  hosts: \\"68799a02-8be9-11e8-9eb6-529269fb1459.example.com\\"
+  vars:
+    insights_signature_exclude: \\"/hosts\\"
+  become: True
+  gather_facts: False
+  tasks:
+    - when:
+        - insights_needs_reboot is defined
+        - insights_needs_reboot
+      block:
+        - name: Reboot system
+          shell: sleep 2 && shutdown -r now \\"Ansible triggered reboot\\"
+          async: 1
+          poll: 0
+          ignore_errors: true
+
+        - name: Wait for system to boot up
+          local_action:
+            module: wait_for
+            host: \\"{{ hostvars[inventory_hostname]['ansible_host'] | default(hostvars[inventory_hostname]['ansible_ssh_host'], true) | default(inventory_hostname, true) }}\\"
+            port: \\"{{ hostvars[inventory_hostname]['ansible_port'] | default(hostvars[inventory_hostname]['ansible_ssh_port'], true) | default('22', true) }}\\"
+            delay: 15
+            search_regex: OpenSSH
+            timeout: 300
+          become: false
+
+- name: run insights
+  hosts: \\"68799a02-8be9-11e8-9eb6-529269fb1459.example.com\\"
+  vars:
+    insights_signature_exclude: \\"/hosts\\"
+  become: True
+  gather_facts: False
+  tasks:
+    - name: run insights
+      command: insights-client
+      changed_when: false"
+`;

--- a/src/generator/factories/ComplianceFactory.js
+++ b/src/generator/factories/ComplianceFactory.js
@@ -8,6 +8,8 @@ const Factory = require('./Factory');
 module.exports = class ComplianceFactory extends Factory {
 
     async createPlay ({id, hosts, resolution}, strict = true) {
+        if (id.issue.includes('rsyslog_remote_loghost')) { return null; }
+
         const handler = issues.getHandler(id);
 
         const [resolutions, rule] = await P.all([

--- a/src/generator/ssg.integration.js
+++ b/src/generator/ssg.integration.js
@@ -35,6 +35,24 @@ test('generates a simple playbook with multiple compliance remediation', async (
     expect(normalizePlaybookVersionForSnapshot(res.text)).toMatchSnapshot();
 });
 
+test('ignores rsyslog_remote_loghost rules for compliance remediations', async () => {
+    const data = {
+        issues: [{
+            id: 'ssg:rhel7|pci-dss|xccdf_org.ssgproject.content_rule_disable_prelink',
+            systems: ['68799a02-8be9-11e8-9eb6-529269fb1459']
+        }, {
+            id: 'ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_rsyslog_remote_loghost',
+            systems: ['68799a02-8be9-11e8-9eb6-529269fb1459']
+        }]
+    };
+
+    const res = await request
+    .post('/v1/playbook')
+    .send(data)
+    .expect(200);
+    expect(normalizePlaybookVersionForSnapshot(res.text)).toMatchSnapshot();
+});
+
 test('400s on unknown issue id', () => {
     const {id, header} = reqId();
 


### PR DESCRIPTION
An initial attempt to disable resolutions of rule rsyslog_remote_loghost for all RHEL versions and profiles.

  ## Secure Coding Practices Checklist GitHub Link
  - https://github.com/RedHatInsights/secure-coding-checklist

  ## Secure Coding Checklist
  - [x] Input Validation
  - [x] Output Encoding
  - [x] Authentication and Password Management
  - [x] Session Management
  - [x] Access Control
  - [x] Cryptographic Practices
  - [x] Error Handling and Logging
  - [x] Data Protection
  - [x] Communication Security
  - [x] System Configuration
  - [x] Database Security
  - [x] File Management
  - [x] Memory Management
  - [x] General Coding Practices

CC @aleccohan @jharting 

Testing with Compliance locally (`false` means no remediation available):
```rb
JSON.parse(RemediationsAPI.new(Account.first).send(:remediations_response, Rule.where(ref_id: 'xccdf_org.ssgproject.content_rule_rsyslog_remote_loghost')).body)
=> {"ssg:rhel8|hipaa|xccdf_org.ssgproject.content_rule_rsyslog_remote_loghost"=>false,
 "ssg:rhel7|c2s|xccdf_org.ssgproject.content_rule_rsyslog_remote_loghost"=>false,
 "ssg:rhel8|cui|xccdf_org.ssgproject.content_rule_rsyslog_remote_loghost"=>false,
 "ssg:rhel7|hipaa|xccdf_org.ssgproject.content_rule_rsyslog_remote_loghost"=>false,
 "ssg:rhel7|anssi_nt28_enhanced|xccdf_org.ssgproject.content_rule_rsyslog_remote_loghost"=>false,
 "ssg:rhel6|cs2|xccdf_org.ssgproject.content_rule_rsyslog_remote_loghost"=>false,
 "ssg:rhel7|nist-800-171-cui|xccdf_org.ssgproject.content_rule_rsyslog_remote_loghost"=>false}
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>