### PR TITLE
RHCLOUD-19950: Dispatcher returns error for more than one target

### DIFF
--- a/src/remediations/remediations.format.js
+++ b/src/remediations/remediations.format.js
@@ -216,10 +216,15 @@ exports.rhcWorkRequest = function (rhc_client_id, account_number, remediation_id
 };
 
 exports.rhcSatelliteWorkRequest = function (executor, remediation, username, tenant_org_id, playbook_run_id) {
-    const systems = executor.systems.map(system => ({
-        ansible_host: system.ansible_host || "",
-        inventory_id: system.id
-    }));
+    const systems = executor.systems.map(system => {
+        let host = {"inventory_id": system.id};
+
+        if (!_.isNull(system.ansible_host)) {
+            host.absible_host = system.ansible_host
+        }
+
+        return host
+    });
 
     const request = {
         recipient: executor.satRhcId,


### PR DESCRIPTION
Fix the Dispatcher error when returning more than one target host.  In this case the "ansible_host" will not be added to the message if the value is null, this will stop any key constraints from occuring.
    
    ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices