### PR TITLE
RHCLOUD-12760: Modify Remediations to include RHC compatability

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -714,8 +714,7 @@ components:
                 type: array
                 items:
                   type: string
-                  format: uuid
-                  example: 9197ba55-0abc-4028-9bbe-269e530f8bd5
+                  example: 9197ba55-0abc-4028-9bbe-269e530f8bd5 or "RHC"
 
   schemas:
     #

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -35,6 +35,7 @@ const config = {
     port: (env.NODE_ENV === 'test') ? 9003 : 9002,
     commit: env.OPENSHIFT_BUILD_COMMIT,
     demo: (env.DEMO_MODE === 'true') ? true : false,
+    platformHostname: env.PLATFORM_HOSTNAME || 'hostname',
 
     bodyParserLimit: env.BODY_PARSER_LIMIT || '1mb',
 

--- a/src/connectors/inventory/impl.js
+++ b/src/connectors/inventory/impl.js
@@ -108,7 +108,7 @@ module.exports = new class extends Connector {
         uri.segment(ids.join());
         uri.segment('system_profile');
         uri.addQuery('per_page', String(pageSize));
-        uri.addQuery('fields[system_profile]', 'owner_id');
+        uri.addQuery('fields[system_profile]', 'owner_id,rhc_client_id');
 
         let response = null;
 

--- a/src/connectors/inventory/impl.unit.js
+++ b/src/connectors/inventory/impl.unit.js
@@ -254,7 +254,8 @@ describe('inventory impl', function () {
                     results: [{
                         id: '9dae9304-86a8-4f66-baa3-a1b27dfdd479',
                         system_profile: {
-                            owner_id: '81390ad6-ce49-4c8f-aa64-729d374ee65c'
+                            owner_id: '81390ad6-ce49-4c8f-aa64-729d374ee65c',
+                            rhc_client_id: 'f415fc2d-9700-4e30-9621-6a410ccc92c8'
                         }
                     }]
                 },
@@ -267,6 +268,7 @@ describe('inventory impl', function () {
             const result = results['9dae9304-86a8-4f66-baa3-a1b27dfdd479'];
             result.should.have.property('id', '9dae9304-86a8-4f66-baa3-a1b27dfdd479');
             result.system_profile.should.have.property('owner_id', '81390ad6-ce49-4c8f-aa64-729d374ee65c');
+            result.system_profile.should.have.property('rhc_client_id', 'f415fc2d-9700-4e30-9621-6a410ccc92c8');
 
             http.callCount.should.equal(1);
             const options = http.args[0][0];
@@ -296,7 +298,8 @@ describe('inventory impl', function () {
                     results: [{
                         id: '9dae9304-86a8-4f66-baa3-a1b27dfdd479',
                         system_profile: {
-                            owner_id: '81390ad6-ce49-4c8f-aa64-729d374ee65c'
+                            owner_id: '81390ad6-ce49-4c8f-aa64-729d374ee65c',
+                            rhc_client_id: 'f415fc2d-9700-4e30-9621-6a410ccc92c8'
                         }
                     }]
                 },
@@ -309,6 +312,7 @@ describe('inventory impl', function () {
             const result = results['9dae9304-86a8-4f66-baa3-a1b27dfdd479'];
             result.should.have.property('id', '9dae9304-86a8-4f66-baa3-a1b27dfdd479');
             result.system_profile.should.have.property('owner_id', '81390ad6-ce49-4c8f-aa64-729d374ee65c');
+            result.system_profile.should.have.property('rhc_client_id', 'f415fc2d-9700-4e30-9621-6a410ccc92c8');
 
             http.callCount.should.equal(3);
             const options = http.args[0][0];

--- a/src/connectors/inventory/mock.js
+++ b/src/connectors/inventory/mock.js
@@ -51,6 +51,16 @@ function generateSystemProfile (id) {
         return null;
     }
 
+    if (id === '750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4') {
+        return {
+            id,
+            system_profile: {
+                owner_id: '81390ad6-ce49-4c8f-aa64-729d374ee65c',
+                rhc_client_id: 'f415fc2d-9700-4e30-9621-6a410ccc92c8'
+            }
+        };
+    }
+
     // eslint-disable-next-line security/detect-object-injection
     return {
         id,

--- a/src/connectors/inventory/xjoin.queries.js
+++ b/src/connectors/inventory/xjoin.queries.js
@@ -51,7 +51,7 @@ exports.BATCH_PROFILE_QUERY = `
         {
             data {
                 id
-                system_profile_facts (filter: ["owner_id"])
+                system_profile_facts (filter: ["owner_id", "rhc_client_id"])
             }
         }
     }

--- a/src/connectors/inventory/xjoin.unit.js
+++ b/src/connectors/inventory/xjoin.unit.js
@@ -178,7 +178,8 @@ describe('inventory xjoin', function () {
                             {
                                 id: '9dae9304-86a8-4f66-baa3-a1b27dfdd479',
                                 system_profile_facts: {
-                                    owner_id: '81390ad6-ce49-4c8f-aa64-729d374ee65c'
+                                    owner_id: '81390ad6-ce49-4c8f-aa64-729d374ee65c',
+                                    rhc_client_id: 'f415fc2d-9700-4e30-9621-6a410ccc92c8'
                                 }
                             }
                         ]
@@ -203,7 +204,8 @@ describe('inventory xjoin', function () {
                             {
                                 id: '9dae9304-86a8-4f66-baa3-a1b27dfdd479',
                                 system_profile_facts: {
-                                    owner_id: '81390ad6-ce49-4c8f-aa64-729d374ee65c'
+                                    owner_id: '81390ad6-ce49-4c8f-aa64-729d374ee65c',
+                                    rhc_client_id: 'f415fc2d-9700-4e30-9621-6a410ccc92c8'
                                 }
                             }
                         ]
@@ -217,6 +219,7 @@ describe('inventory xjoin', function () {
             const result = results['9dae9304-86a8-4f66-baa3-a1b27dfdd479'];
             result.should.have.property('id', '9dae9304-86a8-4f66-baa3-a1b27dfdd479');
             result.system_profile.should.have.property('owner_id', '81390ad6-ce49-4c8f-aa64-729d374ee65c');
+            result.system_profile.should.have.property('rhc_client_id', 'f415fc2d-9700-4e30-9621-6a410ccc92c8');
 
             http.callCount.should.equal(1);
         });
@@ -235,7 +238,8 @@ describe('inventory xjoin', function () {
                             {
                                 id: '9dae9304-86a8-4f66-baa3-a1b27dfdd479',
                                 system_profile_facts: {
-                                    owner_id: '81390ad6-ce49-4c8f-aa64-729d374ee65c'
+                                    owner_id: '81390ad6-ce49-4c8f-aa64-729d374ee65c',
+                                    rhc_client_id: 'f415fc2d-9700-4e30-9621-6a410ccc92c8'
                                 }
                             }
                         ]
@@ -249,6 +253,7 @@ describe('inventory xjoin', function () {
             const result = results['9dae9304-86a8-4f66-baa3-a1b27dfdd479'];
             result.should.have.property('id', '9dae9304-86a8-4f66-baa3-a1b27dfdd479');
             result.system_profile.should.have.property('owner_id', '81390ad6-ce49-4c8f-aa64-729d374ee65c');
+            result.system_profile.should.have.property('rhc_client_id', 'f415fc2d-9700-4e30-9621-6a410ccc92c8');
 
             http.callCount.should.equal(3);
         });

--- a/src/probes.js
+++ b/src/probes.js
@@ -121,6 +121,24 @@ exports.splitPlaybookPerSatId = function (receptorWorkRequest, satId, remediatio
     }, 'Full Contents of Work Request before being sent to receptor controller');
 };
 
+exports.splitPlaybookPerRHCEnabledSystems = function (rhcWorkRequest, systems, playbookRunId) {
+    playbookExecutionCounter.inc();
+    log.debug({
+        rhc_work_request: rhcWorkRequest,
+        systems,
+        playbook_run_id: playbookRunId
+    }, 'Full Contents of Work Request before being sent to playbook-dispatcher');
+};
+
+exports.rhcJobDispatched = function (rhcWorkRequest, executor, response, playbookRunId) {
+    log.debug({
+        rhc_work_request: rhcWorkRequest,
+        systems: executor.systems,
+        response,
+        playbook_run_id: playbookRunId
+    });
+};
+
 exports.receptorJobDispatched = function (receptorWorkRequest, executor, response, remediation, playbookRunId) {
     log.info({
         account: receptorWorkRequest.account,

--- a/src/remediations/__snapshots__/fifi.integration.js.snap
+++ b/src/remediations/__snapshots__/fifi.integration.js.snap
@@ -3,8 +3,8 @@
 exports[`FiFi connection status obtains connection status 1`] = `
 "{
     \\"meta\\": {
-        \\"count\\": 6,
-        \\"total\\": 6
+        \\"count\\": 7,
+        \\"total\\": 7
     },
     \\"data\\": [
         {
@@ -52,8 +52,16 @@ exports[`FiFi connection status obtains connection status 1`] = `
             \\"executor_id\\": null,
             \\"executor_type\\": null,
             \\"executor_name\\": null,
-            \\"system_count\\": 2,
+            \\"system_count\\": 1,
             \\"connection_status\\": \\"no_executor\\"
+        },
+        {
+            \\"endpoint_id\\": null,
+            \\"executor_id\\": null,
+            \\"executor_type\\": \\"RHC\\",
+            \\"executor_name\\": null,
+            \\"system_count\\": 1,
+            \\"connection_status\\": \\"connected\\"
         }
     ]
 }"

--- a/src/remediations/fifi.integration.js
+++ b/src/remediations/fifi.integration.js
@@ -64,14 +64,14 @@ describe('FiFi', function () {
             .set(auth.fifi)
             .expect(200);
 
-            headers.etag.should.equal('"10d1-znP/hi4fEIT3PozsJd+nSvx8Im4"');
+            headers.etag.should.equal('"1172-aL66zBR3zzAbkQBquBARuVlS5w0"');
         });
 
         test('304s on ETag match', async () => {
             await request
             .get('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/connection_status?pretty')
             .set(auth.fifi)
-            .set('if-none-match', '"10d1-znP/hi4fEIT3PozsJd+nSvx8Im4"')
+            .set('if-none-match', '"1172-aL66zBR3zzAbkQBquBARuVlS5w0"')
             .expect(304);
         });
     });
@@ -778,14 +778,14 @@ describe('FiFi', function () {
                 await request
                 .post('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/playbook_runs')
                 .set(auth.fifi)
-                .set('if-match', '"10d1-znP/hi4fEIT3PozsJd+nSvx8Im4"')
+                .set('if-match', '"1172-aL66zBR3zzAbkQBquBARuVlS5w0"')
                 .expect(201);
             });
 
             test('400 post playbook run', async () => {
                 await request
                 .set(auth.fifi)
-                .get('/v1/remediations/66eec356-dd06-4c72-a3b6-ef27d150000/connection_status')
+                .get('/v1/remediations/66eec356-dd06-4c72-a3b6-ef27d150000/playbook_runs')
                 .expect(400);
             });
 
@@ -810,17 +810,17 @@ describe('FiFi', function () {
                 const {headers} = await request
                 .post('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/playbook_runs?pretty')
                 .set(auth.fifi)
-                .set('if-match', '"10d1-znP/hi4fEIT3PozsJd+nSvx8Im4"')
+                .set('if-match', '"1172-aL66zBR3zzAbkQBquBARuVlS5w0"')
                 .expect(201);
 
-                headers.etag.should.equal('"10d1-znP/hi4fEIT3PozsJd+nSvx8Im4"');
+                headers.etag.should.equal('"1172-aL66zBR3zzAbkQBquBARuVlS5w0"');
             });
 
             test('201s on ETag match', async () => {
                 await request
                 .post('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/playbook_runs')
                 .set(auth.fifi)
-                .set('if-match', '"10d1-znP/hi4fEIT3PozsJd+nSvx8Im4"')
+                .set('if-match', '"1172-aL66zBR3zzAbkQBquBARuVlS5w0"')
                 .expect(201);
             });
 
@@ -831,7 +831,7 @@ describe('FiFi', function () {
                 .set('if-match', '"1062-Pl88DazTBuJo//SQVNUn6pZAlmk"')
                 .expect(412);
 
-                headers.etag.should.equal('"10d1-znP/hi4fEIT3PozsJd+nSvx8Im4"');
+                headers.etag.should.equal('"1172-aL66zBR3zzAbkQBquBARuVlS5w0"');
             });
 
             test('if if-match is not present, proceed', async () => {
@@ -903,10 +903,10 @@ describe('FiFi', function () {
                 expect(spy.args[0]).toMatchSnapshot();
             });
 
-            test('exclude both connected connectors and return 400 NO_EXECUTORS', async function () {
+            test('exclude all connected connectors and return 400 NO_EXECUTORS', async function () {
                 const {body} = await request
                 .post('/v1/remediations/63d92aeb-9351-4216-8d7c-044d171337bc/playbook_runs')
-                .send({exclude: ['722ec903-f4b5-4b1f-9c2f-23fc7b0ba390', '63142926-46a5-498b-9614-01f2f66fd40b']})
+                .send({exclude: ['722ec903-f4b5-4b1f-9c2f-23fc7b0ba390', '63142926-46a5-498b-9614-01f2f66fd40b', 'RHC']})
                 .set(auth.fifi)
                 .expect(400);
 
@@ -1090,7 +1090,7 @@ describe('FiFi', function () {
                                 display_name: null
                             }
                         ],
-                        type: 'Satellite',
+                        type: 'satellite',
                         name: 'Dynamic Satellite',
                         status: 'connected'
                     }))
@@ -1128,7 +1128,7 @@ describe('FiFi', function () {
                                 display_name: null
                             }
                         ],
-                        type: 'Satellite',
+                        type: 'satellite',
                         name: 'Dynamic Satellite',
                         status: 'connected'
                     }))
@@ -1166,7 +1166,7 @@ describe('FiFi', function () {
                                 display_name: null
                             }
                         ],
-                        type: 'Satellite',
+                        type: 'satellite',
                         name: 'Dynamic Satellite',
                         status: 'connected'
                     }))
@@ -1345,7 +1345,7 @@ describe('FiFi', function () {
             const {body: post} = await request
             .post('/v1/remediations/d12efef0-9580-4c82-b604-9888e2269c5a/playbook_runs')
             .set(auth.fifi)
-            .set('if-match', '"10d1-znP/hi4fEIT3PozsJd+nSvx8Im4"')
+            .set('if-match', '"1172-aL66zBR3zzAbkQBquBARuVlS5w0"')
             .expect(201);
 
             const {body: run} = await request

--- a/src/remediations/remediations.format.js
+++ b/src/remediations/remediations.format.js
@@ -33,6 +33,10 @@ function buildListLinks (total, limit, offset, sort, system) {
     return links;
 }
 
+function buildRHCUrl (remediation_id, system_id) {
+    return `https://${config.platformHostname}${config.path.prefix}/${config.path.app}/v1/${config.path.app}/${remediation_id}/playbook?hosts=${system_id}`;
+}
+
 exports.parseSort = function (param) {
     if (!param) {
         throw new Error(`Invalid sort param value ${param}`);
@@ -183,6 +187,15 @@ exports.receptorWorkRequest = function (playbookRunRequest, account_number, rece
         recipient: receptor_id,
         payload: JSON.stringify(playbookRunRequest),
         directive: 'receptor_satellite:execute'
+    };
+};
+
+exports.rhcWorkRequest = function (rhc_client_id, account_number, remediation_id, system_id, playbook_run_id) {
+    return {
+        recipient: rhc_client_id,
+        account: account_number,
+        url: buildRHCUrl(remediation_id, system_id),
+        labels: { 'playbook-run': playbook_run_id }
     };
 };
 


### PR DESCRIPTION
The purpose of this PR is to modify the current Remediations FiFi pipeline to send RHC registered systems in a work request to the playbook-dispatcher without disturbing the pipeline that is already in place.  

To that end, the way that the pipeline works now is that instead of having a sole executor at the end of the "Preflight Check" that are not runnable due to being "Direct Connect" we now comb through these systems to see if they have an existing "rhc_client_id" if they do they are added to an executor that is marked as "connected" with the type "RHC".  All other systems (without an existing "rhc_client_id" are put in a seperate executor which will show up with an error stating that they cannot be run with FiFi.  

Additionally with these changes I had to modify one of the existing features, specifically the ability to exclude executors from being run by FiFi.  You are now able to add the executor "RHC" to that list which will exclude any system that is RHC enabled from being run.

    ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices