### PR TITLE
RHINENG-18556: Add timeout option to api spec and models

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -1233,17 +1233,17 @@ components:
     PlaybookRunStatus:
       type: string
       example: "pending"
-      enum: ["pending", "running", "success", "failure", "canceled"]
+      enum: ["pending", "running", "success", "failure", "canceled", "timeout"]
 
     PlaybookRunExecutorStatus:
       type: string
       example: "pending"
-      enum: ["pending", "acked", "running", "success", "failure", "canceled"]
+      enum: ["pending", "acked", "running", "success", "failure", "canceled", "timeout"]
 
     PlaybookRunSystemStatus:
       type: string
       example: "pending"
-      enum: ["pending", "running", "success", "failure", "canceled"]
+      enum: ["pending", "running", "success", "failure", "canceled", "timeout"]
 
     PlaybookRunId:
       type: string

--- a/src/remediations/models/playbookRunExecutors.js
+++ b/src/remediations/models/playbookRunExecutors.js
@@ -25,7 +25,7 @@ module.exports = (sequelize, {STRING, UUID, ENUM, DATE, TEXT, BOOLEAN, INTEGER})
         },
         status: {
             type: ENUM,
-            values: ['pending', 'running', 'success', 'failure', 'canceled', 'acked'],
+            values: ['pending', 'running', 'success', 'failure', 'canceled', 'acked', 'timeout'],
             defaultValue: 'pending',
             allowNull: false
         },

--- a/src/remediations/models/playbookRunSystems.js
+++ b/src/remediations/models/playbookRunSystems.js
@@ -16,7 +16,7 @@ module.exports = (sequelize, {UUID, ENUM, STRING, DATE, TEXT, INTEGER}) => {
         },
         status: {
             type: ENUM,
-            values: ['pending', 'running', 'success', 'failure', 'canceled'],
+            values: ['pending', 'running', 'success', 'failure', 'canceled', 'timeout'],
             defaultValue: 'pending',
             allowNull: false
         },

--- a/src/remediations/models/playbookRuns.js
+++ b/src/remediations/models/playbookRuns.js
@@ -8,7 +8,7 @@ module.exports = (sequelize, {STRING, UUID, ENUM, DATE}) => {
         },
         status: {
             type: ENUM,
-            values: ['pending', 'acked', 'running', 'success', 'failure', 'canceled'],
+            values: ['pending', 'acked', 'running', 'success', 'failure', 'canceled', 'timeout'],
             defaultValue: 'pending',
             allowNull: false
         },


### PR DESCRIPTION
## Summary by Sourcery

Introduce a timeout status option across API definitions and data models for playbook runs, executors, and systems to support timeout handling.

New Features:
- Add 'timeout' enum value to PlaybookRunStatus, PlaybookRunExecutorStatus, and PlaybookRunSystemStatus in the OpenAPI spec
- Include 'timeout' as a valid status in the Sequelize models for playbookRuns, playbookRunExecutors, and playbookRunSystems