### PR TITLE
RHINENG-11246: Compliance playbook downloads failing

### DIFF
--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -166,6 +166,8 @@ objects:
             value: ${SSG_IMPL}
           - name: SSG_HOST
             value: ${SSG_HOST}
+          - name: SSG_REVALIDATION_INTERVAL
+            value: ${SSG_REVALIDATION_INTERVAL}
           - name: TENANT_TRANSLATOR_HOST
             value: ${TENANT_TRANSLATOR_HOST}
           - name: TENANT_TRANSLATOR_PORT
@@ -428,6 +430,7 @@ parameters:
 - name: SSG_IMPL
   value: impl
 - name: SSG_HOST
+- name: SSG_REVALIDATION_INTERVAL
 - name: TENANT_TRANSLATOR_HOST
 - name: TENANT_TRANSLATOR_PORT
 - name: USERS_IMPL

--- a/src/config/__snapshots__/config.unit.js.snap
+++ b/src/config/__snapshots__/config.unit.js.snap
@@ -143,6 +143,7 @@ exports[`Configuration Verify app-common-js function 1`] = `
   "ssg": {
     "host": "http://localhost:8090",
     "impl": undefined,
+    "revalidationInterval": 3600,
   },
   "users": {
     "auth": "",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -176,7 +176,8 @@ function Config() {
         },
 
         ssg: {
-            impl: env.SSG_IMPL
+            impl: env.SSG_IMPL,
+            revalidationInterval: parseIntEnv('SSG_REVALIDATION_INTERVAL', 60 * 60) // 1 hour
         },
 
         users: {

--- a/src/connectors/ssg/impl.js
+++ b/src/connectors/ssg/impl.js
@@ -6,7 +6,7 @@ const metrics = require('../metrics');
 const assert = require('assert');
 const trace = require('../../util/trace');
 
-const {host} = require('../../config').ssg;
+const {host, revalidationInterval } = require('../../config').ssg;
 const VERSION_HEADER = 'x-ssg-version';
 
 module.exports = new class extends Connector {
@@ -28,7 +28,7 @@ module.exports = new class extends Connector {
 
         const result = this.doHttp(
             { uri: uri.toString() },
-            false,
+            { revalidationInterval },
             this.metrics,
             // eslint-disable-next-line security/detect-object-injection
             res => res === null ? null : ({template: res.body, version: res.headers[VERSION_HEADER]})


### PR DESCRIPTION
Compliance playbook generation as failing once a remediation plan contained enough issues and systems.  This was caused by rate-limiting of the internal SSG playbook service and inefficient playbook generation code.

Resolved by cacheing compliance playbook snippets.