### PR TITLE
Add '+' char to IssueId validation

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -713,7 +713,7 @@ components:
 
     IssueId:
       type: string
-      pattern: ^(advisor|vulnerabilities|ssg|test|patch-advisory|patch-package):[\w\d_|:\.-]+$
+      pattern: ^(advisor|vulnerabilities|ssg|test|patch-advisory|patch-package):[\w\d_|:\.+-]+$
       example: advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074
 
     RemediationAutoReboot:

--- a/src/connectors/vmaas/mock.js
+++ b/src/connectors/vmaas/mock.js
@@ -50,6 +50,15 @@ const PACKAGES = {
     },
     'systemd-239-13.el8_0.5.x86_64': {
         description: 'systemd is a system and service manager that runs as PID 1 and starts.'
+    },
+    'libstdc++-8.3.1-5.1.el8.x86_64': {
+        description: 'GNU Standard C++ Library'
+    },
+    'qemu-guest-agent-15:4.2.0-34.module+el8.3.0+8829+e7a0a3ea.1.x86_64': {
+        description: 'QEMU Guest Agent'
+    },
+    'some.my-odd_pkg-1000:11.23.444.5-8.1.el8.x86_64': {
+        description: 'Some testing rpm with weird package name'
     }
 };
 

--- a/src/generator/__snapshots__/package.integration.js.snap
+++ b/src/generator/__snapshots__/package.integration.js.snap
@@ -167,14 +167,17 @@ exports[`patchman - package using patch-package generates a playbook with multip
 # responsible for any adverse outcomes related to these recommendations or Playbooks.
 
 # Upgrade the following packages:
+#   - Upgrade packages libstdc++-8.3.1-5.1.el8.x86_64
+#   - Upgrade packages qemu-guest-agent-15:4.2.0-34.module+el8.3.0+8829+e7a0a3ea.1.x86_64
 #   - Upgrade packages rpm-4.14.2-37.el8.x86_64
+#   - Upgrade packages some.my-odd_pkg-1000:11.23.444.5-8.1.el8.x86_64
 #   - Upgrade packages systemd-239-13.el8_0.5.x86_64
-# Identifier: (patch-package:rpm-4.14.2-37.el8.x86_64,patch-package:systemd-239-13.el8_0.5.x86_64,fix)
+# Identifier: (patch-package:libstdc++-8.3.1-5.1.el8.x86_64,patch-package:qemu-guest-agent-15:4.2.0-34.module+el8.3.0+8829+e7a0a3ea.1.x86_64,patch-package:rpm-4.14.2-37.el8.x86_64,patch-package:some.my-odd_pkg-1000:11.23.444.5-8.1.el8.x86_64,patch-package:systemd-239-13.el8_0.5.x86_64,fix)
 # Version: test
 - name: update packages
   hosts: \\"68799a02-8be9-11e8-9eb6-529269fb1459.example.com\\"
   vars:
-    insights_issues: \\"rpm-4.14.2-37.el8.x86_64 systemd-239-13.el8_0.5.x86_64\\"
+    insights_issues: \\"libstdc++-8.3.1-5.1.el8.x86_64 qemu-guest-agent-15:4.2.0-34.module+el8.3.0+8829+e7a0a3ea.1.x86_64 rpm-4.14.2-37.el8.x86_64 some.my-odd_pkg-1000:11.23.444.5-8.1.el8.x86_64 systemd-239-13.el8_0.5.x86_64\\"
     insights_signature_exclude: \\"/hosts,/vars/insights_issues\\"
   become: true
   tasks:

--- a/src/generator/package.integration.js
+++ b/src/generator/package.integration.js
@@ -28,6 +28,15 @@ describe('patchman - package using patch-package', function () {
             }, {
                 id: 'patch-package:systemd-239-13.el8_0.5.x86_64',
                 systems: ['68799a02-8be9-11e8-9eb6-529269fb1459']
+            }, {
+                id: 'patch-package:libstdc++-8.3.1-5.1.el8.x86_64',
+                systems: ['68799a02-8be9-11e8-9eb6-529269fb1459']
+            }, {
+                id: 'patch-package:qemu-guest-agent-15:4.2.0-34.module+el8.3.0+8829+e7a0a3ea.1.x86_64',
+                systems: ['68799a02-8be9-11e8-9eb6-529269fb1459']
+            }, {
+                id: 'patch-package:some.my-odd_pkg-1000:11.23.444.5-8.1.el8.x86_64',
+                systems: ['68799a02-8be9-11e8-9eb6-529269fb1459']
             }]
         };
 

--- a/src/issues/index.js
+++ b/src/issues/index.js
@@ -7,7 +7,7 @@ const CSAW_PATTERN = /^CVE-20[\d]{2}-[\d]{4,}:\w+\|[A-Z\d_]+$/;
 const ADVISOR_PATTERN = /^\w+\|[A-Z\d_]+$/;
 const CVE_PATTERN = /^CVE-20[\d]{2}-[\d]{4,}/;
 // eslint-disable-next-line security/detect-unsafe-regex
-const PKG_PATTERN = /^[a-z]+-(\d+:)?([\d]|\.)+-[a-z0-9._]+\.[a-z0-9_]+$/;
+const PKG_PATTERN = /^[a-z-._+]+-(\d+:)?([\d-]|\.)+-[a-z0-9-._+]+\.[a-z0-9-._+]+$/;
 
 const advisorHandler = new(require('./AdvisorHandler'))();
 const cveHandler = new(require('./CVEHandler'))();

--- a/src/remediations/read.integration.js
+++ b/src/remediations/read.integration.js
@@ -534,7 +534,7 @@ describe('remediations', function () {
             '400 on bad issue_id',
             '/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/issues/test:/systems',
             'pattern.openapi.validation',
-            'should match pattern "^(advisor|vulnerabilities|ssg|test|patch-advisory|patch-package):[\\w\\d_|:\\.-]+$" (location: path, path: issue)'
+            'should match pattern "^(advisor|vulnerabilities|ssg|test|patch-advisory|patch-package):[\\w\\d_|:\\.+-]+$" (location: path, path: issue)'
         );
 
         test400(

--- a/src/util/identifiers.js
+++ b/src/util/identifiers.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const errors = require('../errors');
-const PATTERN = /^(advisor|vulnerabilities|ssg|test|patch-advisory|patch-package):([\w\d_|:\\.-]+)$/;
+const PATTERN = /^(advisor|vulnerabilities|ssg|test|patch-advisory|patch-package):([\w\d_|:\\.+-]+)$/;
 const SSG_PATTERN = /^([\w-]+)\|([\w-]+)\|xccdf_org\.ssgproject\.content_rule_([\w\d-_:\\.]+)$/;
 const CSAW_PATTERN = /^(CVE-20[\d]{2}-[\d]{4,}):(\w+\|[A-Z\d_]+)$/;
 const CSAW_RULE_PATTERN = /^(\w+\|[A-Z\d_]+)$/;

--- a/src/util/identifiers.unit.js
+++ b/src/util/identifiers.unit.js
@@ -32,6 +32,20 @@ test('parses a vulnerabilities (erratum) id', () => {
     parsed.should.have.property('full', 'vulnerabilities:RHBA-2007:0331');
 });
 
+test('parses patch (erratum) id', () => {
+    const parsed = identifiers.parse('patch-advisory:RHBA-2021:0439');
+    parsed.should.have.property('app', 'patch-advisory');
+    parsed.should.have.property('issue', 'RHBA-2021:0439');
+    parsed.should.have.property('full', 'patch-advisory:RHBA-2021:0439');
+});
+
+test('parses patch (package) id', () => {
+    const parsed = identifiers.parse('patch-package:libstdc++-8.3.1-5.1.el8.x86_64');
+    parsed.should.have.property('app', 'patch-package');
+    parsed.should.have.property('issue', 'libstdc++-8.3.1-5.1.el8.x86_64');
+    parsed.should.have.property('full', 'patch-package:libstdc++-8.3.1-5.1.el8.x86_64');
+});
+
 test('parses a vulnerabilities (csaw) id', () => {
     const parsed = identifiers.parse('vulnerabilities:CVE-2017-5715:network_bond_opts_config_issue|NETWORK_BONDING_OPTS_DOUBLE_QUOTES_ISSUE');
     parsed.should.have.property('app', 'vulnerabilities');


### PR DESCRIPTION
'+' is a valid character to be contained in package names and versions. 
Some examples:
Package name: 'libstdc++'
Package with module: qemu-guest-agent-15:4.2.0-34.module+el8.3.0+8829+e7a0a3ea.1.x86_64

Currently, remediation fails on API validation due to this.