### PR TITLE
Relax openapi remediation plan name restrictions pending db updates

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -878,7 +878,7 @@ components:
     RemediationName:
       type: string
       nullable: false
-      pattern: ^(?!\s).+(?<!\s)$  # can't start or end with whitespace
+      pattern: ^.*[\w]+.*$  # Anything that contains at least one character
       example: Fix Critical CVEs
 
     RemediationArchived:

--- a/src/remediations/write.integration.js
+++ b/src/remediations/write.integration.js
@@ -101,7 +101,7 @@ describe('remediations', function () {
                 id,
                 status: 400,
                 code: 'pattern.openapi.requestValidation',
-                title: 'must match pattern \"^(?!\\s).+(?<!\\s)$\" (location: body, path: name)'
+                title: 'must match pattern \"^.*[\\w]+.*$\" (location: body, path: name)'
             }]);
         });
 
@@ -306,7 +306,7 @@ describe('remediations', function () {
             .expect(201);
         });
 
-        test('400s when remediation plan name has leading/trailing whitespace', async () => {
+        test.skip('400s when remediation plan name has leading/trailing whitespace', async () => {
             const name_1 = ' duplicate plan for whitespace test';
             const name_2 = 'duplicate plan for whitespace test ';
             const {id, header} = reqId();
@@ -322,7 +322,7 @@ describe('remediations', function () {
                 id,
                 status: 400,
                 code: 'pattern.openapi.requestValidation',
-                title: 'must match pattern \"^(?!\\s).+(?<!\\s)$\" (location: body, path: name)'
+                title: 'must match pattern \"^.*[\\w]+.*$\" (location: body, path: name)'
             }]);
 
             const {body: body_2} = await request
@@ -336,7 +336,7 @@ describe('remediations', function () {
                 id,
                 status: 400,
                 code: 'pattern.openapi.requestValidation',
-                title: 'must match pattern \"^(?!\\s).+(?<!\\s)$\" (location: body, path: name)'
+                title: 'must match pattern \"^.*[\\w]+.*$\" (location: body, path: name)'
             }]);
         });
 
@@ -355,7 +355,7 @@ describe('remediations', function () {
                 id,
                 status: 400,
                 code: 'pattern.openapi.requestValidation',
-                title: 'must match pattern \"^(?!\\s).+(?<!\\s)$\" (location: body, path: name)'
+                title: 'must match pattern \"^.*[\\w]+.*$\" (location: body, path: name)'
             }]);
         });
 
@@ -731,7 +731,7 @@ describe('remediations', function () {
                         id,
                         status: 400,
                         code: 'pattern.openapi.requestValidation',
-                        title: 'must match pattern \"^(?!\\s).+(?<!\\s)$\" (location: body, path: name)'
+                        title: 'must match pattern \"^.*[\\w]+.*$\" (location: body, path: name)'
                     }]);
                 });
 


### PR DESCRIPTION
Relax the leading/trailing whitespace restrictions until we can fix the handful of database entries with "invalid" names.