### PR TITLE
Draft: Optionally list playbook run ID in remediations list

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -39,6 +39,7 @@ paths:
         - $ref: '#/components/parameters/Offset'
         - $ref: '#/components/parameters/RemediationSystem'
         - $ref: '#/components/parameters/HideArchived'
+        - $ref: '#/components/parameters/IncludeRunId'
       responses:
         200:
           description: OK
@@ -69,10 +70,10 @@ paths:
       tags:
         - remediations
       summary: Bulk Delete Remediations
-      description: Removes the given list of Remediations.  Requests 
+      description: Removes the given list of Remediations.  Requests
         containing malformed remediation IDs are rejected.  Duplicate or missing
         IDs are ignored.
-        
+
         RBAC permission {remediations:remediation:write}
       operationId: deleteRemediations
       requestBody:
@@ -731,6 +732,13 @@ components:
         type: string
         enum: [system_name, -system_name]
         default: system_name
+    IncludeRunId:
+      in: query
+      name: include_run_id
+      description: Include the playbook run ID in remediation details
+      required: false
+      schema:
+        type: boolean
 
 
   requestBodies:
@@ -1483,6 +1491,9 @@ components:
           $ref: '#/components/schemas/RemediationNeedsReboot'
         archived:
           $ref: '#/components/schemas/RemediationArchived'
+        playbook_run_id:
+          $ref: '#/components/schemas/PlaybookRunId'
+          nullable: true
 
     RemediationConnectionStatus:
       type: object


### PR DESCRIPTION
In order to speed up the Insights Dashboard, it would be useful if Remediations can get the most recent playbook run ID for each remediation listed.  That way those can be compiled into a single request to Playbook Dispatcher for information about those run IDs.

This is just a place-holder so far, adding the optional parameters and response fields into the OpenAPI.yaml description.

    ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices