### PR TITLE
RHINENG-16702: Added GET /remediations/:id?format=(summary|detail) support

### DIFF
--- a/doc/diagrams/v1/remediations/{plan_id}/get.md
+++ b/doc/diagrams/v1/remediations/{plan_id}/get.md
@@ -1,0 +1,51 @@
+### GET v1/remediations/:plan_id
+
+#### Procedure
+1. Fetch plan from db
+2. Get systems from inventory
+   1. Remove systems not in inventory
+3. Get resolution for each issue
+4. Get details for each issue
+5. Get user details from BOP
+6. Remove issues with 0 systems or missing details
+7. Infer needs_reboot
+8. Return formatted result
+
+#### Sequence Diagram
+```mermaid
+sequenceDiagram
+    actor u as User
+    participant rem as Remediations
+    participant db as Remediations<br>Database
+    participant hbi as Inventory
+    participant bop as Back<br>Office<br>Proxy
+    participant svc as Issue<br>Service
+
+    u ->> + rem: GET v1/remediations/:plan_id
+
+   rect rgba(191, 223, 255, .1)
+       rem -->> db: SELECT * FROM remediations * issues * issue_systems WHERE id = :plan_id
+       db ->> rem: (plan details)
+   end
+   
+   rect rgba(191, 223, 255, .1)
+      rem -->> hbi: GET /inventory/v1/hosts
+      hbi ->> rem: [systems]
+      rem ->> rem: Remove duplicate systems
+   end
+
+   rect rgba(191, 223, 255, .1)
+      loop for each issue
+         rem -->> svc: GET issue resolution
+         svc ->> rem: (resolution details)
+         rem -->> svc: GET issue details
+         svc ->> rem: (issue details)
+      end
+   end
+
+   rect rgba(191, 223, 255, .1)
+      rem -->> bop: GET user details
+      bop ->> rem: (user details)
+   end
+
+```

--- a/doc/diagrams/v1/remediations/{plan_id}/get.md
+++ b/doc/diagrams/v1/remediations/{plan_id}/get.md
@@ -2,14 +2,17 @@
 
 #### Procedure
 1. Fetch plan from db
-2. Get systems from inventory
-   1. Remove systems not in inventory
-3. Get resolution for each issue
-4. Get details for each issue
-5. Get user details from BOP
-6. Remove issues with 0 systems or missing details
-7. Infer needs_reboot
-8. Return formatted result
+2. Get user details from BOP
+4. `if ?format=summary`
+   1. Extract details from plan
+3. `else`
+   1. Get systems from inventory
+      1. Remove systems not in inventory
+   2. Get resolution for each issue
+   3. Get details for each issue
+   4. Remove issues with 0 systems or missing details
+   5. Infer needs_reboot
+4. Return formatted result
 
 #### Sequence Diagram
 ```mermaid
@@ -22,30 +25,35 @@ sequenceDiagram
     participant svc as Issue<br>Service
 
     u ->> + rem: GET v1/remediations/:plan_id
+    
+    rect rgba(191, 223, 255, .1)
+        rem -->> db: SELECT * FROM remediations * issues * issue_systems WHERE id = :plan_id
+        db ->> rem: (plan details)
+    end
+    
+    rect rgba(191, 223, 255, .1)
+        rem -->> bop: GET user details
+        bop ->> rem: (user details)
+    end
+    
+    alt ?format=summary
+        rem ->> rem: Extract details from plan
+    else    
+        rect rgba(191, 223, 255, .1)
+           loop for each issue
+              rem -->> svc: GET issue resolution
+              svc ->> rem: (resolution details)
+              rem -->> svc: GET issue details
+              svc ->> rem: (issue details)
+           end
+        end
 
-   rect rgba(191, 223, 255, .1)
-       rem -->> db: SELECT * FROM remediations * issues * issue_systems WHERE id = :plan_id
-       db ->> rem: (plan details)
-   end
-   
-   rect rgba(191, 223, 255, .1)
-      rem -->> hbi: GET /inventory/v1/hosts
-      hbi ->> rem: [systems]
-      rem ->> rem: Remove duplicate systems
-   end
-
-   rect rgba(191, 223, 255, .1)
-      loop for each issue
-         rem -->> svc: GET issue resolution
-         svc ->> rem: (resolution details)
-         rem -->> svc: GET issue details
-         svc ->> rem: (issue details)
-      end
-   end
-
-   rect rgba(191, 223, 255, .1)
-      rem -->> bop: GET user details
-      bop ->> rem: (user details)
-   end
-
+        rect rgba(191, 223, 255, .1)
+            rem -->> hbi: GET /inventory/v1/hosts
+            hbi ->> rem: [systems]
+            rem ->> rem: Remove duplicate systems
+        end
+    end
+    
+    rem ->> - u: HTTP 200
 ```

--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -39,7 +39,7 @@ paths:
         - $ref: '#/components/parameters/Offset'
         - $ref: '#/components/parameters/RemediationSystem'
         - $ref: '#/components/parameters/HideArchived'
-        - $ref: '#/components/parameters/Fields'
+        - $ref: '#/components/parameters/RemediationFields'
       responses:
         200:
           description: OK
@@ -115,6 +115,7 @@ paths:
       operationId: getRemediation
       parameters:
         - $ref: '#/components/parameters/RemediationId'
+        - $ref: '#/components/parameters/RemediationFormat'
       responses:
         200:
           description: OK
@@ -821,7 +822,7 @@ components:
       schema:
         type: boolean
         default: false
-    Fields:
+    RemediationFields:
       in: query
       name: fields[data]
       description: |
@@ -836,6 +837,40 @@ components:
           enum:
             - name
             - playbook_runs
+    RemediationFormat:
+      in: query
+      name: format
+      description: |
+        Optional format for returned data.  `'summary'` format returns counts instead of issue and system details, e.g.:
+        ```
+        {
+          "id": "9197ba55-0abc-4028-9bbe-269e530f8bd5",
+          "name": "Fix Critical CVEs",
+          "archived": true,
+          "auto_reboot": true,
+          "created_at": "2018-12-05T08:19:36.641Z",
+          "created_by": {
+            "username": "jharting@redhat.com",
+            "first_name": "Jozef",
+            "last_name": "Hartinger"
+          },
+          "updated_at": "2018-12-05T08:19:36.641Z",
+          "updated_by": {
+            "username": "jharting@redhat.com",
+            "first_name": "Jozef",
+            "last_name": "Hartinger"
+          },
+          "issue_count": 5,
+          "system_count": 12
+        }
+        ```
+      required: false
+      schema:
+        type: string
+        default: detail
+        enum:
+          - detail
+          - summary
     SelectedHosts:
       in: query
       name: hosts
@@ -976,6 +1011,7 @@ components:
 
 
 
+
     RemediationId:
       type: string
       format: uuid
@@ -1068,6 +1104,13 @@ components:
       type: integer
       example: 27
 
+    IssueCount:
+      type: integer
+      example: 27
+
+    SystemCount:
+      type: integer
+      example: 78
 
     #
     # Input schemas
@@ -1631,7 +1674,7 @@ components:
     RemediationDetails:
       type: object
       additionalProperties: false
-      required: [id, name, needs_reboot, auto_reboot, created_by, created_at, updated_by, updated_at, resolved_count, issues, archived]
+      required: [id, name, auto_reboot, created_by, created_at, updated_by, updated_at, archived]
       properties:
         id:
           $ref: '#/components/schemas/RemediationId'
@@ -1653,6 +1696,10 @@ components:
           $ref: '#/components/schemas/DateTime'
         resolved_count:
           $ref: '#/components/schemas/ResolvedCount'
+        issue_count:
+          $ref: '#/components/schemas/IssueCount'
+        system_count:
+          $ref: '#/components/schemas/SystemCount'
         issues:
           type: array
           items:

--- a/src/concurrent.js
+++ b/src/concurrent.js
@@ -1,0 +1,5 @@
+'use strict';
+
+let requests = 0;
+
+exports.requests = requests;

--- a/src/remediations/__snapshots__/read.integration.js.snap
+++ b/src/remediations/__snapshots__/read.integration.js.snap
@@ -290,7 +290,6 @@ exports[`remediations get get remediation 1`] = `
 "{
     "id": "66eec356-dd06-4c72-a3b6-ef27d1508a02",
     "name": "Test1",
-    "needs_reboot": true,
     "auto_reboot": true,
     "archived": true,
     "created_by": {
@@ -305,6 +304,7 @@ exports[`remediations get get remediation 1`] = `
         "last_name": "user"
     },
     "updated_at": "2018-10-04T08:19:36.641Z",
+    "needs_reboot": true,
     "resolved_count": 2,
     "issues": [
         {
@@ -435,7 +435,6 @@ exports[`remediations get get remediation with many systems 1`] = `
 "{
     "id": "c3f9f751-4bcc-4222-9b83-77f5e6e603da",
     "name": "many systems",
-    "needs_reboot": true,
     "auto_reboot": true,
     "archived": false,
     "created_by": {
@@ -450,6 +449,7 @@ exports[`remediations get get remediation with many systems 1`] = `
         "last_name": "user"
     },
     "updated_at": "2018-11-04T04:19:36.641Z",
+    "needs_reboot": true,
     "resolved_count": 0,
     "issues": [
         {
@@ -1973,7 +1973,6 @@ exports[`remediations get get remediation with test namespace resolutions 1`] = 
 "{
     "id": "5e6d136e-ea32-46e4-a350-325ef41790f4",
     "name": "test namespace",
-    "needs_reboot": true,
     "auto_reboot": false,
     "archived": false,
     "created_by": {
@@ -1988,6 +1987,7 @@ exports[`remediations get get remediation with test namespace resolutions 1`] = 
         "last_name": "user"
     },
     "updated_at": "2018-11-04T03:19:36.641Z",
+    "needs_reboot": true,
     "resolved_count": 0,
     "issues": [
         {
@@ -2036,6 +2036,29 @@ exports[`remediations get get remediation with test namespace resolutions 1`] = 
         }
     ]
 }"
+`;
+
+exports[`remediations get summary format 1`] = `
+{
+  "archived": true,
+  "auto_reboot": true,
+  "created_at": "2018-10-04T08:19:36.641Z",
+  "created_by": {
+    "first_name": "test",
+    "last_name": "user",
+    "username": "tuser@redhat.com",
+  },
+  "id": "66eec356-dd06-4c72-a3b6-ef27d1508a02",
+  "issue_count": 6,
+  "name": "Test1",
+  "system_count": 2,
+  "updated_at": "2018-10-04T08:19:36.641Z",
+  "updated_by": {
+    "first_name": "test",
+    "last_name": "user",
+    "username": "tuser@redhat.com",
+  },
+}
 `;
 
 exports[`remediations list filter basic filter 1`] = `

--- a/src/remediations/read.integration.js
+++ b/src/remediations/read.integration.js
@@ -332,6 +332,20 @@ describe('remediations', function () {
             expect(text).toMatchSnapshot();
         });
 
+        test('summary format', async () => {
+            const {body} = await request
+            .get('/v1/remediations/66eec356-dd06-4c72-a3b6-ef27d1508a02?format=summary')
+            .expect(200);
+
+            expect(body).not.toHaveProperty('needs_reboot');
+            expect(body).not.toHaveProperty('issues');
+            expect(body).not.toHaveProperty('resolved_count');
+            expect(body).toHaveProperty('issue_count');
+            expect(body).toHaveProperty('system_count');
+
+            expect(body).toMatchSnapshot();
+        });
+
         test('get remediation with test namespace resolutions', async () => {
             const {body, text} = await request
             .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4?pretty')

--- a/src/remediations/remediations.format.js
+++ b/src/remediations/remediations.format.js
@@ -98,19 +98,30 @@ exports.list = function (remediations, total, limit, offset, sort, system) {
     };
 };
 
-exports.get = function ({id, name, needs_reboot, auto_reboot, created_by, created_at, updated_by, updated_at, issues, resolved_count, archived}) {
-    return {
+exports.get = function ({id, name, needs_reboot, auto_reboot, created_by, created_at, updated_by, updated_at,
+                            issues, resolved_count, issue_count, system_count, archived}) {
+    const formatted =  {
         id,
         name,
-        needs_reboot,
         auto_reboot,
         archived,
         created_by: _.pick(created_by, USER),
         created_at: created_at.toISOString(),
         updated_by: _.pick(updated_by, USER),
-        updated_at: updated_at.toISOString(),
-        resolved_count: (resolved_count === null) ? 0 : resolved_count,
-        issues: _.map(issues, ({issue_id, resolution, details, systems, resolutionsAvailable }) => ({
+        updated_at: updated_at.toISOString()
+    };
+
+    // handle format='detail' items
+    if (typeof needs_reboot !== 'undefined') {
+        formatted.needs_reboot = needs_reboot;
+    }
+
+    if (typeof resolved_count !== 'undefined') {
+        formatted.resolved_count = (resolved_count === null) ? 0 : resolved_count;
+    }
+
+    if (typeof issues !== 'undefined') {
+        formatted.issues = _.map(issues, ({issue_id, resolution, details, systems, resolutionsAvailable }) => ({
             id: issue_id,
             description: details.description,
             resolution: {
@@ -126,8 +137,19 @@ exports.get = function ({id, name, needs_reboot, auto_reboot, created_by, create
                 display_name,
                 resolved
             }))
-        }))
-    };
+        }));
+    }
+
+    // handle format='summary' items
+    if (typeof issue_count !== 'undefined') {
+        formatted.issue_count = issue_count;
+    }
+
+    if (typeof system_count !== 'undefined') {
+        formatted.system_count = system_count;
+    }
+
+    return formatted;
 };
 
 exports.created = function ({id}) {


### PR DESCRIPTION
Added `?format=(summary|detail)` support to `GET /remediations/:id` endpoint

## Summary by Sourcery

Add support for optional format parameter in GET /remediations/:id endpoint to allow retrieving either detailed or summary view of a remediation plan

New Features:
- Introduce `?format` query parameter to GET /remediations/:id endpoint, supporting 'summary' and 'detail' modes
- Add ability to retrieve a lightweight summary of a remediation plan with issue and system counts

Enhancements:
- Modify remediation details response to conditionally include or exclude detailed information based on format parameter
- Update OpenAPI specification to include new format parameter and response schema