### PR TITLE
RHINENG-12150: Fixed user check for cached remediation plans when using cert auth

### DIFF
--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -286,7 +286,8 @@ exports.get = async function (id, tenant_org_id, created_by = null, useCache = f
             result = JSON.parse(result);
 
             // make sure tenant_org_id and created_by match - Remediation plans are scoped to a particular user.
-            if (result?.tenant_org_id !== tenant_org_id || result?.created_by !== created_by) {
+            // created_by will be null for cert auth "users"
+            if (result?.tenant_org_id !== tenant_org_id || (created_by && result?.created_by !== created_by)) {
                 result = null;
             }
         }


### PR DESCRIPTION
Cert auth identities have no username.  The validation code for cached remediation plans was expecting the plan, which HAS an associated username since it was created via the UI, to match "null" and returning a null for the fetched plan, causing playbook downloads to work on the first try but fail on subsequent attempts (once the remediation plan has been cached).