### PR TITLE
RHCLOUD-11059: Remediation issues count not being displayed correctly

### DIFF
--- a/src/remediations/__snapshots__/read.integration.js.snap
+++ b/src/remediations/__snapshots__/read.integration.js.snap
@@ -3188,9 +3188,9 @@ exports[`remediations missing listing of remediations does not blow up 1`] = `
                 \\"last_name\\": \\"user\\"
             },
             \\"updated_at\\": \\"2018-11-04T05:19:36.641Z\\",
-            \\"needs_reboot\\": true,
+            \\"needs_reboot\\": false,
             \\"system_count\\": 1,
-            \\"issue_count\\": 2,
+            \\"issue_count\\": 0,
             \\"resolved_count\\": 0,
             \\"archived\\": false
         },

--- a/src/remediations/controller.read.js
+++ b/src/remediations/controller.read.js
@@ -157,9 +157,12 @@ exports.list = errors.async(async function (req, res) {
         resolveUsers(req, ...remediations)
     ]);
 
+    // Add 'details' if they exist to each issue in remediation.issues
+    await P.map(remediations, remediation => resolveIssues(remediation));
+
     remediations.forEach(remediation => {
-        // filter out issues with 0 systems and unknown issues
-        remediation.issues = remediation.issues.filter(issue => issue.resolution);
+        // filter out issues with 0 systems, unknown issues and details
+        remediation.issues = remediation.issues.filter(issue => issue.resolution && issue.details);
         remediation.needs_reboot = inferNeedsReboot(remediation);
 
         // issue_count is not filtered on 0 systems by default


### PR DESCRIPTION
Update the `/remediation` list function to also filter on issues that don't have the "details" section.  This "should" allow the issue_count variable in both the `/remediations` method as well as the `/remediations/:id` method to always be the same.

JIRA:  https://issues.redhat.com/browse/RHCLOUD-11059

## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices