### PR TITLE
Update add noop to prod build.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,7 @@ const prod_image_files = [
     'src/**/*.js',
     'src/**/*.yaml',
     'src/**/*.yml',
+    'src/**/noop.js',
     'certs/**/*',
     'db/**/*',
     '.sequelizerc',
@@ -20,7 +21,6 @@ const prod_image_files = [
 ];
 const test_image_files = [
     'src/**/__snapshots__/*',
-    'src/**/noop.js',
     'src/**/mock.js',
     'src/**/serviceMock.js',
     'src/**/*.unit.js',


### PR DESCRIPTION
This PR moves noop module to the prod image files so that it is included in the prod build along with the test build. This is to avoid the following error when deploying when noop is required:

```
Error: Cannot find module './noop'
```