### PR TITLE
RHINENG-17235: Added missing 'additionalProperties: false' statement

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -713,6 +713,7 @@ components:
           - type: string
             description: (legacy) Filter by plan name (allows partial match)
           - type: object
+            additionalProperties: false
             properties:
               name:
                 type: string


### PR DESCRIPTION
As a matter of policy we should explicitly list all properties allowed for an `object` and set `additionalProperties: false` 