### PR TITLE
RHINENG-8757: Fixed issue with db query returning fewer rows.

### DIFF
--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -171,9 +171,10 @@ exports.loadDetails = async function (tenant_org_id, created_by, rows) {
     let result = [];
 
     try {
-        result = rows.map(row => _.assign(byId[row.id].toJSON(), row));
+        result = rows.map(row => _.assign(byId[row.id]?.toJSON(), row));
     }
 
+    // TODO: delete this debug try/catch...
     catch (e) {
         trace.event(`ERROR: results = ${JSON.stringify(results)},\nbyId = ${JSON.stringify(byId)},\nrows = ${JSON.stringify(rows)}`);
         trace.force = true;


### PR DESCRIPTION
src/remediations/remediations.queries.js(loadDetails) excludes issues with 0 systems, which can lead to a remediation being excluded, which leads to a db query returning fewer rows than expected.  Code was adjusted to accommodate the missing row(s).