### PR TITLE
Added pino transport error handler to catch pino-cloudwatch errors

### DIFF
--- a/src/util/log.js
+++ b/src/util/log.js
@@ -64,6 +64,10 @@ function buildTransport () {
 
     const transport = pino.transport(options);
 
+    transport.on('error', err => {
+        console.error('caught pino transport error:', err);
+    });
+
     return transport;
 }
 


### PR DESCRIPTION
Try catching pino-cloudwatch errors to see if we can keep from torpedoing our pods...