### PR TITLE
RHINENG-11011: Fix null dereference errors

### DIFF
--- a/src/remediations/controller.read.js
+++ b/src/remediations/controller.read.js
@@ -204,7 +204,7 @@ exports.list = errors.async(async function (req, res) {
                 req.user.username
             );
 
-            playbook_runs = playbook_runs?.toJSON();
+            playbook_runs = playbook_runs?.toJSON() || {};
 
             // Join rhcRuns and playbookRuns
             trace.event(`[${local_iteration}] Combine runs`);


### PR DESCRIPTION
Fixed the code to handle case where sequelize returns a null.