### PR TITLE
RHINENG-18476: Add dispatcher_runs table and store dispatcher runs

### DIFF
--- a/db/migrations/20250613153111-add-dispatcher-runs.js
+++ b/db/migrations/20250613153111-add-dispatcher-runs.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+    async up (q, {BOOLEAN, DATE, INTEGER, fn, STRING, UUID, ENUM}) {
+        await q.createTable('dispatcher_runs', {
+            dispatcher_run_id: {
+                type: UUID,
+                primaryKey: true
+            },
+            remediations_run_id: {
+                type: UUID,
+                allowNull: false,
+                references: {
+                    model: 'playbook_runs',
+                    key: 'id'
+                }
+            },
+            status: {
+                type: ENUM,
+                values: ['pending', 'running', 'success', 'failure', 'canceled', 'timeout'],
+                defaultValue: 'pending',
+                allowNull: false
+            },
+            created_at: {
+                type: DATE,
+                allowNull: false,
+                defaultValue: fn('now')
+            },
+            updated_at: {
+                type: DATE,
+                allowNull: false,
+                defaultValue: fn('now')
+            }
+        });
+    },
+
+    async down (q) {
+        await q.dropTable('dispatcher_runs');
+    }
+};

--- a/db/migrations/20250613153111-add-dispatcher-runs.js
+++ b/db/migrations/20250613153111-add-dispatcher-runs.js
@@ -13,13 +13,20 @@ module.exports = {
                 references: {
                     model: 'playbook_runs',
                     key: 'id'
-                }
+                },
+                onDelete: 'cascade',
+                onUpdate: 'cascade'
             },
             status: {
                 type: ENUM,
                 values: ['pending', 'running', 'success', 'failure', 'canceled', 'timeout'],
                 defaultValue: 'pending',
                 allowNull: false
+            },
+            pd_response_code: {
+                type: INTEGER,
+                allowNull: true,
+                comment: 'HTTP response code from playbook-dispatcher when creating the run'
             },
             created_at: {
                 type: DATE,
@@ -32,9 +39,27 @@ module.exports = {
                 defaultValue: fn('now')
             }
         });
+
+        // Add indexes for performance
+        await q.addIndex('dispatcher_runs', ['remediations_run_id'], {
+            name: 'dispatcher_runs_remediations_run_id'
+        });
+
+        await q.addIndex('dispatcher_runs', ['status'], {
+            name: 'dispatcher_runs_status'
+        });
+
+        // Composite index for common queries
+        await q.addIndex('dispatcher_runs', ['remediations_run_id', 'status'], {
+            name: 'dispatcher_runs_remediation_status'
+        });
     },
 
     async down (q) {
+        // Remove indexes first, then drop table
+        await q.removeIndex('dispatcher_runs', ['remediations_run_id', 'status']);
+        await q.removeIndex('dispatcher_runs', ['status']);
+        await q.removeIndex('dispatcher_runs', ['remediations_run_id']);
         await q.dropTable('dispatcher_runs');
     }
 };

--- a/src/remediations/fifi_2.js
+++ b/src/remediations/fifi_2.js
@@ -186,7 +186,7 @@ async function dispatchWorkRequests (workRequests, playbook_run_id) {
 
         // Store dispatcher runs
         const successfulRuns = response
-            .filter(r => (r.code === 200 || r.code === 201) && r.id)
+            .filter(r => (r.code >= 200 && r.code < 300) && r.id)
             .map(r => ({
                 dispatcher_run_id: r.id,
                 remediations_run_id: playbook_run_id

--- a/src/remediations/models/dispatcherRuns.js
+++ b/src/remediations/models/dispatcherRuns.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = (sequelize, { STRING, UUID, ENUM, DATE }) => {
+module.exports = (sequelize, { STRING, UUID, ENUM, DATE, INTEGER }) => {
     const DispatcherRuns = sequelize.define('dispatcher_runs', {
         dispatcher_run_id: {
             type: UUID,
@@ -19,6 +19,10 @@ module.exports = (sequelize, { STRING, UUID, ENUM, DATE }) => {
             values: ['pending', 'running', 'success', 'failure', 'canceled', 'timeout'],
             defaultValue: 'pending',
             allowNull: false
+        },
+        pd_response_code: {
+            type: INTEGER,
+            allowNull: true
         },
         created_at: {
             type: DATE,

--- a/src/remediations/models/dispatcherRuns.js
+++ b/src/remediations/models/dispatcherRuns.js
@@ -1,0 +1,45 @@
+'use strict';
+
+module.exports = (sequelize, { STRING, UUID, ENUM, DATE }) => {
+    const DispatcherRuns = sequelize.define('dispatcher_runs', {
+        dispatcher_run_id: {
+            type: UUID,
+            primaryKey: true
+        },
+        remediations_run_id: {
+            type: UUID,
+            allowNull: false,
+            references: {
+                model: 'playbook_runs',
+                key: 'id'
+            }
+        },
+        status: {
+            type: ENUM,
+            values: ['pending', 'running', 'success', 'failure', 'canceled', 'timeout'],
+            defaultValue: 'pending',
+            allowNull: false
+        },
+        created_at: {
+            type: DATE,
+            allowNull: false
+        },
+        updated_at: {
+            type: DATE,
+            allowNull: false
+        }
+    }, {
+        timestamps: true,
+        createdAt: 'created_at',
+        updatedAt: 'updated_at'
+    });
+
+    DispatcherRuns.associate = models => {
+        DispatcherRuns.belongsTo(models.playbook_runs, {
+            foreignKey: 'remediations_run_id',
+            as: 'playbook_run'
+        });
+    };
+
+    return DispatcherRuns;
+};

--- a/src/remediations/models/playbookRuns.js
+++ b/src/remediations/models/playbookRuns.js
@@ -22,7 +22,7 @@ module.exports = (sequelize, {STRING, UUID, ENUM, DATE}) => {
         },
         created_at: {
             type: DATE,
-            allowNullL: false
+            allowNull: false
         },
         updated_at: {
             type: DATE,
@@ -42,6 +42,11 @@ module.exports = (sequelize, {STRING, UUID, ENUM, DATE}) => {
         PlaybookRuns.hasMany(models.playbook_run_executors, {
             foreignKey: 'playbook_run_id',
             as: 'executors'
+        });
+
+        PlaybookRuns.hasMany(models.dispatcher_runs, {
+            foreignKey: 'remediations_run_id',
+            as: 'dispatcher_runs'
         });
     };
 

--- a/src/remediations/models/playbookRuns.js
+++ b/src/remediations/models/playbookRuns.js
@@ -46,7 +46,9 @@ module.exports = (sequelize, {STRING, UUID, ENUM, DATE}) => {
 
         PlaybookRuns.hasMany(models.dispatcher_runs, {
             foreignKey: 'remediations_run_id',
-            as: 'dispatcher_runs'
+            as: 'dispatcher_runs',
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE'
         });
     };
 

--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -686,26 +686,15 @@ exports.insertRHCPlaybookRun = async function (run) {
 };
 
 exports.insertDispatcherRuns = async function (runs) {
-    const ids = runs.map(r => r.dispatcher_run_id);
-
-    // We also attempt to create dispatcher_runs entries in remediations-consumer,
-    // which processes Kafka messages from playbook-dispatcher when playbook runs are created or updated.
-    // To avoid duplicate entries, we need to check whether a dispatcher_runs record already exists—
-    // in case the 'create' Kafka message was processed before reaching this point.
-    const existingIds = new Set(
-        (await db.dispatcher_runs.findAll({
-            where: { dispatcher_run_id: ids },
-            attributes: ['dispatcher_run_id'],
-            raw: true
-        })).map(r => r.dispatcher_run_id)
-    );
-
-    const newRuns = runs.filter(r => !existingIds.has(r.dispatcher_run_id));
-
-    if (newRuns.length) {
-        await db.dispatcher_runs.bulkCreate(newRuns);
+    if (runs.length === 0) {
+        return [];
     }
 
-    return newRuns;
-};
+    // Use ignoreDuplicates to handle race conditions with remediations-consumer
+    // which may also create dispatcher_runs entries from Kafka messages
+    await db.dispatcher_runs.bulkCreate(runs, { 
+        ignoreDuplicates: true 
+    });
 
+    return runs;
+};


### PR DESCRIPTION
## Summary by Sourcery

Enable tracking of dispatcher runs by creating a new dispatcher_runs table and model, updating dispatch logic to persist dispatcher run entries while avoiding duplicates, and validating the functionality with integration tests.

New Features:
- Add dispatcher_runs table through a migration with relevant indexes
- Define a Sequelize model and associations for dispatcher_runs
- Persist dispatcher_runs entries after dispatching work requests

Enhancements:
- Introduce insertDispatcherRuns query to bulk insert new runs while skipping existing ones
- Fix allowNull typo in playbookRuns model
- Improve error logging for failed dispatch operations

Tests:
- Add integration test to verify dispatcher run records are stored when posting playbook runs