### PR TITLE
fix: Make the psk-playbook-dispatcher secret optional

### DIFF
--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -135,6 +135,7 @@ objects:
               secretKeyRef:
                 key: key
                 name: psk-playbook-dispatcher
+                optional: true
           - name: PLATFORM_HOSTNAME_URL
             value: ${PLATFORM_HOSTNAME_URL}
           - name: PATH_PREFIX


### PR DESCRIPTION
We do not have this secret available in all environments so it should be made optional

    ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices