### PR TITLE
RHINENG-5482: Added code to extract tenant_org_id for ServiceAccount …

### DIFF
--- a/src/middleware/identity/impl.js
+++ b/src/middleware/identity/impl.js
@@ -37,6 +37,15 @@ module.exports = function (req, res, next) {
             };
         }
 
+        if (req.identity.type === 'ServiceAccount') {
+            req.user = {
+                account_number: '',
+                tenant_org_id: req.identity.org_id,
+                username: req.identity.service_account.username,
+                is_internal: false
+            };
+        }
+
         next();
     } catch (e) {
         log.debug({header: raw, error: e.message, reqId}, 'Error decoding identity header');


### PR DESCRIPTION
Added missing code to extract the org id from the identity header when using service accounts.