### PR TITLE
RHINENG-18136: Bump npm to 11.3.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,7 +11,7 @@ ENV APP_ROOT=/opt/app-root
 WORKDIR $APP_ROOT
 RUN mkdir -p $APP_ROOT/.npm/{_logs,_cacache} && chgrp -R 0 $APP_ROOT && chmod -R ug+rwX $APP_ROOT
 
-RUN npm install -g npm@10.8.1
+RUN npm install -g npm@11.3.0
 
 USER 1001
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump npm from 10.8.1 to 11.3.0 in the Dockerfile