### PR TITLE
Add tenant_id retrieval function to sources connector

### DIFF
--- a/src/connectors/sources/impl.js
+++ b/src/connectors/sources/impl.js
@@ -15,6 +15,7 @@ module.exports = new class extends Connector {
         super(module);
         this.sourcesMetrics = metrics.createConnectorMetric(this.getName(), 'getSources');
         this.endpointMetrics = metrics.createConnectorMetric(this.getName(), 'getEndpoints');
+        this.tenantMetrics = metrics.createConnectorMetric(this.getName(), 'getTenant');
     }
 
     async findSources (ids) {
@@ -78,6 +79,26 @@ module.exports = new class extends Connector {
         });
 
         return sources;
+    }
+
+    // TODO: Update this once the Sources team allows for querying of list of ids
+    async getTenant (satellite_id) {
+        const uri = this.buildUri(host, 'internal', 'v2.0', 'sources');
+        uri.query({id: satellite_id});
+
+        const result = await this.doHttp({
+            uri: uri.toString(),
+            method: 'GET',
+            json: true,
+            rejectUnauthorized: !insecure,
+            headers: this.getForwardedHeaders()
+        }, false, this.tenantMetrics);
+
+        if (!result) {
+            return null;
+        }
+
+        return result.data;
     }
 
     async ping () {

--- a/src/connectors/sources/mock.js
+++ b/src/connectors/sources/mock.js
@@ -90,6 +90,11 @@ module.exports = new class extends Connector {
         .value();
     }
 
+    async getTenant () {
+        // TODO: Update when this is implemented
+        return '12345';
+    }
+
     async ping () {
         await this.findSources('test');
     }


### PR DESCRIPTION
## What
This PR is to create an additional function in the Remediations sources API connector to allow for the retrieval of the "tenant" id which is the center point for the changes needed for the new satellite -> RHC pipeline.

## Why
Currently the only place that serves the "tenant org id" is the internal sources API, as a result we need to make a seperate connector in order to retrieve that data by passing in the corresponding satellite ID and retrieving the information about that satellite:
```
{
	"meta": {
		"count": 1,
		"limit": 100,
		"offset": 0
	},
	"links": {
		"first": "/internal/v2.0/sources?name=1643138807&offset=0",
		"last": "/internal/v2.0/sources?name=1643138807&offset=0"
	},
	"data": [
		{
			"created_at": "2022-01-25T19:26:47Z",
			"id": "49",
			"name": "1643138807",
			"source_type_id": "1",
			"uid": "42431bd4-7f3f-4c71-b38a-c731addda6d7",
			"updated_at": "2022-01-25T19:26:47Z",
			"tenant": "6089719"
		}
	]
}
```

## Additional Info
JIRA TICKET:  https://issues.redhat.com/browse/RHCLOUD-17761
PARENT JIRA TICKET: https://issues.redhat.com/browse/RHCLOUD-17416
    
    
    ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices