### PR TITLE
RHCLOUD-13607: Create /executable endpoint for FE

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.0.0
 info:
   title: Insights Remediations
   description: Insights Remediations Service
-  version: 1.3.2
+  version: 1.3.3
   contact:
     email: jharting@redhat.com
 
@@ -140,6 +140,26 @@ paths:
           $ref: '#/components/responses/BadRequest'
         404:
           $ref: '#/components/responses/NotFound'
+
+  /remediations/{id}/executable:
+    get:
+      tags:
+        - remediations
+      summary: Check smart_managment systems
+      description: Checks remediation for the existence of smart_managment flaged systems
+      operationId: checkExecutable
+      parameters:
+        - $ref: '#/components/parameters/RemediationId'
+      responses:
+        200:
+          description: OK
+        400:
+          $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        404:
+          $ref: '#/components/responses/NotFound'
+
 
   /remediations/{id}/playbook:
     get:
@@ -1537,6 +1557,12 @@ components:
       description: Entity Not Found
     BadRequest:
       description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RequestError'
+    Forbidden:
+      description: Forbidden
       content:
         application/json:
           schema:

--- a/src/remediations/controller.fifi.js
+++ b/src/remediations/controller.fifi.js
@@ -13,6 +13,22 @@ const fifi = require('./fifi');
 const notMatching = res => res.sendStatus(412);
 const notFound = res => res.sendStatus(404);
 
+exports.checkExecutable = errors.async(async function (req, res) {
+    const remediation = await queries.get(req.params.id, req.user.account_number, req.user.username);
+
+    if (!remediation) {
+        return notFound(res);
+    }
+
+    const executable = await fifi.checkSmartManagement(remediation, req.entitlements.smart_management);
+
+    if (!executable) {
+        throw new errors.Forbidden();
+    }
+
+    res.sendStatus(200);
+});
+
 exports.connection_status = errors.async(async function (req, res) {
     const [remediation, rhcEnabled] = await Promise.all([
         queries.get(req.params.id, req.user.account_number, req.user.username),

--- a/src/remediations/fifi.integration.js
+++ b/src/remediations/fifi.integration.js
@@ -15,6 +15,50 @@ const config = require('../config');
 const db = require('../db');
 
 describe('FiFi', function () {
+    describe('executable', function () {
+        test('remediation is executable', async () => {
+            await request
+            .get('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/executable')
+            .set(auth.fifi)
+            .expect(200);
+        });
+
+        test('remediation is executable with smartManagement false but RHC on', async () => {
+            base.getSandbox().stub(config, 'isMarketplace').value(true);
+            await request
+            .get('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/executable')
+            .set(utils.IDENTITY_HEADER, utils.createIdentityHeader('fifi', 'fifi', true, data => {
+                data.entitlements.smart_management = false;
+                return data;
+            }))
+            .expect(200);
+        });
+
+        test('remediation is not executable with smartManagment false but isMarketplace false', async () => {
+            await request
+            .get('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/executable')
+            .set(utils.IDENTITY_HEADER, utils.createIdentityHeader('fifi', 'fifi', true, data => {
+                data.entitlements.smart_management = false;
+                return data;
+            }))
+            .expect(403);
+        });
+
+        test('400 on incorrect remediationID', async () => {
+            await request
+            .get('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5c/executable')
+            .set(auth.fifi)
+            .expect(400);
+        });
+
+        test('404 on unknown remediationID', async () => {
+            await request
+            .get('/v1/remediations/6ecb5db7-2f1a-441b-8220-e5ce45066f60/executable')
+            .set(auth.fifi)
+            .expect(404);
+        });
+    });
+
     describe('connection status', function () {
         test('obtains connection status', async () => {
             const {text} = await request

--- a/src/remediations/routes.js
+++ b/src/remediations/routes.js
@@ -46,6 +46,11 @@ module.exports = function (router) {
         rbacWrite,
         write.removeIssueSystem);
 
+    router.get('/remediations/:id/executable',
+        openapi('checkExecutable'),
+        rbacRead,
+        fifi.checkExecutable);
+
     router.get('/remediations/:id/connection_status',
         openapi('getRemediationConnectionStatus'),
         rbacExecute,


### PR DESCRIPTION
Create /remediation/:id/executable endpoint for FE.  This endpoint check to see if there are any smart_management systems in a specific remediation OR if the smart_management entitlement is declared.

JIRA: https://issues.redhat.com/browse/RHCLOUD-13607    
    
    
    ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices