### PR TITLE
RHINENG-18655: Added check for null return from db playbook run query

### DIFF
--- a/src/remediations/controller.read.js
+++ b/src/remediations/controller.read.js
@@ -212,24 +212,27 @@ exports.list = errors.async(async function (req, res) {
                 'created_at'
             );
 
-            playbook_runs = playbook_runs?.toJSON();
+            // getPlaybookRuns _can_ return null...
+            if (playbook_runs) {
+                playbook_runs = playbook_runs.toJSON();
 
-            // Join rhcRuns and playbookRuns
-            trace.event(`[${local_iteration}] Combine runs`);
-            playbook_runs.iteration = local_iteration;
-            playbook_runs.playbook_runs = await fifi.combineRuns(playbook_runs);
+                // Join rhcRuns and playbookRuns
+                trace.event(`[${local_iteration}] Combine runs`);
+                playbook_runs.iteration = local_iteration;
+                playbook_runs.playbook_runs = await fifi.combineRuns(playbook_runs);
 
-            trace.event(`[${local_iteration}] Resolve users`);
-            playbook_runs = await fifi.resolveUsers(req, playbook_runs);
+                trace.event(`[${local_iteration}] Resolve users`);
+                playbook_runs = await fifi.resolveUsers(req, playbook_runs);
 
-            // Update playbook_run status based on executor status (RHC)
-            trace.event(`[${local_iteration}] Update playbook run status`);
-            fifi.updatePlaybookRunsStatus(playbook_runs.playbook_runs);
+                // Update playbook_run status based on executor status (RHC)
+                trace.event(`[${local_iteration}] Update playbook run status`);
+                fifi.updatePlaybookRunsStatus(playbook_runs.playbook_runs);
 
-            trace.event(`[${local_iteration}] Format playbook run`);
-            remediation.playbook_runs = format.formatRuns(playbook_runs.playbook_runs);
+                trace.event(`[${local_iteration}] Format playbook run`);
+                remediation.playbook_runs = format.formatRuns(playbook_runs.playbook_runs);
 
-            trace.leave(`[${local_iteration}] Process remediation: ${remediation.id}`);
+                trace.leave(`[${local_iteration}] Process remediation: ${remediation.id}`);
+            }
         })
     }
 


### PR DESCRIPTION
Added a check for getPlaybookRuns returning a `null`.  I'm not entirely sure why this occasionally happens but suspect it may be a race condition between the dashboard widget and a user deleting a remediation plan 🤷🏻‍♂️

## Summary by Sourcery

Bug Fixes:
- Handle occasional null return from getPlaybookRuns to avoid runtime errors