### PR TITLE
RHCLOUD-19293: Fix Playbook Dispatcher error with pre-flight check

### DIFF
--- a/src/remediations/fifi.js
+++ b/src/remediations/fifi.js
@@ -283,8 +283,12 @@ async function defineDirectConnectedRHCSystems (executor, smart_management, org_
         rhcSystems = _.partition(executor.systems, system => !_.isUndefined(system.rhc_client) && system.marketplace);
     }
 
-    const dispatcherStatusRequest = _.map(rhcSystems[0], system => { return {recipient: system.rhc_client, org_id: String(org_id) }; });
+    // If there are no systems to check, return rhcSystems
+    if (_.isEmpty(rhcSystems[0])) {
+        return rhcSystems;
+    }
 
+    const dispatcherStatusRequest = _.map(rhcSystems[0], system => { return {recipient: system.rhc_client, org_id: String(org_id) }; });
     const requestStatuses = await dispatcher.getPlaybookRunRecipientStatus(dispatcherStatusRequest);
 
     // partition systems containing rhc_client_ids by connection status


### PR DESCRIPTION
RHCLOUD-19293: Fix Playbook Dispatcher error with pre-flight check.

Due to the error where a satellite_instance_id is not being set in the facts field in inventory there is an interaction that is currently breaking the pre-flight check.  This check should fix the logic to show the status as per-usual.
    
    ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices