### PR TITLE
RHINENG-16071: Add correct filter for Compliance v2 /security_guides call

### DIFF
--- a/src/connectors/compliance/impl.js
+++ b/src/connectors/compliance/impl.js
@@ -57,10 +57,8 @@ module.exports = new class extends Connector {
 
     async buildV2Uri(id, ssgRefId, ssgVersion, refresh, retries) {
       const ssgUri = this.buildUri(host, 'compliance', 'v2', 'security_guides');
-      const searchParams = new URLSearchParams();
 
-      searchParams.set('filter', `ref_id=${ssgRefId} AND version=${ssgVersion}`);
-      ssgUri.search = searchParams.toString();
+      ssgUri.addQuery('filter', `ref_id=${ssgRefId} AND version=${ssgVersion}`);
 
       // Fetch info about the scap security guide(SSG) that the rule belongs to
       const ssgResult = await this.doHttp({


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices

## Summary by Sourcery

Update the construction of the filter query parameter for Compliance v2 `/security_guides` API calls.

Bug Fixes:
- Ensure the filter parameter is correctly applied to the `/security_guides` endpoint URI.

Tests:
- Add a unit test to verify the correct construction of the `/security_guides` URI, including the filter parameter.