### PR TITLE
RHINENG-16796: Add sorting/filtering options to API spec

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -660,11 +660,25 @@ components:
     RemediationSort:
       in: query
       name: sort
-      description: Sort order
+      description: Sort order. Use `-` before a field name for descending order (e.g., `?-system_count`).
       required: false
       schema:
         type: string
-        enum: [updated_at, -updated_at, name, -name, system_count, -system_count, issue_count, -issue_count]
+        enum: 
+          - updated_at
+          - -updated_at
+          - created_at
+          - -created_at
+          - last_run_at
+          - -last_run_at
+          - name
+          - -name
+          - system_count
+          - -system_count
+          - issue_count
+          - -issue_count
+          - status
+          - -status
         default: -updated_at
     RemediationSystem:
       in: query
@@ -677,10 +691,37 @@ components:
     RemediationFilter:
       in: query
       name: filter
-      description: Remediation name filter. If specified only remediations whose name matches the given string will be returned.
+      description: Allows filtering remediations based on various criteria including name, creation time, last run time, status, and update time.
       required: false
       schema:
-        type: string
+        anyOf:
+          - type: string
+            description: Simple string filter (e.g., name filtering)
+          - type: object
+            properties:
+              name:
+                type: string
+                description: Filter by remediation name (partial match allowed)
+              created_after:
+                type: string
+                format: date-time
+                description: Filter remediations created after this timestamp (ISO 8601 format)
+              last_run_after:
+                oneOf:
+                  - type: string
+                    format: date-time
+                    description: Filter remediations with last run after this timestamp (ISO 8601 format)
+                  - type: string
+                    enum: ["never"]
+                    description: Filter remediations that have never run. Case insensitive.
+              updated_after:
+                type: string
+                format: date-time
+                description: Filter remediations updated after this timestamp (ISO 8601 format)
+              status:
+                $ref: '#/components/schemas/PlaybookRunStatus'
+      style: deepObject
+      explode: true
     SystemId:
       in: path
       name: system

--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -664,7 +664,7 @@ components:
       required: false
       schema:
         type: string
-        enum: 
+        enum:
           - updated_at
           - -updated_at
           - created_at
@@ -691,35 +691,51 @@ components:
     RemediationFilter:
       in: query
       name: filter
-      description: Allows filtering remediations based on various criteria including name, creation time, last run time, status, and update time.
+      description: |
+        For filtering by various criteria.
+
+        There are two styles of filter: legacy and new.
+        
+        Legacy filtering allows for filtering by remediation plan name and is of the form: `?filter=plan name`.
+        If specified, only remediations whose name matches the given string will be returned.
+        
+        New style filters allow for filtering by various criteria and are of the form: `?filter[<field>]=<value>`.
+        
+        Available filter fields:
+        - name: plan names matching string, `?filter[name]=my plan name`
+        - created_after: created on or after date-time, `filter[created_after]=2025-03-31T08:19:36.641Z`
+        - updated_after: modified on or after date-time, `filter[updated_after]=2025-03-31T08:19:36.641Z`
+        - last_run_after: executed on or after date-time or 'never', `filter[last_run_after]=never` 
+        - status: status matching one of [running, success, failure], `filter[status]=failure`
       required: false
       schema:
         anyOf:
           - type: string
-            description: Simple string filter (e.g., name filtering)
+            description: (legacy) Filter by plan name (allows partial match)
           - type: object
             properties:
               name:
                 type: string
-                description: Filter by remediation name (partial match allowed)
-              created_after:
-                type: string
-                format: date-time
-                description: Filter remediations created after this timestamp (ISO 8601 format)
+                description: Filter by plan name (allows partial match)
               last_run_after:
                 oneOf:
                   - type: string
                     format: date-time
-                    description: Filter remediations with last run after this timestamp (ISO 8601 format)
+                    description: Filter remediations with last run on or after this timestamp (ISO 8601 format)
                   - type: string
-                    enum: ["never"]
-                    description: Filter remediations that have never run. Case insensitive.
+                    enum: ['never']
+                    description: Filter remediations that have never run
+              created_after:
+                type: string
+                format: date-time
+                description: Filter remediations created on or after this timestamp (ISO 8601 format)
+              status:
+                type: string
+                enum: [running, success, failure]
               updated_after:
                 type: string
                 format: date-time
-                description: Filter remediations updated after this timestamp (ISO 8601 format)
-              status:
-                $ref: '#/components/schemas/PlaybookRunStatus'
+                description: Filter remediations updated on or after this timestamp (ISO 8601 format)
       style: deepObject
       explode: true
     SystemId:


### PR DESCRIPTION
Didn't remove the 'pending' status here because this breaks a lot of tests so I was thinking we could create a separate subtask for this?

`deepObject` and `explode: true` determine how query parameters are formatted so this allows for a filter like this:
```
?filter[name]=example-remediation&filter[status]=completed
```

If a plain string is passed, it's interpreted as a name search:
```
?filter=example-remediation
```

 ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices