### PR TITLE
RHINENG-17392: Removing filter code that handles null remediation names

### DIFF
--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -136,13 +136,6 @@ exports.list = function (
             name: {
                 [Op.iLike]: filter
             }
-        }, {
-            [Op.and]: [
-                {
-                    name: null
-                },
-                where(literal(db.s.escape(NULL_NAME_VALUE)), Op.iLike, filter)
-            ]
         }];
     }
 


### PR DESCRIPTION
 There are tests that cover creating a remediation with a null name or empty name in `write.integration.js` and it returns a 400. So there should never be null/empty remediation plan names in the database. 

  ## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices