### PR TITLE
RHINENG-7766: Added workaround for missing inventory ids

### DIFF
--- a/src/remediations/fifi.js
+++ b/src/remediations/fifi.js
@@ -232,7 +232,7 @@ exports.formatRunHosts = async function (rhcRuns, playbook_run_id) {
             const rhcRunHosts = await dispatcher.fetchPlaybookRunHosts(runHostsFilter, RHCRUNFIELDS);
 
             hosts.push(..._.map(rhcRunHosts.data, host => ({
-                system_id: host.inventory_id,
+                system_id: host.inventory_id || run.labels['inventory-id'], // pending resolution of RHCLOUD-30669
                 system_name: host.host,
                 status: (host.status === 'timeout' ? 'failure' : host.status),
                 updated_at: run.updated_at,


### PR DESCRIPTION
Added code to extract inventory id from label attached to rhc-direct run requests (until RHCLOUD-30669 is resolved)