### PR TITLE
RHCLOUD-12216: Advisor template fails with unexpected templating

### DIFF
--- a/src/generator/__snapshots__/advisor.unit.js.snap
+++ b/src/generator/__snapshots__/advisor.unit.js.snap
@@ -16,7 +16,7 @@ exports[`does not mind extra whitespace in HOSTS variable declaration 1`] = `
   become: True
   tasks:
     - name: obtain diagnosis info
-      command: \\"insights-client --diagnosis{{ remediation | regex_search('[a-fA-F0-9]{8}[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
+      command: \\"insights-client --diagnosis{{ insights_remediation | regex_search('\\\\\\\\s[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
       register: insights_result
       changed_when: false
       check_mode: false
@@ -84,7 +84,7 @@ exports[`generates a rule-based playbook 1`] = `
   become: True
   tasks:
     - name: obtain diagnosis info
-      command: \\"insights-client --diagnosis{{ remediation | regex_search('[a-fA-F0-9]{8}[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
+      command: \\"insights-client --diagnosis{{ insights_remediation | regex_search('\\\\\\\\s[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
       register: insights_result
       changed_when: false
       check_mode: false
@@ -145,7 +145,7 @@ exports[`puts quotes around hosts list 1`] = `
   become: True
   tasks:
     - name: obtain diagnosis info
-      command: \\"insights-client --diagnosis{{ remediation | regex_search('[a-fA-F0-9]{8}[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
+      command: \\"insights-client --diagnosis{{ insights_remediation | regex_search('\\\\\\\\s[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
       register: insights_result
       changed_when: false
       check_mode: false

--- a/src/generator/__snapshots__/generator.unit.js.snap
+++ b/src/generator/__snapshots__/generator.unit.js.snap
@@ -16,7 +16,7 @@ exports[`adds diagnosis play 1`] = `
   become: True
   tasks:
     - name: obtain diagnosis info
-      command: \\"insights-client --diagnosis{{ remediation | regex_search('[a-fA-F0-9]{8}[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
+      command: \\"insights-client --diagnosis{{ insights_remediation | regex_search('\\\\\\\\s[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
       register: insights_result
       changed_when: false
       check_mode: false
@@ -192,7 +192,7 @@ exports[`generates a CSAW playbook (rule only) 1`] = `
   become: True
   tasks:
     - name: obtain diagnosis info
-      command: \\"insights-client --diagnosis{{ remediation | regex_search('[a-fA-F0-9]{8}[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
+      command: \\"insights-client --diagnosis{{ insights_remediation | regex_search('\\\\\\\\s[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
       register: insights_result
       changed_when: false
       check_mode: false
@@ -253,7 +253,7 @@ exports[`generates a CSAW playbook full id 1`] = `
   become: True
   tasks:
     - name: obtain diagnosis info
-      command: \\"insights-client --diagnosis{{ remediation | regex_search('[a-fA-F0-9]{8}[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
+      command: \\"insights-client --diagnosis{{ insights_remediation | regex_search('\\\\\\\\s[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
       register: insights_result
       changed_when: false
       check_mode: false

--- a/src/generator/__snapshots__/vulnerabilities.unit.js.snap
+++ b/src/generator/__snapshots__/vulnerabilities.unit.js.snap
@@ -113,7 +113,7 @@ exports[`generates a rule-based playbook with resolution preference 1`] = `
   become: True
   tasks:
     - name: obtain diagnosis info
-      command: \\"insights-client --diagnosis{{ remediation | regex_search('[a-fA-F0-9]{8}[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
+      command: \\"insights-client --diagnosis{{ insights_remediation | regex_search('\\\\\\\\s[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
       register: insights_result
       changed_when: false
       check_mode: false

--- a/src/remediations/__snapshots__/playbook.integration.js.snap
+++ b/src/remediations/__snapshots__/playbook.integration.js.snap
@@ -21,7 +21,7 @@ exports[`playbooks generates playbook that does not need reboot 1`] = `
   become: True
   tasks:
     - name: obtain diagnosis info
-      command: \\"insights-client --diagnosis{{ remediation | regex_search('[a-fA-F0-9]{8}[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
+      command: \\"insights-client --diagnosis{{ insights_remediation | regex_search('\\\\\\\\s[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
       register: insights_result
       changed_when: false
       check_mode: false
@@ -87,7 +87,7 @@ exports[`playbooks generates playbook with pydata and playbook support 1`] = `
   become: True
   tasks:
     - name: obtain diagnosis info
-      command: \\"insights-client --diagnosis{{ remediation | regex_search('[a-fA-F0-9]{8}[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
+      command: \\"insights-client --diagnosis{{ insights_remediation | regex_search('\\\\\\\\s[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}\\"
       register: insights_result
       changed_when: false
       check_mode: false

--- a/src/remediations/playbook.integration.js
+++ b/src/remediations/playbook.integration.js
@@ -60,8 +60,8 @@ describe('playbooks', function () {
             });
         }
 
-        testCaching('pydata playbook', '66eec356-dd06-4c72-a3b6-ef27d1508a02', 'W/"292f-RhymYQZkvsq5SZnCeg/Oondk6wo"');
-        testCaching('no reboot playbook', 'e809526c-56f5-4cd8-a809-93328436ea23', 'W/"a93-/APLwi8eU+qMHspypf9qDdvTR34"');
+        testCaching('pydata playbook', '66eec356-dd06-4c72-a3b6-ef27d1508a02', 'W/"292d-19TCgRBe3p5W8Ih3o8V01ru//1E"');
+        testCaching('no reboot playbook', 'e809526c-56f5-4cd8-a809-93328436ea23', 'W/"a91-HLtU1TToIdeOcfS5dYLwu0kPtps"');
         testCaching('playbook with suppressed reboot', '178cf0c8-35dd-42a3-96d5-7b50f9d211f6',
             'W/"c59-sbR6UQ00yl1kGotASakmwxFFBEM"');
 

--- a/src/templates/static/special/diagnosis.yml
+++ b/src/templates/static/special/diagnosis.yml
@@ -6,7 +6,7 @@
   become: True
   tasks:
     - name: obtain diagnosis info
-      command: "insights-client --diagnosis{{ remediation | regex_search('[a-fA-F0-9]{8}[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}"
+      command: "insights-client --diagnosis{{ insights_remediation | regex_search('\\s[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}') }}"
       register: insights_result
       changed_when: false
       check_mode: false


### PR DESCRIPTION
Updated default Advisor diagnosis template to fix issue in this bugzilla.  Turns out the Regex needed to be slightly changed to acomodate for the whitespace character as well as the variable needing to be changed.    

Bugzilla in question: https://bugzilla.redhat.com/show_bug.cgi?id=1925655
JIRA: https://issues.redhat.com/browse/RHCLOUD-12216

## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices