### PR TITLE
RHCLOUD-13324: Update dispatcher-connector with new API endpoints

### DIFF
--- a/src/connectors/dispatcher/impl.js
+++ b/src/connectors/dispatcher/impl.js
@@ -2,15 +2,21 @@
 
 const _ = require('lodash');
 const URI = require('urijs');
+const qs = require('qs');
+const config = require('../../config');
 const {host, insecure, auth} = require('../../config').dispatcher;
 
 const Connector = require('../Connector');
 const metrics = require('../metrics');
 
+const QSOPTIONS = { encode: false };
+
 module.exports = new class extends Connector {
     constructor () {
         super(module);
         this.postRunRequests = metrics.createConnectorMetric(this.getName(), 'postPlaybookRunRequests');
+        this.fetchRuns = metrics.createConnectorMetric(this.getName(), 'fetchPlaybookRuns');
+        this.fetchRunHosts = metrics.createConnectorMetric(this.getName(), 'fetchPlaybookRunHosts');
     }
 
     async postPlaybookRunRequests (dispatcherWorkRequest) {
@@ -35,6 +41,66 @@ module.exports = new class extends Connector {
         }
 
         const result = await this.doHttp (options, false, this.postRunRequests);
+
+        if (_.isEmpty(result)) {
+            return null;
+        }
+
+        return result;
+    }
+
+    async fetchPlaybookRuns (filter = null, fields = null, sort_by = null) {
+        const uri = new URI(config.platformHostname);
+        uri.path('/api/playbook-dispatcher/v1/runs');
+
+        if (filter) {
+            uri.addQuery(qs.stringify(filter, QSOPTIONS));
+        }
+
+        if (fields) {
+            uri.addQuery(qs.stringify(fields, QSOPTIONS));
+        }
+
+        if (sort_by) {
+            uri.addQuery('sort_by', sort_by);
+        }
+
+        const options = {
+            uri: uri.toString(),
+            method: 'GET',
+            json: true,
+            headers: this.getForwardedHeaders()
+        };
+
+        const result = await this.doHttp (options, false, this.fetchRuns);
+
+        if (_.isEmpty(result)) {
+            return null;
+        }
+
+        return result;
+    }
+
+    async fetchPlaybookRunHosts (filter = null, fields = null) {
+        const uri = new URI(config.platformHostname);
+        uri.path('/api/playbook-dispatcher/v1/run_hosts');
+
+        if (filter) {
+            uri.addQuery(qs.stringify(filter, QSOPTIONS));
+        }
+
+        if (fields) {
+            uri.addQuery(qs.stringify(fields, QSOPTIONS));
+        }
+
+        const options = {
+            uri: uri.toString(),
+            method: 'GET',
+            json: true,
+            headers: this.getForwardedHeaders()
+        };
+
+        const result = await this.doHttp (options, false, this.fetchRunHosts);
 
         if (_.isEmpty(result)) {
             return null;

--- a/src/connectors/dispatcher/impl.unit.js
+++ b/src/connectors/dispatcher/impl.unit.js
@@ -79,4 +79,179 @@ describe('dispatcher impl', function () {
             await expect(impl.postPlaybookRunRequests(DISPATCHERWORKREQUEST)).rejects.toThrow(errors.DependencyError);
         });
     });
+
+    describe('getPlaybookRuns', function () {
+        test('get list of runs', async function () {
+            const http = base.getSandbox().stub(request, 'run').resolves({
+                statusCode: 200,
+                body: {
+                    meta: {
+                        count: 2
+                    },
+                    data: [
+                        {
+                            id: '8e015e92-02bd-4df1-80c5-3a00b93c4a4a',
+                            account: 654321,
+                            recipient: '9574cba7-b9ce-4725-b392-e959afd3e69a',
+                            correlation_id: '5c9ae28b-1728-4067-b1f3-f4ad992a8296',
+                            url: 'https://cloud.redhat.com/api/remediations/v1/remediations/f376d664-5725-498d-8cf9-bbfaa51b80ca/playbook?hosts=9574cba7-b9ce-4725-b392-e959afd3e69a&localhost',
+                            labels: {
+                                'playbook-run': 'ef7a1724-6adc-4370-b88c-bed7cb2d3fd2'
+                            },
+                            status: 'running',
+                            service: 'remediations',
+                            created_at: 'sometime',
+                            updated_at: 'sometime'
+                        },
+                        {
+                            id: '9ce94170-34a0-4aa6-976a-9728aa4da7a4',
+                            account: 654321,
+                            recipient: '750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4',
+                            correlation_id: '1b4244aa-2572-4067-bf44-ad4e5bfaafc4',
+                            url: 'https://cloud.redhat.com/api/remediations/v1/remediations/f376d664-5725-498d-8cf9-bbfaa51b80ca/playbook?hosts=750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4&localhost',
+                            labels: {
+                                'playbook-run': 'fe7a1724-6adc-4370-b88c-bed7cb2d3fd4'
+                            },
+                            status: 'running',
+                            service: 'remediations',
+                            created_at: 'sometime',
+                            updated_at: 'sometime'
+                        }
+                    ]
+                },
+                headers: {}
+            });
+
+            const results = await impl.fetchPlaybookRuns();
+            results.data.should.have.size(2);
+
+            const result1 = results.data[0];
+            result1.should.have.property('id', '8e015e92-02bd-4df1-80c5-3a00b93c4a4a');
+            result1.should.have.property('account', 654321);
+            result1.should.have.property('recipient', '9574cba7-b9ce-4725-b392-e959afd3e69a');
+            result1.should.have.property('correlation_id', '5c9ae28b-1728-4067-b1f3-f4ad992a8296');
+            result1.should.have.property('url', 'https://cloud.redhat.com/api/remediations/v1/remediations/f376d664-5725-498d-8cf9-bbfaa51b80ca/playbook?hosts=9574cba7-b9ce-4725-b392-e959afd3e69a&localhost');
+            result1.should.have.property('labels', {'playbook-run': 'ef7a1724-6adc-4370-b88c-bed7cb2d3fd2'});
+            result1.should.have.property('status', 'running');
+            result1.should.have.property('service', 'remediations');
+            result1.should.have.property('created_at', 'sometime');
+            result1.should.have.property('updated_at', 'sometime');
+
+            const result2 = results.data[1];
+            result2.should.have.property('id', '9ce94170-34a0-4aa6-976a-9728aa4da7a4');
+            result2.should.have.property('account', 654321);
+            result2.should.have.property('recipient', '750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4');
+            result2.should.have.property('correlation_id', '1b4244aa-2572-4067-bf44-ad4e5bfaafc4');
+            result2.should.have.property('url', 'https://cloud.redhat.com/api/remediations/v1/remediations/f376d664-5725-498d-8cf9-bbfaa51b80ca/playbook?hosts=750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4&localhost');
+            result2.should.have.property('labels', {'playbook-run': 'fe7a1724-6adc-4370-b88c-bed7cb2d3fd4'});
+            result2.should.have.property('status', 'running');
+            result2.should.have.property('service', 'remediations');
+            result2.should.have.property('created_at', 'sometime');
+            result2.should.have.property('updated_at', 'sometime');
+
+            http.callCount.should.equal(1);
+            const options = http.args[0][0];
+            options.headers.should.have.size(2);
+            options.headers.should.have.property('x-rh-insights-request-id', 'request-id');
+            options.headers.should.have.property('x-rh-identity', 'identity');
+        });
+
+        test('returns null dispatcherWorkRequest is incorrect', async function () {
+            base.getSandbox().stub(Connector.prototype, 'doHttp').resolves([]);
+            await expect(impl.fetchPlaybookRuns()).resolves.toBeNull();
+        });
+
+        test('connection error handling dispatcherWorkRequest', async function () {
+            base.mockRequestError();
+            await expect(impl.fetchPlaybookRuns()).rejects.toThrow(errors.DependencyError);
+        });
+
+        test('status code handling dispatcherWorkRequest', async function () {
+            base.mockRequestStatusCode();
+            await expect(impl.fetchPlaybookRuns()).rejects.toThrow(errors.DependencyError);
+        });
+    });
+
+    describe('getPlaybookRunHosts', function () {
+        test('get list of run hosts', async function () {
+            const http = base.getSandbox().stub(request, 'run').resolves({
+                statusCode: 200,
+                body: {
+                    meta: {
+                        count: 2
+                    },
+                    data: [
+                        {
+                            host: '9574cba7-b9ce-4725-b392-e959afd3e69a',
+                            run: {
+                                id: '8e015e92-02bd-4df1-80c5-3a00b93c4a4a',
+                                account: 654321,
+                                recipient: '9574cba7-b9ce-4725-b392-e959afd3e69a',
+                                correlation_id: '5c9ae28b-1728-4067-b1f3-f4ad992a8296',
+                                url: 'https://cloud.redhat.com/api/remediations/v1/remediations/f376d664-5725-498d-8cf9-bbfaa51b80ca/playbook?hosts=9574cba7-b9ce-4725-b392-e959afd3e69a&localhost',
+                                labels: {
+                                    'playbook-run': 'ef7a1724-6adc-4370-b88c-bed7cb2d3fd2'
+                                },
+                                timeout: '2000',
+                                status: 'running'
+                            },
+                            status: 'running',
+                            stdout: 'console log goes here'
+                        },
+                        {
+                            host: '750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4',
+                            run: {
+                                id: '9ce94170-34a0-4aa6-976a-9728aa4da7a4',
+                                account: 654321,
+                                recipient: '750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4',
+                                url: 'https://cloud.redhat.com/api/remediations/v1/remediations/f376d664-5725-498d-8cf9-bbfaa51b80ca/playbook?hosts=750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4&localhost',
+                                labels: {
+                                    'playbook-run': 'fe7a1724-6adc-4370-b88c-bed7cb2d3fd4'
+                                },
+                                timeout: '2000',
+                                status: 'running'
+                            },
+                            status: 'running',
+                            stdout: 'console log goes here'
+                        }
+                    ]
+                },
+                headers: {}
+            });
+
+            const results = await impl.fetchPlaybookRunHosts();
+            results.data.should.have.size(2);
+
+            const result1 = results.data[0];
+            result1.should.have.property('host', '9574cba7-b9ce-4725-b392-e959afd3e69a');
+            result1.should.have.property('status', 'running');
+            result1.should.have.property('stdout', 'console log goes here');
+
+            const result2 = results.data[1];
+            result2.should.have.property('host', '750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4');
+            result2.should.have.property('status', 'running');
+            result2.should.have.property('stdout', 'console log goes here');
+
+            http.callCount.should.equal(1);
+            const options = http.args[0][0];
+            options.headers.should.have.size(2);
+            options.headers.should.have.property('x-rh-insights-request-id', 'request-id');
+            options.headers.should.have.property('x-rh-identity', 'identity');
+        });
+
+        test('returns null dispatcherWorkRequest is incorrect', async function () {
+            base.getSandbox().stub(Connector.prototype, 'doHttp').resolves([]);
+            await expect(impl.fetchPlaybookRunHosts()).resolves.toBeNull();
+        });
+
+        test('connection error handling dispatcherWorkRequest', async function () {
+            base.mockRequestError();
+            await expect(impl.fetchPlaybookRunHosts()).rejects.toThrow(errors.DependencyError);
+        });
+
+        test('status code handling dispatcherWorkRequest', async function () {
+            base.mockRequestStatusCode();
+            await expect(impl.fetchPlaybookRunHosts()).rejects.toThrow(errors.DependencyError);
+        });
+    });
 });

--- a/src/connectors/dispatcher/mock.js
+++ b/src/connectors/dispatcher/mock.js
@@ -1,6 +1,8 @@
 'use strict';
 
+const _ = require('lodash');
 const Connector = require('../Connector');
+/* eslint-disable max-len */
 
 const MOCKDISPATCHRESPONSE = [
     {
@@ -12,6 +14,73 @@ const MOCKDISPATCHRESPONSE = [
     }
 ];
 
+const RUNS = {
+    '9574cba7-b9ce-4725-b392-e959afd3e69a': {
+        id: '8e015e92-02bd-4df1-80c5-3a00b93c4a4a',
+        account: 654321,
+        recipient: '9574cba7-b9ce-4725-b392-e959afd3e69a',
+        correlation_id: '5c9ae28b-1728-4067-b1f3-f4ad992a8296',
+        url: 'https://cloud.redhat.com/api/remediations/v1/remediations/f376d664-5725-498d-8cf9-bbfaa51b80ca/playbook?hosts=9574cba7-b9ce-4725-b392-e959afd3e69a&localhost',
+        labels: {
+            'playbook-run': 'ef7a1724-6adc-4370-b88c-bed7cb2d3fd2'
+        },
+        status: 'running',
+        service: 'remediations',
+        created_at: 'sometime',
+        updated_at: 'sometime'
+    },
+    '750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4': {
+        id: '9ce94170-34a0-4aa6-976a-9728aa4da7a4',
+        account: 654321,
+        recipient: '750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4',
+        correlation_id: '1b4244aa-2572-4067-bf44-ad4e5bfaafc4',
+        url: 'https://cloud.redhat.com/api/remediations/v1/remediations/f376d664-5725-498d-8cf9-bbfaa51b80ca/playbook?hosts=750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4&localhost',
+        labels: {
+            'playbook-run': 'fe7a1724-6adc-4370-b88c-bed7cb2d3fd4'
+        },
+        status: 'running',
+        service: 'remediations',
+        created_at: 'sometime',
+        updated_at: 'sometime'
+    }
+};
+
+const RUNHOSTS = {
+    '9574cba7-b9ce-4725-b392-e959afd3e69a': {
+        host: '9574cba7-b9ce-4725-b392-e959afd3e69a',
+        run: {
+            id: '8e015e92-02bd-4df1-80c5-3a00b93c4a4a',
+            account: 654321,
+            recipient: '9574cba7-b9ce-4725-b392-e959afd3e69a',
+            correlation_id: '5c9ae28b-1728-4067-b1f3-f4ad992a8296',
+            url: 'https://cloud.redhat.com/api/remediations/v1/remediations/f376d664-5725-498d-8cf9-bbfaa51b80ca/playbook?hosts=9574cba7-b9ce-4725-b392-e959afd3e69a&localhost',
+            labels: {
+                'playbook-run': 'ef7a1724-6adc-4370-b88c-bed7cb2d3fd2'
+            },
+            timeout: '2000',
+            status: 'running'
+        },
+        status: 'running',
+        stdout: 'console log goes here'
+    },
+    '750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4': {
+        host: '750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4',
+        run: {
+            id: '9ce94170-34a0-4aa6-976a-9728aa4da7a4',
+            account: 654321,
+            recipient: '750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4',
+            url: 'https://cloud.redhat.com/api/remediations/v1/remediations/f376d664-5725-498d-8cf9-bbfaa51b80ca/playbook?hosts=750c60ee-b67e-4ccd-8d7f-cb8aed2bdbf4&localhost',
+            labels: {
+                'playbook-run': 'fe7a1724-6adc-4370-b88c-bed7cb2d3fd4'
+            },
+            timeout: '2000',
+            status: 'running'
+        },
+        status: 'running',
+        stdout: 'console log goes here'
+    }
+};
+
 module.exports = new class extends Connector {
     constructor () {
         super(module);
@@ -19,6 +88,26 @@ module.exports = new class extends Connector {
 
     postPlaybookRunRequests () {
         return MOCKDISPATCHRESPONSE;
+    }
+
+    getPlaybookRuns (filter = null) {
+        if (filter) {
+            if (!_.isUndefined(filter.recipient)) {
+                return RUNS[filter.recipient];
+            }
+        }
+
+        return _.flatMap(RUNS);
+    }
+
+    getPlaybookRunHosts (filter = null) {
+        if (filter) {
+            if (!_.isUndefined(filter.run.id)) {
+                return RUNHOSTS[filter.run.id];
+            }
+        }
+
+        return _.flatMap(RUNHOSTS);
     }
 
     ping () {}


### PR DESCRIPTION
Updated playbook dispatcher connector to have additional endpoints for pulling current information about running jobs.  Specificly the 'dispatcher/v1/run_hosts' endpoint and the 'dispatcher/v1/runs' endpoint which will be used / configured with the current FiFi endpoints to fetch information about direct-connect jobs.

JIRA: https://issues.redhat.com/browse/RHCLOUD-13324    

## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices