### PR TITLE
RHCLOUD-13852: Add additional states to pre-flight check

### DIFF
--- a/src/remediations/__snapshots__/fifi.integration.js.snap
+++ b/src/remediations/__snapshots__/fifi.integration.js.snap
@@ -9,6 +9,14 @@ exports[`FiFi connection status get connection status with false smartManagement
     \\"data\\": [
         {
             \\"endpoint_id\\": null,
+            \\"executor_id\\": null,
+            \\"executor_type\\": \\"RHC\\",
+            \\"executor_name\\": \\"Direct connection - AWS Marketplace\\",
+            \\"system_count\\": 1,
+            \\"connection_status\\": \\"connected\\"
+        },
+        {
+            \\"endpoint_id\\": null,
             \\"executor_id\\": \\"01bf542e-6092-485c-ba04-c656d77f988a\\",
             \\"executor_type\\": \\"satellite\\",
             \\"executor_name\\": \\"Satellite 01bf542e-6092-485c-ba04-c656d77f988a\\",
@@ -46,14 +54,6 @@ exports[`FiFi connection status get connection status with false smartManagement
             \\"executor_name\\": \\"Satellite 72f44b25-64a7-4ee7-a94e-3beed9393972\\",
             \\"system_count\\": 5,
             \\"connection_status\\": \\"no_smart_management\\"
-        },
-        {
-            \\"endpoint_id\\": null,
-            \\"executor_id\\": null,
-            \\"executor_type\\": \\"RHC\\",
-            \\"executor_name\\": null,
-            \\"system_count\\": 1,
-            \\"connection_status\\": \\"connected\\"
         },
         {
             \\"endpoint_id\\": null,
@@ -76,6 +76,14 @@ exports[`FiFi connection status get connection status with false smartManagment 
     \\"data\\": [
         {
             \\"endpoint_id\\": null,
+            \\"executor_id\\": null,
+            \\"executor_type\\": \\"RHC\\",
+            \\"executor_name\\": \\"Direct connection - AWS Marketplace\\",
+            \\"system_count\\": 1,
+            \\"connection_status\\": \\"disabled\\"
+        },
+        {
+            \\"endpoint_id\\": null,
             \\"executor_id\\": \\"01bf542e-6092-485c-ba04-c656d77f988a\\",
             \\"executor_type\\": \\"satellite\\",
             \\"executor_name\\": \\"Satellite 01bf542e-6092-485c-ba04-c656d77f988a\\",
@@ -113,14 +121,6 @@ exports[`FiFi connection status get connection status with false smartManagment 
             \\"executor_name\\": \\"Satellite 72f44b25-64a7-4ee7-a94e-3beed9393972\\",
             \\"system_count\\": 5,
             \\"connection_status\\": \\"no_smart_management\\"
-        },
-        {
-            \\"endpoint_id\\": null,
-            \\"executor_id\\": null,
-            \\"executor_type\\": \\"RHC\\",
-            \\"executor_name\\": null,
-            \\"system_count\\": 1,
-            \\"connection_status\\": \\"disabled\\"
         },
         {
             \\"endpoint_id\\": null,

--- a/src/remediations/fifi.js
+++ b/src/remediations/fifi.js
@@ -383,13 +383,17 @@ async function fetchReceptorStatus (receptor, account) {
     return _.get(result, 'status', null);
 }
 
-function getName (executor) {
+function getName (executor, smart_management) {
     if (executor.source) {
         return executor.source.name;
     }
 
     if (executor.id) {
         return `Satellite ${executor.id}`;
+    }
+
+    if (!smart_management && !_.includes([null, 'no_smart_management'], executor.rhcStatus)) {
+        return 'Direct connection - AWS Marketplace';
     }
 
     return null;
@@ -409,7 +413,7 @@ function getStatus (executor, smart_management) {
             return 'no_receptor';
         }
 
-        if (executor.receptorStatus !== 'connected') {
+        if (executor.receptorStatus !== CONNECTED) {
             return 'disconnected';
         }
     } else if (executor.type === 'RHC') {
@@ -451,7 +455,7 @@ function normalize (satellites, smart_management) {
         endpointId: _.get(satellite.receptor, 'id', null),
         systems: _.map(satellite.systems, system => _.pick(system, SYSTEM_FIELDS)),
         type: satellite.type,
-        name: getName(satellite),
+        name: getName(satellite, smart_management),
         status: getStatus(satellite, smart_management)
     }));
 }

--- a/src/remediations/fifi.js
+++ b/src/remediations/fifi.js
@@ -392,7 +392,7 @@ function getName (executor, smart_management) {
         return `Satellite ${executor.id}`;
     }
 
-    if (!smart_management && !_.includes([null, 'no_smart_management'], executor.rhcStatus)) {
+    if (!smart_management && executor.rhcStatus !== 'no_smart_management') {
         return 'Direct connection - AWS Marketplace';
     }
 


### PR DESCRIPTION
RHCLOUD-13852: Add additional states to pre-flight check.  These states are to designate which Direct connected systems are "regular" RHC systems and which are "Marketplace" systems.

JIRA:  https://issues.redhat.com/browse/RHCLOUD-13852

    ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices