### PR TITLE
RHINENG-15288: Bump semver to 5.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3410,6 +3410,15 @@
         "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
       }
     },
+    "node_modules/cls-hooked/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
@@ -11725,14 +11734,6 @@
       "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o=",
       "dev": true
     },
-    "node_modules/semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/semver-greatest-satisfied-range": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-2.0.0.tgz",
@@ -16389,7 +16390,14 @@
       "requires": {
         "async-hook-jl": "^1.7.6",
         "emitter-listener": "^1.0.1",
-        "semver": "^5.4.1"
+        "semver": "^5.7.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
+        }
       }
     },
     "cluster-key-slot": {
@@ -22637,11 +22645,6 @@
       "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
       "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o=",
       "dev": true
-    },
-    "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "semver-greatest-satisfied-range": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,9 @@
     },
     "os-locale": {
       "execa": "^9.5.1"
+    },
+    "cls-hooked": {
+      "semver": "^5.7.2"
     }
   },
   "scripts": {


### PR DESCRIPTION
Vulnerable version of semver was 5.7.0 so bumped it to the fixed version which is 5.7.2.

![Screenshot 2025-01-14 at 12 13 54 PM](https://github.com/user-attachments/assets/6ecf7e56-922a-4975-b0f7-91cf0ce548fa)


    ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices