### PR TITLE
RHCLOUD-13082: Update playbook generation pipeline to use marketplace logic

### DIFF
--- a/db/seeders/20191223133315-fifi.js
+++ b/db/seeders/20191223133315-fifi.js
@@ -37,6 +37,7 @@ const systems = [
     // no_executor
     '9574cba7-b9ce-4725-b392-e959afd3e69a',
     '750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4',
+    '0341e468-fbae-416c-b16f-5abb64d99834',
 
     // connected
     // these two systems have the same ansible_host - only one of them should show up

--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -1466,6 +1466,8 @@ components:
             - no_executor
             - no_source
             - no_receptor
+            - no_smart_management
+            - no_rhc
 
     SystemOut:
       type: object

--- a/src/connectors/inventory/mock.js
+++ b/src/connectors/inventory/mock.js
@@ -62,6 +62,17 @@ function generateSystemProfile (id) {
         };
     }
 
+    if (id === '0341e468-fbae-416c-b16f-5abb64d99834') {
+        return {
+            id,
+            system_profile: {
+                owner_id: '81390ad6-ce49-4c8f-aa64-729d374ee65c',
+                rhc_client_id: 'f415fc2d-9700-4e30-9621-6a410ccc92c8',
+                is_marketplace: false
+            }
+        };
+    }
+
     // eslint-disable-next-line security/detect-object-injection
     return {
         id,

--- a/src/remediations/__snapshots__/fifi.integration.js.snap
+++ b/src/remediations/__snapshots__/fifi.integration.js.snap
@@ -1,5 +1,80 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FiFi connection status get connection status with false smartManagement but with system connected to RHC 1`] = `
+"{
+    \\"meta\\": {
+        \\"count\\": 8,
+        \\"total\\": 8
+    },
+    \\"data\\": [
+        {
+            \\"endpoint_id\\": null,
+            \\"executor_id\\": \\"01bf542e-6092-485c-ba04-c656d77f988a\\",
+            \\"executor_type\\": \\"satellite\\",
+            \\"executor_name\\": \\"Satellite 01bf542e-6092-485c-ba04-c656d77f988a\\",
+            \\"system_count\\": 4,
+            \\"connection_status\\": \\"no_smart_management\\"
+        },
+        {
+            \\"endpoint_id\\": null,
+            \\"executor_id\\": \\"409dd231-6297-43a6-a726-5ce56923d624\\",
+            \\"executor_type\\": \\"satellite\\",
+            \\"executor_name\\": \\"Satellite 409dd231-6297-43a6-a726-5ce56923d624\\",
+            \\"system_count\\": 6,
+            \\"connection_status\\": \\"no_smart_management\\"
+        },
+        {
+            \\"endpoint_id\\": null,
+            \\"executor_id\\": \\"63142926-46a5-498b-9614-01f2f66fd40b\\",
+            \\"executor_type\\": \\"satellite\\",
+            \\"executor_name\\": \\"Satellite 63142926-46a5-498b-9614-01f2f66fd40b\\",
+            \\"system_count\\": 1,
+            \\"connection_status\\": \\"no_smart_management\\"
+        },
+        {
+            \\"endpoint_id\\": null,
+            \\"executor_id\\": \\"722ec903-f4b5-4b1f-9c2f-23fc7b0ba390\\",
+            \\"executor_type\\": \\"satellite\\",
+            \\"executor_name\\": \\"Satellite 722ec903-f4b5-4b1f-9c2f-23fc7b0ba390\\",
+            \\"system_count\\": 3,
+            \\"connection_status\\": \\"no_smart_management\\"
+        },
+        {
+            \\"endpoint_id\\": null,
+            \\"executor_id\\": \\"72f44b25-64a7-4ee7-a94e-3beed9393972\\",
+            \\"executor_type\\": \\"satellite\\",
+            \\"executor_name\\": \\"Satellite 72f44b25-64a7-4ee7-a94e-3beed9393972\\",
+            \\"system_count\\": 5,
+            \\"connection_status\\": \\"no_smart_management\\"
+        },
+        {
+            \\"endpoint_id\\": null,
+            \\"executor_id\\": null,
+            \\"executor_type\\": null,
+            \\"executor_name\\": null,
+            \\"system_count\\": 1,
+            \\"connection_status\\": \\"no_executor\\"
+        },
+        {
+            \\"endpoint_id\\": null,
+            \\"executor_id\\": null,
+            \\"executor_type\\": \\"RHC\\",
+            \\"executor_name\\": null,
+            \\"system_count\\": 1,
+            \\"connection_status\\": \\"connected\\"
+        },
+        {
+            \\"endpoint_id\\": null,
+            \\"executor_id\\": null,
+            \\"executor_type\\": \\"RHC\\",
+            \\"executor_name\\": null,
+            \\"system_count\\": 1,
+            \\"connection_status\\": \\"no_smart_management\\"
+        }
+    ]
+}"
+`;
+
 exports[`FiFi connection status obtains connection status 1`] = `
 "{
     \\"meta\\": {
@@ -60,7 +135,7 @@ exports[`FiFi connection status obtains connection status 1`] = `
             \\"executor_id\\": null,
             \\"executor_type\\": \\"RHC\\",
             \\"executor_name\\": null,
-            \\"system_count\\": 1,
+            \\"system_count\\": 2,
             \\"connection_status\\": \\"connected\\"
         }
     ]

--- a/src/remediations/controller.fifi.js
+++ b/src/remediations/controller.fifi.js
@@ -26,7 +26,7 @@ exports.connection_status = errors.async(async function (req, res) {
         throw new errors.Forbidden();
     }
 
-    const status = await fifi.getConnectionStatus(remediation, req.identity.account_number);
+    const status = await fifi.getConnectionStatus(remediation, req.identity.account_number, req.entitlements.smart_management);
 
     res.set('etag', etag(JSON.stringify(status)));
     res.json(format.connectionStatus(status));
@@ -45,7 +45,7 @@ exports.executePlaybookRuns = errors.async(async function (req, res) {
         throw new errors.Forbidden();
     }
 
-    const status = await fifi.getConnectionStatus(remediation, req.identity.account_number);
+    const status = await fifi.getConnectionStatus(remediation, req.identity.account_number, req.entitlements.smart_management);
     const currentEtag = etag(JSON.stringify(status));
 
     res.set('etag', currentEtag);

--- a/src/remediations/fifi.integration.js
+++ b/src/remediations/fifi.integration.js
@@ -60,13 +60,15 @@ describe('FiFi', function () {
 
         test('get connection status with false smartManagement but with system connected to RHC', async () => {
             base.getSandbox().stub(config, 'isMarketplace').value(true);
-            await request
+            const {text} = await request
             .get('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/connection_status?pretty')
             .set(utils.IDENTITY_HEADER, utils.createIdentityHeader('fifi', 'fifi', true, data => {
                 data.entitlements.smart_management = false;
                 return data;
             }))
             .expect(200);
+
+            expect(text).toMatchSnapshot();
         });
 
         test('sets ETag', async () => {
@@ -75,14 +77,14 @@ describe('FiFi', function () {
             .set(auth.fifi)
             .expect(200);
 
-            headers.etag.should.equal('"11a6-sMkp3MoGBinxNmeldH7IHGb/MUk"');
+            headers.etag.should.equal('"126e-MHacGzIMEd1TEWbdQQBBLW62CF0"');
         });
 
         test('304s on ETag match', async () => {
             await request
             .get('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/connection_status?pretty')
             .set(auth.fifi)
-            .set('if-none-match', '"11a6-sMkp3MoGBinxNmeldH7IHGb/MUk"')
+            .set('if-none-match', '"126e-MHacGzIMEd1TEWbdQQBBLW62CF0"')
             .expect(304);
         });
     });
@@ -749,7 +751,7 @@ describe('FiFi', function () {
                 await request
                 .post('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/playbook_runs')
                 .set(auth.fifi)
-                .set('if-match', '"11a6-sMkp3MoGBinxNmeldH7IHGb/MUk"')
+                .set('if-match', '"126e-MHacGzIMEd1TEWbdQQBBLW62CF0"')
                 .expect(201);
             });
 
@@ -792,17 +794,17 @@ describe('FiFi', function () {
                 const {headers} = await request
                 .post('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/playbook_runs?pretty')
                 .set(auth.fifi)
-                .set('if-match', '"11a6-sMkp3MoGBinxNmeldH7IHGb/MUk"')
+                .set('if-match', '"126e-MHacGzIMEd1TEWbdQQBBLW62CF0"')
                 .expect(201);
 
-                headers.etag.should.equal('"11a6-sMkp3MoGBinxNmeldH7IHGb/MUk"');
+                headers.etag.should.equal('"126e-MHacGzIMEd1TEWbdQQBBLW62CF0"');
             });
 
             test('201s on ETag match', async () => {
                 await request
                 .post('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/playbook_runs')
                 .set(auth.fifi)
-                .set('if-match', '"11a6-sMkp3MoGBinxNmeldH7IHGb/MUk"')
+                .set('if-match', '"126e-MHacGzIMEd1TEWbdQQBBLW62CF0"')
                 .expect(201);
             });
 
@@ -813,7 +815,7 @@ describe('FiFi', function () {
                 .set('if-match', '"1062-Pl88DazTBuJo//SQVNUn6pZAlmk"')
                 .expect(412);
 
-                headers.etag.should.equal('"11a6-sMkp3MoGBinxNmeldH7IHGb/MUk"');
+                headers.etag.should.equal('"126e-MHacGzIMEd1TEWbdQQBBLW62CF0"');
             });
 
             test('if if-match is not present, proceed', async () => {
@@ -1327,7 +1329,7 @@ describe('FiFi', function () {
             const {body: post} = await request
             .post('/v1/remediations/d12efef0-9580-4c82-b604-9888e2269c5a/playbook_runs')
             .set(auth.fifi)
-            .set('if-match', '"11a6-sMkp3MoGBinxNmeldH7IHGb/MUk"')
+            .set('if-match', '"126e-MHacGzIMEd1TEWbdQQBBLW62CF0"')
             .expect(201);
 
             const {body: run} = await request


### PR DESCRIPTION
Now that the new smartManagement / marketplace check is in use the "run playbook" pipeline must make use of the "is_marketplace" field to only run playbooks on systems that have the "is_marketplace" field set to true (unless of course the customer has the smart_management entitlement.

JIRA: https://issues.redhat.com/browse/RHCLOUD-13082

    ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices