### PR TITLE
Configure dependabot to check for updates on Sunday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
     directory: "/build"
     schedule:
       interval: "weekly"
+      day: "sunday"


### PR DESCRIPTION
Make dependabot run on Sundays so we can schedule any updates for the week on Monday mornings.