### PR TITLE
Add apiPath to api public web service

### DIFF
--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -32,6 +32,7 @@ objects:
       webServices:
         public:
           enabled: true
+          apiPath: remediations
       podSpec:
         image: quay.io/cloudservices/remediations:${IMAGE_TAG}
         initContainers:


### PR DESCRIPTION
This PR just adds 1 line: `apiPath: remediations` to the public web service for the API in the ClowdApp.