### PR TITLE
RHINENG-19477: Bump from nodejs:20 to nodejs:22

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,8 +2,8 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1751286687 AS base
 
-RUN microdnf module enable -y nodejs:20 && \
-    microdnf install -y shadow-utils jq nodejs --nodocs && \
+RUN microdnf module enable -y nodejs:22 && \
+    microdnf install -y shadow-utils jq nodejs npm --nodocs && \
     microdnf upgrade -y && \
     microdnf clean all
 
@@ -11,7 +11,7 @@ ENV APP_ROOT=/opt/app-root
 WORKDIR $APP_ROOT
 RUN mkdir -p $APP_ROOT/.npm/{_logs,_cacache} && chgrp -R 0 $APP_ROOT && chmod -R ug+rwX $APP_ROOT
 
-RUN npm install -g npm@11.3.0
+RUN npm install -g npm@11.4.2
 
 USER 1001
 


### PR DESCRIPTION
## Summary by Sourcery

Bump the Docker build environment to Node.js 22, include npm in the microdnf installation, and upgrade the globally installed npm to version 11.4.2.

Enhancements:
- Enable the nodejs:22 module stream and install both nodejs and npm via microdnf
- Upgrade the global npm installation from v11.3.0 to v11.4.2

Build:
- Update the Dockerfile to use Node.js 22 on UBI9 base image