### PR TITLE
Reorder anyOf statements

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -47,8 +47,8 @@ paths:
             application/json:
               schema:
                 anyOf:
-                  - $ref: '#/components/schemas/RemediationNameList'
                   - $ref: '#/components/schemas/RemediationList'
+                  - $ref: '#/components/schemas/RemediationNameList'
         400:
           $ref: '#/components/responses/BadRequest'
     post:


### PR DESCRIPTION
GET /remediations returns one of two objects:

* RemediationList
* RemediationNameList

The openapi-generator-cli v7.6.0 python binding generator generates a distinct schema for each of these objects. When decoding a response, the bindings will attempt to match the response to each of these schemas, in the same order as given in the spec file.

RemediationNameList is a strict subset of RemediationList. If the response is matched against these schemas in this order, then the first comparison will always succeed, and the first type of object will always be returned. This is problematic.

Fix: https://issues.redhat.com/browse/RHINENG-10796