### PR TITLE
RHINENG-16923: remove prismjs as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "app-common-js": "^2.2.4",
         "bluebird": "^3.7.2",
         "body-parser": "^1.20.3",
+        "clean-modules": "^3.1.1",
         "cls-bluebird": "^2.1.0",
         "dedent-js": "^1.0.1",
         "etag": "^1.8.1",
@@ -35,7 +36,6 @@
         "pino-cloudwatch": "^0.7.0",
         "pino-http": "^8.3.3",
         "pino-pretty": "^10.0.0",
-        "prismjs": "^1.30.0",
         "prom-client": "^11.5.3",
         "request": "^2.88.2",
         "request-promise": "^4.2.6",
@@ -46,7 +46,6 @@
         "uuid": "^7.0.3"
       },
       "devDependencies": {
-        "clean-modules": "^3.1.1",
         "eslint": "9.2",
         "eslint-plugin-jest": "^28.5.0",
         "globals": "^15.1.0",
@@ -3261,7 +3260,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/clean-modules/-/clean-modules-3.1.1.tgz",
       "integrity": "sha512-t/7dNtn6vQYxujYxdwZeLa0NsLE92KQ0XeV3CDJ2TXgLTvn3ijmjlQN0Dm9wjYQgC0miZiF66ClTQzgIeYw96A==",
-      "dev": true,
       "dependencies": {
         "clipanion": "^3.2.1",
         "picomatch": "^2.3.0",
@@ -3280,7 +3278,6 @@
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
       "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -3307,7 +3304,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-3.2.1.tgz",
       "integrity": "sha512-dYFdjLb7y1ajfxQopN05mylEpK9ZX0sO1/RfMXdfmwjlIsPkbh4p7A682x++zFPLDCo1x3p82dtljHf5cW2LKA==",
-      "dev": true,
       "workspaces": [
         "website"
       ],
@@ -10302,7 +10298,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
       "integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -10489,7 +10484,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -10920,7 +10914,6 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
       "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
-      "dev": true,
       "engines": {
         "node": "^14.13.1 || >=16.0.0"
       },
@@ -10964,7 +10957,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
       "integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
-      "dev": true,
       "dependencies": {
         "parse-ms": "^3.0.0"
       },
@@ -10979,6 +10971,7 @@
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
       "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -13160,7 +13153,6 @@
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/typanion/-/typanion-3.14.0.tgz",
       "integrity": "sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==",
-      "dev": true,
       "workspaces": [
         "website"
       ]
@@ -16306,7 +16298,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/clean-modules/-/clean-modules-3.1.1.tgz",
       "integrity": "sha512-t/7dNtn6vQYxujYxdwZeLa0NsLE92KQ0XeV3CDJ2TXgLTvn3ijmjlQN0Dm9wjYQgC0miZiF66ClTQzgIeYw96A==",
-      "dev": true,
       "requires": {
         "clipanion": "^3.2.1",
         "picomatch": "^2.3.0",
@@ -16318,8 +16309,7 @@
         "supports-color": {
           "version": "9.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
-          "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
-          "dev": true
+          "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw=="
         }
       }
     },
@@ -16339,7 +16329,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-3.2.1.tgz",
       "integrity": "sha512-dYFdjLb7y1ajfxQopN05mylEpK9ZX0sO1/RfMXdfmwjlIsPkbh4p7A682x++zFPLDCo1x3p82dtljHf5cW2LKA==",
-      "dev": true,
       "requires": {
         "typanion": "^3.8.0"
       }
@@ -21628,8 +21617,7 @@
     "parse-ms": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
-      "integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
-      "dev": true
+      "integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw=="
     },
     "parse-passwd": {
       "version": "1.0.0",
@@ -21765,8 +21753,7 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pidtree": {
       "version": "0.6.0",
@@ -22074,8 +22061,7 @@
     "pretty-bytes": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
-      "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
-      "dev": true
+      "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="
     },
     "pretty-format": {
       "version": "29.7.0",
@@ -22106,7 +22092,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
       "integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
-      "dev": true,
       "requires": {
         "parse-ms": "^3.0.0"
       }
@@ -22114,7 +22099,8 @@
     "prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
-      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "dev": true
     },
     "process": {
       "version": "0.11.10",
@@ -23772,8 +23758,7 @@
     "typanion": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/typanion/-/typanion-3.14.0.tgz",
-      "integrity": "sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==",
-      "dev": true
+      "integrity": "sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug=="
     },
     "type": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "pino-cloudwatch": "^0.7.0",
     "pino-http": "^8.3.3",
     "pino-pretty": "^10.0.0",
-    "prismjs": "^1.30.0",
     "prom-client": "^11.5.3",
     "request": "^2.88.2",
     "request-promise": "^4.2.6",


### PR DESCRIPTION
prismjs is listed as a direct dependency, which is causing problems with updates.  I'm removing it and letting npm sort out the details...