### PR TITLE
RHICOMPL-2025 use a private web port for compliance-ssg

### DIFF
--- a/cdappconfig.json
+++ b/cdappconfig.json
@@ -26,13 +26,15 @@
         "secretKey": "value",
 	    "tls": false
     },
-    "endpoints":[
+    "privateEndpoints": [
         {
             "app": "compliance-ssg",
             "name": "service",
             "hostname": "compliance-service.ephem.svc",
-            "port": 8000
-        },
+            "port": 10000
+        }
+    ],
+    "endpoints":[
         {
             "app": "config-manager",
             "name": "service",


### PR DESCRIPTION
@aleccohan just some ideas here. Where is your clowder config logic? You will need to update it to use this new `privateDependencyEndpoints` rather than just `dependencyEndpoints`.

Signed-off-by: Andrew Kofink <akofink@redhat.com>

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
  - [X] Input Validation
  - [X] Output Encoding
  - [X] Authentication and Password Management
  - [X] Session Management
  - [X] Access Control
  - [X] Cryptographic Practices
  - [X] Error Handling and Logging
  - [X] Data Protection
  - [X] Communication Security
  - [X] System Configuration
  - [X] Database Security
  - [X] File Management
  - [X] Memory Management
  - [X] General Coding Practices