### PR TITLE
Removing temp log messages that were for debugging

### DIFF
--- a/src/connectors/compliance/impl.js
+++ b/src/connectors/compliance/impl.js
@@ -30,7 +30,6 @@ module.exports = new class extends Connector {
                 if (ssgVersion) {
                     // Build URI that will fetch the rule using Compliance API v2
                     uri = await this.buildV2Uri(id, ssgRefId, ssgVersion, refresh, retries);
-                    log.warn(`URI: ${uri}`);
                 } else {
                     // Build URI that will fetch the rule using Compliance API v1
                     uri = this.buildUri(host, 'compliance', 'rules', id);
@@ -48,8 +47,6 @@ module.exports = new class extends Connector {
                     refresh,
                     revalidationInterval
                 }, this.metrics);
-
-                log.warn(`Result: ${result}`);
 
                 // In Compliance api v1, rule info is under data.attributes
                 // In Compliance api v2, rule info is directly under data


### PR DESCRIPTION
These log messages were only used for debugging and won't really be useful in the future. I left the log message that's in `if(!ssgId){...}` because that can be useful. 

## Secure Coding Practices Checklist GitHub Link
    - https://github.com/RedHatInsights/secure-coding-checklist

    ## Secure Coding Checklist
    - [ ] Input Validation
    - [ ] Output Encoding
    - [ ] Authentication and Password Management
    - [ ] Session Management
    - [ ] Access Control
    - [ ] Cryptographic Practices
    - [ ] Error Handling and Logging
    - [ ] Data Protection
    - [ ] Communication Security
    - [ ] System Configuration
    - [ ] Database Security
    - [ ] File Management
    - [ ] Memory Management
    - [ ] General Coding Practices

## Summary by Sourcery

Chores:
- Remove unnecessary debug log messages that were used during development