### PR TITLE
Fix advisor host from clowder

### DIFF
--- a/deployment/clowdapp.yml
+++ b/deployment/clowdapp.yml
@@ -14,6 +14,7 @@ objects:
     - rbac
     - host-inventory
     optionalDependencies:
+    - advisor-backend
     - compliance
     - compliance-ssg
     - config-manager

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -243,11 +243,11 @@ function Config() {
         config.logging.cloudwatch.options.aws_region = loadedConfig.logging.cloudwatch.region || env.LOG_CW_REGION;
         config.logging.cloudwatch.options.group = loadedConfig.logging.cloudwatch.logGroup || env.LOG_CW_GROUP;
 
-        config.advisor.host = getHostForApp(dependencyEndpoints, 'advisor', 'service', 'ADVISOR') || env.ADVISOR_HOST || 'http://insights-advisor-api.advisor-ci.svc.cluster.local:8000';
+        config.advisor.host = getHostForApp(dependencyEndpoints, 'advisor-backend', 'api', 'ADVISOR') || env.ADVISOR_HOST || 'http://insights-advisor-api.advisor-ci.svc.cluster.local:8000';
         config.bop.host = getHostForApp(dependencyEndpoints, 'bop', 'service', 'TENANT_TRANSLATOR') || `http://${env.TENANT_TRANSLATOR_HOST}:${env.TENANT_TRANSLATOR_PORT}` || 'http://gateway.3scale-dev.svc.cluster.local:8892';
         config.compliance.host = getHostForApp(dependencyEndpoints, 'compliance', 'service', 'COMPLIANCE') || env.COMPLIANCE_HOST || 'http://compliance-backend.compliance-ci.svc.cluster.local:3000';
         config.configManager.host = getHostForApp(dependencyEndpoints, 'config-manager', 'service', 'CONFIG_MANAGER') || env.CONFIG_MANAGER_HOST || 'http://config-manager-service.config-manager-ci.svc.cluster.local:8081';
-        config.contentServer.host = getHostForApp(dependencyEndpoints, 'advisor', 'service', 'CONTENT_SERVER') || env.CONTENT_SERVER_HOST || 'http://insights-advisor-api.advisor-ci.svc.cluster.local:8000';
+        config.contentServer.host = getHostForApp(dependencyEndpoints, 'advisor-backend', 'api', 'CONTENT_SERVER') || env.CONTENT_SERVER_HOST || 'http://insights-advisor-api.advisor-ci.svc.cluster.local:8000';
         config.dispatcher.host = getHostForApp(dependencyEndpoints, 'playbook-dispatcher', 'api', 'PLAYBOOK_DISPATCHER') || env.PLAYBOOK_DISPATCHER_HOST || 'http://playbook-dispatcher-api.playbook-dispatcher-ci.svc.cluster.local:8000';
         config.inventory.host = getHostForApp(dependencyEndpoints, 'host-inventory', 'service', 'INVENTORY') || env.INVENTORY_HOST || 'http://insights-inventory.platform-ci.svc.cluster.local:8080';
         config.patchman.host = getHostForApp(dependencyEndpoints, 'patchman', 'manager', 'PATCHMAN') || env.PATCHMAN_HOST || 'http://localhost:8080';


### PR DESCRIPTION
`advisor-backend` is the correct clowd app name to grab the API service
endpoint.

[RHINENG-13051](https://issues.redhat.com/browse/RHINENG-13051)

    ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices