### PR TITLE
RHINENG-12281: Removed resolved issue count subquery from playbook download code

### DIFF
--- a/src/remediations/controller.read.js
+++ b/src/remediations/controller.read.js
@@ -301,8 +301,11 @@ exports.playbook = errors.async(async function (req, res) {
     const tenant_org_id = req.identity.org_id;
     const creator = cert_auth ? null : req.user.username;
 
+    const USE_CACHE = true;
+    const EXCLUDE_RESOLVED_COUNT = false;
+
     trace.event('Get remediation plan from db (w/caching)');
-    const remediation = await queries.get(id, tenant_org_id, creator, true);
+    const remediation = await queries.get(id, tenant_org_id, creator, EXCLUDE_RESOLVED_COUNT, USE_CACHE);
 
     if (!remediation) {
         return notFound(res);

--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -237,15 +237,14 @@ exports.getPlanNames = function (tenant_org_id) {
     ]
   }
 */
-exports.get = async function (id, tenant_org_id, created_by = null, useCache = false) {
+exports.get = async function (id, tenant_org_id, created_by = null, includeResolvedCount = true, useCache = false) {
     // This gets called with a high degree of concurrency during playbook runs with RHC direct systems.
     // Remediation plan changes during a playbook run are undesireable anyway so allow for caching these results
     // to ease the load on the database.
 
     const query = {
         attributes: [
-            ...REMEDIATION_ATTRIBUTES,
-            [resolvedCountSubquery(), 'resolved_count']
+            ...REMEDIATION_ATTRIBUTES
         ],
         include: [{
             attributes: ISSUE_ATTRIBUTES,
@@ -271,6 +270,10 @@ exports.get = async function (id, tenant_org_id, created_by = null, useCache = f
             [db.issue, db.issue.associations.systems, 'system_id']
         ]
     };
+
+    if (includeResolvedCount) {
+        query.attributes.push([resolvedCountSubquery(), 'resolved_count']);
+    }
 
     if (created_by) {
         query.where.created_by = created_by;


### PR DESCRIPTION
The remediation plan query used by the playbook download endpoint included a sub-query to count resolved issues, which is rather inefficient.  Since this value is never used, a parameter was added to remove it from the query for this code path.