### PR TITLE
refactor(dev): update postgresql-rds image tag

### DIFF
--- a/build/docker-compose-unit_test.yml
+++ b/build/docker-compose-unit_test.yml
@@ -17,7 +17,7 @@ services:
     restart: "no"
 
   db:
-    image: quay.io/cloudservices/postgresql-rds:14-1
+    image: quay.io/cloudservices/postgresql-rds:14
     ports:
       - "5432:5432"
     environment:

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     restart: always
 
   db:
-    image: quay.io/cloudservices/postgresql-rds:14-1
+    image: quay.io/cloudservices/postgresql-rds:14
     ports:
       - 5432:5432
     environment:


### PR DESCRIPTION
postgresql-rds "-1" images are being deprecated; moving to postgresql-rds:14 instead.