### PR TITLE
RHINENG-19924: Improve Compliance invalid issue id error message

### DIFF
--- a/src/connectors/compliance/impl.js
+++ b/src/connectors/compliance/impl.js
@@ -16,13 +16,17 @@ module.exports = new class extends Connector {
     }
 
     async getRule(id, ssgRefId = null, ssgVersion = null, refresh = false, retries = 2) {
-        id = id.replace(/\./g, '-'); // compliance API limitation
-
         // Compliance API v1 is deprecated. Require v2 format with ssgVersion
         // Note: ssgVersion is extracted by identifiers.parseSSG() and will be null for v1 format
         if (!ssgVersion) {
-            throw errors.invalidIssueId(`${id} - Use Compliance API v2 format: ssg:xccdf_org.ssgproject.content_benchmark_RHEL-X|version|profile|xccdf_org.ssgproject.content_rule_${id}`);
+            throw new errors.BadRequest(
+                'INVALID_ISSUE_IDENTIFIER',
+                `Compliance v1 issue identifiers have been retired. Please update your v1 issue ID, "ssg:<platform>|<profile>|${id}", to the v2 format of "ssg:xccdf_org.ssgproject.content_benchmark_RHEL-X|<version>|<profile>|${id}"`
+            );
         }
+
+        // After validation, normalize id for Compliance API routing (dots to dashes)
+        id = id.replace(/\./g, '-'); // compliance API limitation
 
         for (let i = 0; i <= retries; i++) {
             try {

--- a/src/connectors/compliance/impl.unit.js
+++ b/src/connectors/compliance/impl.unit.js
@@ -23,7 +23,7 @@ describe('compliance impl', function () {
         } catch (error) {
             error.should.be.instanceOf(errors.BadRequest);
             error.error.code.should.equal('INVALID_ISSUE_IDENTIFIER');
-            error.message.should.match(/Use Compliance API v2 format/);
+            error.message.should.equal('Compliance v1 issue identifiers have been retired. Please update your v1 issue ID, "ssg:<platform>|<profile>|xccdf_org.ssgproject.content_rule_sshd_disable_root_login", to the v2 format of "ssg:xccdf_org.ssgproject.content_benchmark_RHEL-X|<version>|<profile>|xccdf_org.ssgproject.content_rule_sshd_disable_root_login"');
         }
     });
 

--- a/src/generator/ssg.integration.js
+++ b/src/generator/ssg.integration.js
@@ -19,7 +19,7 @@ test('rejects v1 issue id format (Compliance API v1 issue id format)', async () 
     .send(data)
     .expect(400);
 
-    res.body.errors.should.eql([{ id, status: 400, code: 'INVALID_ISSUE_IDENTIFIER', title: '"rhel7|pci-dss|xccdf_org.ssgproject.content_rule_disable_prelink - Use Compliance API v2 format: ssg:xccdf_org.ssgproject.content_benchmark_RHEL-X|version|profile|xccdf_org.ssgproject.content_rule_disable_prelink" is not a valid issue identifier.' }]);
+    res.body.errors.should.eql([{ id, status: 400, code: 'INVALID_ISSUE_IDENTIFIER', title: 'Compliance v1 issue identifiers have been retired. Please update your v1 issue ID, "ssg:<platform>|<profile>|xccdf_org.ssgproject.content_rule_disable_prelink", to the v2 format of "ssg:xccdf_org.ssgproject.content_benchmark_RHEL-X|<version>|<profile>|xccdf_org.ssgproject.content_rule_disable_prelink"' }]);
 });
 
 test('generates a simple playbook with single compliance remediation (Compliance API v2 issue id format)', async () => {

--- a/src/resolutions/resolutions.unit.js
+++ b/src/resolutions/resolutions.unit.js
@@ -155,7 +155,7 @@ describe('resolve ssg resolutions', function () {
             id,
             status: 400,
             code: 'INVALID_ISSUE_IDENTIFIER',
-            title: '"rhel7|pci-dss|xccdf_org.ssgproject.content_rule_disable_prelink - Use Compliance API v2 format: ssg:xccdf_org.ssgproject.content_benchmark_RHEL-X|version|profile|xccdf_org.ssgproject.content_rule_disable_prelink" is not a valid issue identifier.'
+            title: 'Compliance v1 issue identifiers have been retired. Please update your v1 issue ID, "ssg:<platform>|<profile>|xccdf_org.ssgproject.content_rule_disable_prelink", to the v2 format of "ssg:xccdf_org.ssgproject.content_benchmark_RHEL-X|<version>|<profile>|xccdf_org.ssgproject.content_rule_disable_prelink"'
         }]);
     });
 
@@ -170,7 +170,7 @@ describe('resolve ssg resolutions', function () {
             id,
             status: 400,
             code: 'INVALID_ISSUE_IDENTIFIER',
-            title: '"rhel7|C2S|xccdf_org.ssgproject.content_rule_disable_host_auth - Use Compliance API v2 format: ssg:xccdf_org.ssgproject.content_benchmark_RHEL-X|version|profile|xccdf_org.ssgproject.content_rule_disable_host_auth" is not a valid issue identifier.'
+            title: 'Compliance v1 issue identifiers have been retired. Please update your v1 issue ID, "ssg:<platform>|<profile>|xccdf_org.ssgproject.content_rule_disable_host_auth", to the v2 format of "ssg:xccdf_org.ssgproject.content_benchmark_RHEL-X|<version>|<profile>|xccdf_org.ssgproject.content_rule_disable_host_auth"'
         }]);
     });
 

--- a/src/resolutions/resolvers/SSGResolver.js
+++ b/src/resolutions/resolvers/SSGResolver.js
@@ -33,7 +33,11 @@ module.exports = class SSGResolver extends Resolver {
 
         // Compliance API v1 is deprecated: require v2 SSG issue format with ssgVersion
         if (!ssgVersion) {
-            throw errors.invalidIssueId(`${id.issue} - Use Compliance API v2 format: ssg:xccdf_org.ssgproject.content_benchmark_RHEL-X|version|profile|xccdf_org.ssgproject.content_rule_${rule}`);
+            const ruleRef = `xccdf_org.ssgproject.content_rule_${rule}`;
+            throw new errors.BadRequest(
+                'INVALID_ISSUE_IDENTIFIER',
+                `Compliance v1 issue identifiers have been retired. Please update your v1 issue ID, "ssg:<platform>|<profile>|${ruleRef}", to the v2 format of "ssg:xccdf_org.ssgproject.content_benchmark_RHEL-X|<version>|<profile>|${ruleRef}"`
+            );
         }
 
         // RHCLOUD-4280: disable rule "rsyslog_remote_loghost"


### PR DESCRIPTION
## Summary by Sourcery

Improve handling of deprecated Compliance API v1 issue identifiers by throwing a standardized BadRequest with code INVALID_ISSUE_IDENTIFIER and clear instructions to migrate to the v2 format, and update tests to validate the new messaging

Enhancements:
- Use errors.BadRequest with code INVALID_ISSUE_IDENTIFIER and a clear migration message instead of errors.invalidIssueId for deprecated Compliance v1 identifiers
- Standardize error messages in compliance connector and SSG resolver to instruct users to update to the v2 issue ID format

Tests:
- Update unit and integration tests to expect the new error code and updated message wording for invalid issue identifiers