### PR TITLE
fix: default page limit for vuln

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -198,7 +198,7 @@ function Config() {
         vulnerabilities: {
             impl: env.VULNERABILITIES_IMPL,
             auth: env.VULNERABILITIES_AUTH || '',
-            pageSize: parseIntEnv('VULNERABILITIES_PAGE_SIZE', 500),
+            pageSize: parseIntEnv('VULNERABILITIES_PAGE_SIZE', 100),
             insecure: (env.VULNERABILITIES_INSECURE === 'true') ? true : false
         },
 


### PR DESCRIPTION
Lower the default page limit for Vulnerability APIs to the max allowed value of 100 items per page.

RHINENG-8207

    ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [X] Input Validation
    - [X] Output Encoding
    - [X] Authentication and Password Management
    - [X] Session Management
    - [X] Access Control
    - [X] Cryptographic Practices
    - [X] Error Handling and Logging
    - [X] Data Protection
    - [X] Communication Security
    - [X] System Configuration
    - [X] Database Security
    - [X] File Management
    - [X] Memory Management
    - [X] General Coding Practices