### PR TITLE
RHINENG-16576: Fix npm clean-modules build boo boo

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -51,6 +51,7 @@ FROM base AS dist
 COPY --from=build $APP_ROOT/dist ./
 
 RUN npm ci --omit=dev && npm cache clean --force
+RUN npx clean-modules -y
 
 EXPOSE 9002
 ENV NODE_ENV=production

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "app-common-js": "^2.2.4",
     "bluebird": "^3.7.2",
     "body-parser": "^1.20.3",
+    "clean-modules": "^3.1.1",
     "cls-bluebird": "^2.1.0",
     "dedent-js": "^1.0.1",
     "etag": "^1.8.1",
@@ -47,7 +48,6 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
-    "clean-modules": "^3.1.1",
     "eslint": "9.2",
     "eslint-plugin-jest": "^28.5.0",
     "globals": "^15.1.0",


### PR DESCRIPTION
The multistage Dockerfile wasn't calling clean-modules during the dist build stage, resulting in all the extraneous items not getting removed from the prod image.