### PR TITLE
Enable support for using redis over SSL when password is present

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -261,6 +261,10 @@ function Config() {
             config.redis.host = loadedConfig.inMemoryDb.hostname;
             config.redis.port = loadedConfig.inMemoryDb.port;
             config.redis.password = loadedConfig.inMemoryDb.password;
+            if (config.redis.password != undefined) {
+                // if the password is set -> we're using TLS: https://github.com/luin/ioredis#tls-options
+                config.redis.tls = {}
+            }
         }
 
         if (loadedConfig.database.sslMode !== 'disable') {
@@ -302,6 +306,10 @@ function Config() {
             config.redis.host = env.REDIS_HOST || 'localhost';
             config.redis.port = parseIntEnv('REDIS_PORT', 6379);
             config.redis.password = env.REDIS_PASSWORD || undefined;
+            if (config.redis.password != undefined) {
+                // if the password is set -> we're using TLS: https://github.com/luin/ioredis#tls-options
+                config.redis.tls = {}
+            }
         }
 
         if (env.DB_SSL_ENABLED !== 'false' && env.DB_CA) {


### PR DESCRIPTION
Tested out on an elasticache with ssl enabled - listing keys:
```
null
[14:21:25.666] INFO (remediations/7): redis enabled
[14:21:25.725] INFO (remediations/7): connected to redis
[
  'celery',
  '_kombu.binding.celery.pidbox',
  '_kombu.binding.celery',
  '_kombu.binding.celeryev'
]
```

    ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices