### PR TITLE
RHCLOUD-12591: Add getSystemProfileBatch() to inventory impl

### DIFF
--- a/db/seeders/20190107133125-tests-read-single.js
+++ b/db/seeders/20190107133125-tests-read-single.js
@@ -5,6 +5,7 @@ const { account_number, username: created_by } = require('../../src/connectors/u
 const { NON_EXISTENT_SYSTEM } = require('../../src/connectors/inventory/mock');
 const SYSTEM = '1040856f-b772-44c7-83a9-eea4813c4be8';
 const SYSTEM2 = '9dae9304-86a8-4f66-baa3-a1b27dfdd479';
+const SYSTEM3 = '4bb19a8a-0c07-4ee6-a78c-504dab783cc8';
 
 const opts = {
     returning: true
@@ -75,6 +76,15 @@ exports.up = async q => {
         created_at: '2018-11-04T03:19:36.641Z',
         updated_by: created_by,
         updated_at: '2018-11-04T03:19:36.641Z'
+    }, {
+        id: '7d727f9c-7d9e-458d-a128-a9ffae1802ab',
+        name: 'system profile test',
+        auto_reboot: false,
+        account_number,
+        created_by,
+        created_at: '2018-11-04T03:19:36.641Z',
+        updated_by: created_by,
+        updated_at: '2018-11-04T03:19:36.641Z'
     }], opts);
 
     const issues = await q.bulkInsert('remediation_issues', [{
@@ -120,6 +130,9 @@ exports.up = async q => {
     }, {
         remediation_id: remediations[6].id,
         issue_id: 'test:reboot'
+    }, {
+        remediation_id: remediations[7].id,
+        issue_id: 'test:reboot'
     }], opts);
 
     await q.bulkInsert('remediation_issue_systems', [
@@ -141,6 +154,11 @@ exports.up = async q => {
         {
             remediation_issue_id: issues[12].id,
             system_id: SYSTEM2,
+            resolved: false
+        },
+        {
+            remediation_issue_id: issues[14].id,
+            system_id: SYSTEM3,
             resolved: false
         }
     ]);

--- a/src/connectors/inventory/mock.js
+++ b/src/connectors/inventory/mock.js
@@ -16,6 +16,7 @@ const SATELLITES = [
 
 const SYSTEMS = {
     'fc94beb8-21ee-403d-99b1-949ef7adb762': {},
+    '4bb19a8a-0c07-4ee6-a78c-504dab783cc8': {},
     '1040856f-b772-44c7-83a9-eeeeeeeeee01': {
         hostname: 'foo,bar,example.com'
     },
@@ -44,6 +45,22 @@ const SYSTEMS = {
         ]
     }
 };
+
+function generateSystemProfile (id) {
+    if (id === NON_EXISTENT_SYSTEM) {
+        return null;
+    }
+
+    // eslint-disable-next-line security/detect-object-injection
+    return [
+        {
+            id,
+            system_profile: {
+                owner_id: '81390ad6-ce49-4c8f-aa64-729d374ee65c'
+            }
+        }
+    ];
+}
 
 function generateSystem (id) {
     const satelliteIndex = parseInt(id[id.length - 1], 16) % SATELLITES.length;
@@ -82,6 +99,14 @@ module.exports = new class extends Connector {
         return Promise.resolve(_(systems)
         .keyBy()
         .mapValues(generateSystem)
+        .pickBy()
+        .value());
+    }
+
+    getSystemProfileBatch (systems) {
+        return Promise.resolve(_(systems)
+        .keyBy()
+        .mapValues(generateSystemProfile)
         .pickBy()
         .value());
     }

--- a/src/connectors/inventory/xjoin.queries.js
+++ b/src/connectors/inventory/xjoin.queries.js
@@ -34,6 +34,29 @@ exports.BATCH_DETAILS_QUERY = `
     }
 `;
 
+exports.BATCH_PROFILE_QUERY = `
+    query hosts (
+        $filter: HostFilter,
+        $order_by: HOSTS_ORDER_BY,
+        $order_how: ORDER_DIR,
+        $limit: Int,
+        $offset: Int) {
+        hosts (
+            filter: $filter
+            order_by: $order_by,
+            order_how: $order_how,
+            limit: $limit,
+            offset: $offset
+        )
+        {
+            data {
+                id
+                system_profile_facts (filter: ["owner_id"])
+            }
+        }
+    }
+`;
+
 exports.INSIGHTS_ID_QUERY = `
     query hosts ($insights_id: String) {
         hosts (filter: {insights_id: {eq: $insights_id}})
@@ -49,7 +72,7 @@ exports.INSIGHTS_ID_QUERY = `
     }
 `;
 
-exports.runQuery = async function (query, variables, headers = { [IDENTITY_HEADER]: createIdentityHeader()}, metrics = false) {
+exports.runQuery = async function (query, variables, headers = {[IDENTITY_HEADER]: createIdentityHeader()}, metrics = false) {
     try {
         const client = new GraphQLClient(xjoinHost, { headers });
         const before = new Date();

--- a/src/remediations/__snapshots__/read.integration.js.snap
+++ b/src/remediations/__snapshots__/read.integration.js.snap
@@ -3100,8 +3100,8 @@ exports[`remediations list system filter filters out remediations not featuring 
 exports[`remediations missing listing of remediations does not blow up 1`] = `
 "{
     \\"meta\\": {
-        \\"count\\": 7,
-        \\"total\\": 7
+        \\"count\\": 8,
+        \\"total\\": 8
     },
     \\"links\\": {
         \\"first\\": \\"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0\\",
@@ -3233,6 +3233,27 @@ exports[`remediations missing listing of remediations does not blow up 1`] = `
             \\"needs_reboot\\": true,
             \\"system_count\\": 2,
             \\"issue_count\\": 2,
+            \\"resolved_count\\": 0,
+            \\"archived\\": false
+        },
+        {
+            \\"id\\": \\"7d727f9c-7d9e-458d-a128-a9ffae1802ab\\",
+            \\"name\\": \\"system profile test\\",
+            \\"created_by\\": {
+                \\"username\\": \\"testReadSingleUser\\",
+                \\"first_name\\": \\"test\\",
+                \\"last_name\\": \\"user\\"
+            },
+            \\"created_at\\": \\"2018-11-04T03:19:36.641Z\\",
+            \\"updated_by\\": {
+                \\"username\\": \\"testReadSingleUser\\",
+                \\"first_name\\": \\"test\\",
+                \\"last_name\\": \\"user\\"
+            },
+            \\"updated_at\\": \\"2018-11-04T03:19:36.641Z\\",
+            \\"needs_reboot\\": true,
+            \\"system_count\\": 1,
+            \\"issue_count\\": 1,
             \\"resolved_count\\": 0,
             \\"archived\\": false
         },

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -63,6 +63,9 @@ exports.auth = Object.freeze({
     cert01: {
         [identityUtils.IDENTITY_HEADER]: identityUtils.createCertIdentityHeader('diagnosis01')
     },
+    cert02: {
+        [identityUtils.IDENTITY_HEADER]: identityUtils.createCertIdentityHeader(USERS.testReadSingleUser.account_number)
+    },
     jharting: createHeader(null, null, null, () => ({
         entitlements: {
             insights: {


### PR DESCRIPTION
Added getSystemProfileBatch() to both inventory impl() as well as xjoin implementations.  This is going to be used for an additional check wrt adding cert auth to remediations /playbook endpoint.

## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices