### PR TITLE
Temporarily switch back to old version of the code to unblock deployments

### DIFF
--- a/src/remediations/__snapshots__/fifi.integration.js.snap
+++ b/src/remediations/__snapshots__/fifi.integration.js.snap
@@ -93,42 +93,42 @@ exports[`FiFi connection status get connection status with false smartManagement
         {
             \\"endpoint_id\\": null,
             \\"executor_id\\": \\"01bf542e-6092-485c-ba04-c656d77f988a\\",
-            \\"executor_type\\": \\"RHC-satellite\\",
+            \\"executor_type\\": \\"satellite\\",
             \\"executor_name\\": \\"Satellite 01bf542e-6092-485c-ba04-c656d77f988a Org 2\\",
             \\"system_count\\": 1,
-            \\"connection_status\\": \\"connected\\"
+            \\"connection_status\\": \\"no_smart_management\\"
         },
         {
             \\"endpoint_id\\": null,
             \\"executor_id\\": \\"409dd231-6297-43a6-a726-5ce56923d624\\",
-            \\"executor_type\\": \\"RHC-satellite\\",
+            \\"executor_type\\": \\"satellite\\",
             \\"executor_name\\": \\"Satellite 409dd231-6297-43a6-a726-5ce56923d624 Org 2\\",
             \\"system_count\\": 1,
-            \\"connection_status\\": \\"disconnected\\"
+            \\"connection_status\\": \\"no_smart_management\\"
         },
         {
             \\"endpoint_id\\": null,
             \\"executor_id\\": \\"63142926-46a5-498b-9614-01f2f66fd40b\\",
-            \\"executor_type\\": \\"RHC-satellite\\",
+            \\"executor_type\\": \\"satellite\\",
             \\"executor_name\\": \\"Satellite 63142926-46a5-498b-9614-01f2f66fd40b Org 2\\",
             \\"system_count\\": 5,
-            \\"connection_status\\": \\"connected\\"
+            \\"connection_status\\": \\"no_smart_management\\"
         },
         {
             \\"endpoint_id\\": null,
             \\"executor_id\\": \\"722ec903-f4b5-4b1f-9c2f-23fc7b0ba390\\",
-            \\"executor_type\\": \\"RHC-satellite\\",
+            \\"executor_type\\": \\"satellite\\",
             \\"executor_name\\": \\"Satellite 722ec903-f4b5-4b1f-9c2f-23fc7b0ba390 Org 2\\",
             \\"system_count\\": 3,
-            \\"connection_status\\": \\"connected\\"
+            \\"connection_status\\": \\"no_smart_management\\"
         },
         {
             \\"endpoint_id\\": null,
             \\"executor_id\\": \\"72f44b25-64a7-4ee7-a94e-3beed9393972\\",
-            \\"executor_type\\": \\"RHC-satellite\\",
+            \\"executor_type\\": \\"satellite\\",
             \\"executor_name\\": \\"Satellite 72f44b25-64a7-4ee7-a94e-3beed9393972 Org 2\\",
             \\"system_count\\": 3,
-            \\"connection_status\\": \\"connected\\"
+            \\"connection_status\\": \\"no_smart_management\\"
         },
         {
             \\"endpoint_id\\": null,
@@ -151,16 +151,16 @@ exports[`FiFi connection status get connection status with false smartManagement
             \\"executor_id\\": null,
             \\"executor_type\\": \\"RHC\\",
             \\"executor_name\\": null,
-            \\"system_count\\": 3,
+            \\"system_count\\": 1,
             \\"connection_status\\": \\"connected\\"
         },
         {
             \\"endpoint_id\\": null,
             \\"executor_id\\": null,
-            \\"executor_type\\": \\"None\\",
+            \\"executor_type\\": \\"RHC\\",
             \\"executor_name\\": null,
-            \\"system_count\\": 1,
-            \\"connection_status\\": \\"connected\\"
+            \\"system_count\\": 2,
+            \\"connection_status\\": \\"no_smart_management\\"
         }
     ]
 }"
@@ -259,41 +259,41 @@ exports[`FiFi connection status obtains connection status 1`] = `
         {
             \\"endpoint_id\\": null,
             \\"executor_id\\": \\"01bf542e-6092-485c-ba04-c656d77f988a\\",
-            \\"executor_type\\": \\"RHC-satellite\\",
+            \\"executor_type\\": \\"satellite\\",
             \\"executor_name\\": \\"Satellite 01bf542e-6092-485c-ba04-c656d77f988a Org 2\\",
             \\"system_count\\": 1,
+            \\"connection_status\\": \\"no_source\\"
+        },
+        {
+            \\"endpoint_id\\": \\"805\\",
+            \\"executor_id\\": \\"722ec903-f4b5-4b1f-9c2f-23fc7b0ba390\\",
+            \\"executor_type\\": \\"satellite\\",
+            \\"executor_name\\": \\"Satellite 1 (connected)\\",
+            \\"system_count\\": 3,
             \\"connection_status\\": \\"connected\\"
         },
         {
-            \\"endpoint_id\\": null,
+            \\"endpoint_id\\": \\"806\\",
             \\"executor_id\\": \\"409dd231-6297-43a6-a726-5ce56923d624\\",
-            \\"executor_type\\": \\"RHC-satellite\\",
-            \\"executor_name\\": \\"Satellite 409dd231-6297-43a6-a726-5ce56923d624 Org 2\\",
+            \\"executor_type\\": \\"satellite\\",
+            \\"executor_name\\": \\"Satellite 2 (disconnected)\\",
             \\"system_count\\": 1,
             \\"connection_status\\": \\"disconnected\\"
         },
         {
             \\"endpoint_id\\": null,
-            \\"executor_id\\": \\"63142926-46a5-498b-9614-01f2f66fd40b\\",
-            \\"executor_type\\": \\"RHC-satellite\\",
-            \\"executor_name\\": \\"Satellite 63142926-46a5-498b-9614-01f2f66fd40b Org 2\\",
-            \\"system_count\\": 5,
-            \\"connection_status\\": \\"connected\\"
-        },
-        {
-            \\"endpoint_id\\": null,
-            \\"executor_id\\": \\"722ec903-f4b5-4b1f-9c2f-23fc7b0ba390\\",
-            \\"executor_type\\": \\"RHC-satellite\\",
-            \\"executor_name\\": \\"Satellite 722ec903-f4b5-4b1f-9c2f-23fc7b0ba390 Org 2\\",
-            \\"system_count\\": 3,
-            \\"connection_status\\": \\"connected\\"
-        },
-        {
-            \\"endpoint_id\\": null,
             \\"executor_id\\": \\"72f44b25-64a7-4ee7-a94e-3beed9393972\\",
-            \\"executor_type\\": \\"RHC-satellite\\",
-            \\"executor_name\\": \\"Satellite 72f44b25-64a7-4ee7-a94e-3beed9393972 Org 2\\",
+            \\"executor_type\\": \\"satellite\\",
+            \\"executor_name\\": \\"Satellite 3 (no receptor configured)\\",
             \\"system_count\\": 3,
+            \\"connection_status\\": \\"no_receptor\\"
+        },
+        {
+            \\"endpoint_id\\": \\"808\\",
+            \\"executor_id\\": \\"63142926-46a5-498b-9614-01f2f66fd40b\\",
+            \\"executor_type\\": \\"satellite\\",
+            \\"executor_name\\": \\"Satellite 4 (connected)\\",
+            \\"system_count\\": 5,
             \\"connection_status\\": \\"connected\\"
         },
         {
@@ -317,16 +317,16 @@ exports[`FiFi connection status obtains connection status 1`] = `
             \\"executor_id\\": null,
             \\"executor_type\\": \\"RHC\\",
             \\"executor_name\\": null,
-            \\"system_count\\": 3,
+            \\"system_count\\": 2,
             \\"connection_status\\": \\"connected\\"
         },
         {
             \\"endpoint_id\\": null,
             \\"executor_id\\": null,
-            \\"executor_type\\": \\"None\\",
+            \\"executor_type\\": \\"RHC\\",
             \\"executor_name\\": null,
             \\"system_count\\": 1,
-            \\"connection_status\\": \\"connected\\"
+            \\"connection_status\\": \\"no_rhc\\"
         }
     ]
 }"

--- a/src/remediations/fifi.integration.js
+++ b/src/remediations/fifi.integration.js
@@ -157,14 +157,18 @@ describe('FiFi', function () {
             .set(auth.fifi)
             .expect(200);
 
-            headers.etag.should.equal('"b3f-ap0xZBE6LAEw4CWgNSPJ+fei+6I"');
+            // RHINENG-2835
+            // headers.etag.should.equal('"b3f-ap0xZBE6LAEw4CWgNSPJ+fei+6I"');
+            headers.etag.should.equal('"14d3-oEuP8tEpA8HcXXDPWOOrISoZRR4"');
         });
 
         test('304s on ETag match', async () => {
             await request
             .get('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/connection_status?pretty')
             .set(auth.fifi)
-            .set('if-none-match', '"b3f-ap0xZBE6LAEw4CWgNSPJ+fei+6I"')
+            // RHINENG-2835
+            // .set('if-none-match', '"b3f-ap0xZBE6LAEw4CWgNSPJ+fei+6I"')
+            .set('if-none-match', '"14d3-oEuP8tEpA8HcXXDPWOOrISoZRR4"')
             .expect(304);
         });
     });
@@ -908,7 +912,9 @@ describe('FiFi', function () {
                 await request
                     .post('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/playbook_runs')
                     .set(auth.fifi)
-                    .set('if-match', '"b3f-ap0xZBE6LAEw4CWgNSPJ+fei+6I"')
+                    // RHINENG-2835
+                    // .set('if-match', '"b3f-ap0xZBE6LAEw4CWgNSPJ+fei+6I"')
+                    .set('if-match', '"14d3-oEuP8tEpA8HcXXDPWOOrISoZRR4"')
                     .expect(201);
             });
 
@@ -953,7 +959,9 @@ describe('FiFi', function () {
                 await request
                 .post('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/playbook_runs')
                 .set(auth.fifi)
-                .set('if-match', '"b3f-ap0xZBE6LAEw4CWgNSPJ+fei+6I"')
+                // RHINENG-2835
+                // .set('if-match', '"b3f-ap0xZBE6LAEw4CWgNSPJ+fei+6I"')
+                .set('if-match', '"14d3-oEuP8tEpA8HcXXDPWOOrISoZRR4"')
                 .expect(201);
             });
 
@@ -996,17 +1004,24 @@ describe('FiFi', function () {
                 const {headers} = await request
                 .post('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/playbook_runs?pretty')
                 .set(auth.fifi)
-                .set('if-match', '"b3f-ap0xZBE6LAEw4CWgNSPJ+fei+6I"')
+                // RHINENG-2835
+                // .set('if-match', '"b3f-ap0xZBE6LAEw4CWgNSPJ+fei+6I"')
+                .set('if-match', '"14d3-oEuP8tEpA8HcXXDPWOOrISoZRR4"')
                 .expect(201);
 
-                headers.etag.should.equal('"b3f-ap0xZBE6LAEw4CWgNSPJ+fei+6I"');
+                // RHINENG-2835
+                // headers.etag.should.equal('"b3f-ap0xZBE6LAEw4CWgNSPJ+fei+6I"');
+                headers.etag.should.equal('"14d3-oEuP8tEpA8HcXXDPWOOrISoZRR4"');
             });
 
             test('201s on ETag match', async () => {
                 await request
                 .post('/v1/remediations/0ecb5db7-2f1a-441b-8220-e5ce45066f50/playbook_runs')
                 .set(auth.fifi)
-                .set('if-match', '"b3f-ap0xZBE6LAEw4CWgNSPJ+fei+6I"')
+
+                // RHINENG-2835
+                // .set('if-match', '"b3f-ap0xZBE6LAEw4CWgNSPJ+fei+6I"')
+                .set('if-match', '"14d3-oEuP8tEpA8HcXXDPWOOrISoZRR4"')
                 .expect(201);
             });
 
@@ -1017,7 +1032,9 @@ describe('FiFi', function () {
                 .set('if-match', '"1062-Pl88DazTBuJo//SQVNUn6pZAlmk"')
                 .expect(412);
 
-                headers.etag.should.equal('"b3f-ap0xZBE6LAEw4CWgNSPJ+fei+6I"');
+                // RHINENG-2835
+                // headers.etag.should.equal('"b3f-ap0xZBE6LAEw4CWgNSPJ+fei+6I"');
+                headers.etag.should.equal('"14d3-oEuP8tEpA8HcXXDPWOOrISoZRR4"');
             });
 
             test('if if-match is not present, proceed', async () => {

--- a/src/remediations/routes.js
+++ b/src/remediations/routes.js
@@ -43,11 +43,13 @@ module.exports = function (router) {
         .get(openapi('checkExecutable'), rbacRead, fifi.checkExecutable);
 
     router.route('/remediations/:id/connection_status')
-        .get(trace, openapi('getRemediationConnectionStatus'), rbacExecute, fifi2.connection_status);
+        // .get(trace, openapi('getRemediationConnectionStatus'), rbacExecute, fifi2.connection_status);
+        .get(trace, openapi('getRemediationConnectionStatus'), rbacExecute, fifi.connection_status);
 
     router.route('/remediations/:id/playbook_runs')
         .get(openapi('listPlaybookRuns'), rbacRead, fifi.listPlaybookRuns)
-        .post(openapi('runRemediation'), rbacExecute, fifi2.executePlaybookRuns);
+        // .post(openapi('runRemediation'), rbacExecute, fifi2.executePlaybookRuns);
+        .post(openapi('runRemediation'), rbacExecute, fifi.executePlaybookRuns);
 
     router.route('/remediations/:id/playbook_runs/:playbook_run_id')
         .get(openapi('getPlaybookRunDetails'), rbacRead, fifi.getRunDetails);


### PR DESCRIPTION
Playbook-dispatcher updates are still not in production so I'm parking the code changes that depend on that so we can continue to deploy other code.