### PR TITLE
RHCLOUD-15194 & RHCLOUD-15203 Compliance ssg template generation changes

### DIFF
--- a/src/generator/__snapshots__/ssg.integration.js.snap
+++ b/src/generator/__snapshots__/ssg.integration.js.snap
@@ -11,6 +11,11 @@ exports[`generates a playbook with block 1`] = `
 # Add nodev Option to &#x2F;dev&#x2F;shm
 # Identifier: (ssg:rhel7|ospp42|xccdf_org.ssgproject.content_rule_mount_option_dev_shm_nodev,fix)
 # Version: NORMALIZED_PLACEHOLDER
+# platform = multi_platform_all
+# complexity = low
+# strategy = configure
+# reboot = false
+# disruption = high
 - name: Add nodev Option to /dev/shm
   hosts: '68799a02-8be9-11e8-9eb6-529269fb1459.example.com'
   become: true
@@ -25,15 +30,15 @@ exports[`generates a playbook with block 1`] = `
     - mount_option_dev_shm_nodev
     - no_reboot_needed
   tasks:
+
     - name: get back mount information associated to mountpoint
       command: findmnt --fstab '/dev/shm'
       register: device_name
       failed_when: device_name.rc > 1
       changed_when: false
-      when: >-
-        ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type !=
-        \\"docker\\"
-      notify: insights_reboot_handler
+      when: ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type
+        != \\"docker\\"
+
     - name: create mount_info dictionary variable
       set_fact:
         mount_info: '{{ mount_info|default({})|combine({item.0: item.1}) }}'
@@ -43,10 +48,9 @@ exports[`generates a playbook with block 1`] = `
       when:
         - device_name.stdout is defined and device_name.stdout_lines is defined
         - (device_name.stdout | length > 0)
-        - >-
-          ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type
-          != \\"docker\\"
-      notify: insights_reboot_handler
+        - ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type !=
+          \\"docker\\"
+
     - name: Ensure permission nodev are set on /dev/shm
       mount:
         path: /dev/shm
@@ -57,14 +61,8 @@ exports[`generates a playbook with block 1`] = `
       when:
         - device_name.stdout is defined
         - (device_name.stdout | length > 0)
-        - >-
-          ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type
-          != \\"docker\\"
-      notify: insights_reboot_handler
-  handlers:
-    - name: insights_reboot_handler
-      set_fact:
-        insights_needs_reboot: true
+        - ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type !=
+          \\"docker\\"
 
 
 # Reboots a system if any of the preceeding plays sets the 'insights_needs_reboot' variable to true.
@@ -161,6 +159,11 @@ exports[`generates a simple playbook with multiple compliance remediation 1`] = 
 # Disable Prelinking
 # Identifier: (ssg:rhel7|pci-dss|xccdf_org.ssgproject.content_rule_disable_prelink,fix)
 # Version: NORMALIZED_PLACEHOLDER
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# complexity = low
+# strategy = restrict
+# reboot = false
+# disruption = low
 - name: Disable Prelinking
   hosts: '68799a02-8be9-11e8-9eb6-529269fb1459.example.com'
   become: true
@@ -182,27 +185,28 @@ exports[`generates a simple playbook with multiple compliance remediation 1`] = 
     - no_reboot_needed
     - restrict_strategy
   tasks:
+
     - name: Does prelink file exist
       stat:
         path: /etc/sysconfig/prelink
       register: prelink_exists
-      notify: insights_reboot_handler
+
     - name: disable prelinking
       lineinfile:
         path: /etc/sysconfig/prelink
         regexp: ^PRELINKING=
         line: PRELINKING=no
       when: prelink_exists.stat.exists
-      notify: insights_reboot_handler
-  handlers:
-    - name: insights_reboot_handler
-      set_fact:
-        insights_needs_reboot: true
 
 
 # Enable rsyslog Service
 # Identifier: (ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_rsyslog_enabled,fix)
 # Version: NORMALIZED_PLACEHOLDER
+# platform = multi_platform_all
+# complexity = low
+# strategy = enable
+# reboot = false
+# disruption = low
 - name: Enable rsyslog Service
   hosts: '68799a02-8be9-11e8-9eb6-529269fb1459.example.com'
   become: true
@@ -217,12 +221,14 @@ exports[`generates a simple playbook with multiple compliance remediation 1`] = 
     - no_reboot_needed
     - service_rsyslog_enabled
   tasks:
+
     - name: Enable service rsyslog
       block:
+
         - name: Gather the package facts
           package_facts:
             manager: auto
-          notify: insights_reboot_handler
+
         - name: Enable service rsyslog
           service:
             name: rsyslog
@@ -230,14 +236,8 @@ exports[`generates a simple playbook with multiple compliance remediation 1`] = 
             state: started
           when:
             - '\\"rsyslog\\" in ansible_facts.packages'
-          notify: insights_reboot_handler
-      when: >-
-        ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type !=
-        \\"docker\\"
-  handlers:
-    - name: insights_reboot_handler
-      set_fact:
-        insights_needs_reboot: true
+      when: ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type
+        != \\"docker\\"
 
 
 # Reboots a system if any of the preceeding plays sets the 'insights_needs_reboot' variable to true.
@@ -334,6 +334,11 @@ exports[`generates a simple playbook with single compliance remediation 1`] = `
 # Disable Prelinking
 # Identifier: (ssg:rhel7|pci-dss|xccdf_org.ssgproject.content_rule_disable_prelink,fix)
 # Version: NORMALIZED_PLACEHOLDER
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# complexity = low
+# strategy = restrict
+# reboot = false
+# disruption = low
 - name: Disable Prelinking
   hosts: '68799a02-8be9-11e8-9eb6-529269fb1459.example.com'
   become: true
@@ -355,22 +360,18 @@ exports[`generates a simple playbook with single compliance remediation 1`] = `
     - no_reboot_needed
     - restrict_strategy
   tasks:
+
     - name: Does prelink file exist
       stat:
         path: /etc/sysconfig/prelink
       register: prelink_exists
-      notify: insights_reboot_handler
+
     - name: disable prelinking
       lineinfile:
         path: /etc/sysconfig/prelink
         regexp: ^PRELINKING=
         line: PRELINKING=no
       when: prelink_exists.stat.exists
-      notify: insights_reboot_handler
-  handlers:
-    - name: insights_reboot_handler
-      set_fact:
-        insights_needs_reboot: true
 
 
 # Reboots a system if any of the preceeding plays sets the 'insights_needs_reboot' variable to true.
@@ -467,6 +468,11 @@ exports[`generates a simple playbook with uppercase profile name 1`] = `
 # Disable Host-Based Authentication
 # Identifier: (ssg:rhel7|C2S|xccdf_org.ssgproject.content_rule_disable_host_auth,fix)
 # Version: NORMALIZED_PLACEHOLDER
+# platform = multi_platform_all
+# complexity = low
+# strategy = restrict
+# reboot = false
+# disruption = low
 - name: Disable Host-Based Authentication
   hosts: '68799a02-8be9-11e8-9eb6-529269fb1459.example.com'
   become: true
@@ -485,31 +491,27 @@ exports[`generates a simple playbook with uppercase profile name 1`] = `
     - no_reboot_needed
     - restrict_strategy
   tasks:
+
     - name: Disable Host-Based Authentication
       block:
+
         - name: Deduplicate values from /etc/ssh/sshd_config
           lineinfile:
             path: /etc/ssh/sshd_config
             create: false
             regexp: (?i)^\\\\s*HostbasedAuthentication\\\\s+
             state: absent
-          notify: insights_reboot_handler
+
         - name: Insert correct line to /etc/ssh/sshd_config
           lineinfile:
             path: /etc/ssh/sshd_config
             create: true
             line: HostbasedAuthentication no
             state: present
-            insertbefore: '^[#\\\\s]*Match'
+            insertbefore: ^[#\\\\s]*Match
             validate: /usr/sbin/sshd -t -f %s
-          notify: insights_reboot_handler
-      when: >-
-        ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type !=
-        \\"docker\\"
-  handlers:
-    - name: insights_reboot_handler
-      set_fact:
-        insights_needs_reboot: true
+      when: ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type
+        != \\"docker\\"
 
 
 # Reboots a system if any of the preceeding plays sets the 'insights_needs_reboot' variable to true.

--- a/src/remediations/playbook/__snapshots__/playbook.integration.js.snap
+++ b/src/remediations/playbook/__snapshots__/playbook.integration.js.snap
@@ -1229,6 +1229,11 @@ exports[`playbooks generate playbook with pydata and playbook support 1`] = `
 # Disable the Automounter
 # Identifier: (ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled,fix)
 # Version: NORMALIZED_PLACEHOLDER
+# platform = multi_platform_all
+# complexity = low
+# strategy = disable
+# reboot = false
+# disruption = low
 - name: Disable the Automounter
   hosts: 'fc94beb8-21ee-403d-99b1-949ef7adb762'
   become: true
@@ -1252,10 +1257,10 @@ exports[`playbooks generate playbook with pydata and playbook support 1`] = `
       register: service_file_exists
       changed_when: false
       ignore_errors: true
-      when: >-
+      when:
         ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type !=
         \\"docker\\"
-      notify: insights_reboot_handler
+
     - name: Disable service autofs
       systemd:
         name: autofs.service
@@ -1264,19 +1269,18 @@ exports[`playbooks generate playbook with pydata and playbook support 1`] = `
         masked: 'yes'
       when:
         - '\\"autofs.service\\" in service_file_exists.stdout_lines[1]'
-        - >-
-          ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type
-          != \\"docker\\"
-      notify: insights_reboot_handler
+        - ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type !=
+          \\"docker\\"
+
     - name: Unit Socket Exists - autofs.socket
       command: systemctl list-unit-files autofs.socket
       register: socket_file_exists
       changed_when: false
       ignore_errors: true
-      when: >-
-        ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type !=
-        \\"docker\\"
-      notify: insights_reboot_handler
+      when:
+          ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type !=
+          \\"docker\\"
+
     - name: Disable socket autofs
       systemd:
         name: autofs.socket
@@ -1285,14 +1289,8 @@ exports[`playbooks generate playbook with pydata and playbook support 1`] = `
         masked: 'yes'
       when:
         - '\\"autofs.socket\\" in socket_file_exists.stdout_lines[1]'
-        - >-
-          ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type
-          != \\"docker\\"
-      notify: insights_reboot_handler
-  handlers:
-    - name: insights_reboot_handler
-      set_fact:
-        insights_needs_reboot: true
+        - ansible_virtualization_role != \\"guest\\" or ansible_virtualization_type !=
+          \\"docker\\"
 
 
 # Upgrade packages affected by CVE-2017-5715

--- a/src/remediations/playbook/playbook.integration.js
+++ b/src/remediations/playbook/playbook.integration.js
@@ -264,7 +264,7 @@ describe('playbooks', function () {
             });
         }
 
-        testCaching('pydata playbook', '66eec356-dd06-4c72-a3b6-ef27d1508a02', 'W/"4959-stOmNXX5/EEK73FD+vt5Ssf9a1Y"');
+        testCaching('pydata playbook', '66eec356-dd06-4c72-a3b6-ef27d1508a02', 'W/"48b0-qDcn7oWLJPLNUMQRDy7pNOxCEwc"');
         testCaching('no reboot playbook', 'e809526c-56f5-4cd8-a809-93328436ea23', 'W/"1771-rC4jtT7ig9lQT9CBLpMFkH4Eor8"');
         testCaching('playbook with suppressed reboot', '178cf0c8-35dd-42a3-96d5-7b50f9d211f6',
             'W/"1937-gjoSqp1gpVt5Me22Yni745YaNIc"');

--- a/src/resolutions/resolvers/SSGResolver.unit.js
+++ b/src/resolutions/resolvers/SSGResolver.unit.js
@@ -30,13 +30,6 @@ describe('SSGResolved', function () {
             resolutions[0].description.should.equal('Disable the Automounter');
         });
 
-        test('falls back to all profile if the rule does not belong to the spefified profile', async () => {
-            const id = identifiers.parse('ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_disable_prelink');
-            const resolutions = (await resolver.resolveResolutions(id));
-            resolutions.should.have.size(1);
-            resolutions[0].description.should.equal('Disable Prelinking');
-        });
-
         test('returns 0 if the rule does not exist at all', async () => {
             const id = identifiers.parse('ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_this_is_nonsense');
             const resolutions = (await resolver.resolveResolutions(id));


### PR DESCRIPTION
Due to the recent move from the remediations vendored playbooks-ssg service to the compliance-ssg service vendored by compliance a few changes needed to be made to the playbook generation logic.  Firstly, the logic that defaults to using the"all" template is no longer necessary since compliance should be in charge of making sure all issues are available when queried.  

Additionally with the inclusion of playbook signatures two pieces of logic have been changed to allow for the validation to work.  

1.  Removed the auto-inclusion of the "insights_reboot_handler" due to the fact that the compliance team is now in-charge of adding this to their templates.
2.  Fixed an Issue I was seeing with the signature after the template was loaded and dumped using the "js-yaml" library.  Currently in this version the template is using it's base string form which adds a few comments to the top, however I didn't find this to be too significant.  Please correct me if this is wrong though.

    
    ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices