### PR TITLE
RHINENG-16071: Correct filter for /security_guides?filter call again

### DIFF
--- a/src/connectors/compliance/impl.js
+++ b/src/connectors/compliance/impl.js
@@ -56,9 +56,11 @@ module.exports = new class extends Connector {
     }
 
     async buildV2Uri(id, ssgRefId, ssgVersion, refresh, retries) {
+      // Build the Compliance v2 URI with the correct filters
       const ssgUri = this.buildUri(host, 'compliance', 'v2', 'security_guides');
 
-      ssgUri.addQuery('filter', `ref_id=${ssgRefId} AND version=${ssgVersion}`);
+      // Need to add the filter this way because Compliance uses scoped_search so we need to pass exactly what they expect
+      ssgUri.query(`?filter=ref_id=${ssgRefId}+AND+version=${ssgVersion}`);
 
       // Fetch info about the scap security guide(SSG) that the rule belongs to
       const ssgResult = await this.doHttp({

--- a/src/connectors/compliance/impl.unit.js
+++ b/src/connectors/compliance/impl.unit.js
@@ -289,7 +289,7 @@ describe('compliance impl (v2)', function () {
     });
 
     test('correctly builds the ssgUri with the filter in the buildV2Uri function', async function () {
-        const expectedUri = 'http://compliance-backend.compliance-ci.svc.cluster.local:3000/api/compliance/v2/security_guides?filter=ref_id%3Dxccdf_org.ssgproject.content_benchmark_RHEL-8+AND+version%3D0.0.0';
+        const expectedUri = 'http://compliance-backend.compliance-ci.svc.cluster.local:3000/api/compliance/v2/security_guides?filter=ref_id=xccdf_org.ssgproject.content_benchmark_RHEL-8+AND+version=0.0.0';
         const http = base.getSandbox().stub(request, 'run').callsFake(params => {
             params.uri.should.equal(expectedUri);
             return Promise.resolves({


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices

## Summary by Sourcery

Fix the filter parameter format for the Compliance v2 security guides API call.

Bug Fixes:
- Correct the construction of the `filter` query parameter for the `/compliance/v2/security_guides` endpoint to prevent incorrect URL encoding and ensure it matches the format expected by the Compliance service.

Tests:
- Update the unit test to expect the corrected URI format for the security guides API call.