### PR TITLE
RHINENG-17837: Change api spec to accommodate iqe bindings generator

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -329,42 +329,9 @@ paths:
                    }
                 }
         400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/BadRequest'
-              example: |
-                {
-                  "errors": [
-                    {
-                      "id": "string",
-                      "status": 400,
-                      "code": "INVALID_OFFSET",
-                      "title": "Requested starting offset 30 out of range: [0, 5]",
-                      "details": {}
-                    }
-                  ]
-                }
+          $ref: '#/components/responses/BadRequest'
         404:
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/NotFound'
-              example: |
-                {
-                  "errors": [
-                    {
-                      "id": "string",
-                      "status": 404,
-                      "code": "UNKNOWN_PLAN",
-                      "title": "Unknown plan identifier '9197ba55-0abc-4028-9bbe-269e530f8bd5'",
-                      "details": {}
-                    }
-                  ]
-                }
-
+          $ref: '#/components/responses/NotFound'
     delete:
       tags:
         - remediations


### PR DESCRIPTION
Removed the 400 and 404 examples from `GET /remediations/:id/systems` to accommodate iqe binding generator behavior.

## Summary by Sourcery

Documentation:
- Replace inline JSON examples for 400 and 404 responses with component references in the GET /remediations/:id/systems specification