### PR TITLE
QUICKFIX: fix webServices public enabled field indentation

### DIFF
--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -30,7 +30,7 @@ objects:
       minReplicas: ${{MIN_REPLICAS}}
       webServices:
         public:
-        enabled: True
+          enabled: true
       podSpec:
         image: quay.io/cloudservices/remediations:${IMAGE_TAG}
         initContainers:


### PR DESCRIPTION
This is a quickfix for the Remediations Clowdapp.yml file based on the recent deprecation of the "web: true" field.  A change was made to add in the new format, i.e. webServices/public/enabled.  This PR fixes an indentation problem that caused an outage in STAGE yesterday.