### PR TITLE
fix(migrations): SQL syntax on fix-invalid-plan-names

### DIFF
--- a/db/migrations/20240502174415-fix-invalid-plan-names.js
+++ b/db/migrations/20240502174415-fix-invalid-plan-names.js
@@ -12,7 +12,7 @@ module.exports = {
             SELECT b.name, b.id 
             FROM remediations a 
             JOIN (
-                SELECT TRIM(name) name, id, tenant_org_id 
+                SELECT TRIM(name) AS name, id, tenant_org_id
                 FROM remediations 
                 WHERE name LIKE ' %' OR name LIKE '% '
             ) b 


### PR DESCRIPTION
Fixes SQL in a migration to be compatible with PG 13.

## Summary by Sourcery

Bug Fixes:
- Add AS keyword for column alias in the SQL query within the migration