### PR TITLE
RHINENG-16801: Implement GET /remediations/:id/systems endpoint

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -35,7 +35,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/RemediationSort'
         - $ref: '#/components/parameters/RemediationFilter'
-        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Limit200'
         - $ref: '#/components/parameters/Offset'
         - $ref: '#/components/parameters/RemediationSystem'
         - $ref: '#/components/parameters/HideArchived'
@@ -249,7 +249,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/RemediationId'
         - $ref: '#/components/parameters/IssueId'
-        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Limit200'
         - $ref: '#/components/parameters/Offset'
         - $ref: '#/components/parameters/IssueSystemsSort'
       responses:
@@ -292,7 +292,7 @@ paths:
       operationId: getRemediationSystems
       parameters:
         - $ref: '#/components/parameters/RemediationId'
-        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Limit50'
         - $ref: '#/components/parameters/Offset'
         - $ref: '#/components/parameters/SystemsFilter'
         - $ref: '#/components/parameters/SystemsSort'
@@ -467,7 +467,7 @@ paths:
       operationId: listPlaybookRuns
       parameters:
         - $ref: '#/components/parameters/RemediationId'
-        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Limit200'
         - $ref: '#/components/parameters/Offset'
         - $ref: '#/components/parameters/PlaybookRunSort'
       responses:
@@ -566,7 +566,7 @@ paths:
         - $ref: '#/components/parameters/RemediationId'
         - $ref: '#/components/parameters/PlaybookRunId'
         - $ref: '#/components/parameters/ExecutorId'
-        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Limit200'
         - $ref: '#/components/parameters/Offset'
         - $ref: '#/components/parameters/SystemName'
         - $ref: '#/components/parameters/PlaybookRunSystemSort'
@@ -721,7 +721,7 @@ paths:
 
 components:
   parameters:
-    Limit:
+    Limit200:
       in: query
       name: limit
       description: Maximum number of results to return

--- a/src/remediations/read.integration.js
+++ b/src/remediations/read.integration.js
@@ -983,6 +983,243 @@ describe('remediations', function () {
         );
     });
 
+    describe('remediation plan systems', function () {
+        test('gets list of distinct systems with limit=2', async () => {
+            const { body } = await request
+            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems?limit=2')
+            .set(auth.testReadSingle)
+            .expect(200);
+
+            body.should.have.property('meta');
+            body.meta.should.have.property('count');
+            body.meta.should.have.property('total');
+            body.should.have.property('data');
+            body.data.should.be.Array();
+            body.data.length.should.equal(body.meta.count);
+            if (body.data.length > 0) {
+                body.data[0].should.have.property('id');
+                body.data[0].should.have.property('hostname');
+                body.data[0].should.have.property('display_name');
+            }
+        });
+
+        test('gets list of distinct systems with no limit', async () => {
+            const { body } = await request
+            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems')
+            .set(auth.testReadSingle)
+            .expect(200);
+
+            body.should.have.property('meta');
+            body.meta.should.have.property('count');
+            body.meta.should.have.property('total');
+            body.should.have.property('data');
+            body.data.should.be.Array();
+            body.data.length.should.equal(body.meta.count);
+
+            const ids = body.data.map(r => r.id);
+            new Set(ids).size.should.equal(ids.length);
+            
+            const names = body.data.map(r => (r.display_name || '').toLowerCase());
+            const nonEmpty = names.filter(n => n !== '').sort();
+            const empties = names.filter(n => n === '');
+            names.should.eql([...nonEmpty, ...empties]);
+        });
+
+        test('sorts by hostname desc', async () => {
+            const { body } = await request
+            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems?sort=-hostname&limit=3')
+            .set(auth.testReadSingle)
+            .expect(200);
+
+            const values = body.data.map(r => (r.hostname || '').toLowerCase());
+            const sorted = [...values].sort().reverse();
+            expect(values).toEqual(sorted);
+        });
+
+        test('filters by hostname substring', async () => {
+            const { body } = await request
+            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems?filter[hostname]=example')
+            .set(auth.testReadSingle)
+            .expect(200);
+
+            body.data.forEach(r => {
+                expect((r.hostname || '').toLowerCase()).toContain('example');
+            });
+        });
+
+        test('404 on unknown remediation_id', async () => {
+            await request
+            .get('/v1/remediations/00000000-0000-0000-0000-000000000000/systems')
+            .set(auth.testReadSingle)
+            .expect(404);
+        });
+
+        test('400 on bad sort', async () => {
+            await request
+            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems?sort=bob')
+            .set(auth.testReadSingle)
+            .expect(400);
+        });
+
+        test('400 on bad plan id format', async () => {
+            await request
+            .get('/v1/remediations/not-a-uuid/systems')
+            .set(auth.testReadSingle)
+            .expect(400);
+        });
+
+        test('404 on not plan owner', async () => {
+            await request
+            .get('/v1/remediations/e809526c-56f5-4cd8-a809-93328436ea23/systems')
+            .set(auth.fifi)
+            .expect(404);
+        });
+
+        test('400 when limit=0', async () => {
+            await request
+            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems?limit=0')
+            .set(auth.testReadSingle)
+            .expect(400);
+        });
+
+        test('400 when limit>50', async () => {
+            await request
+            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems?limit=200')
+            .set(auth.testReadSingle)
+            .expect(400);
+        });
+
+        test('400 on invalid offset type', async () => {
+            await request
+            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems?offset=salad')
+            .set(auth.testReadSingle)
+            .expect(400);
+        });
+
+        test('400 on giant offset', async () => {
+            await request
+            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems?offset=1000000')
+            .set(auth.testReadSingle)
+            .expect(400);
+        });
+
+        test('filters by id/display_name substrings', async () => {
+            const { body } = await request
+            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems?filter[id]=a8&filter[display_name]=system')
+            .set(auth.testReadSingle)
+            .expect(200);
+
+            body.data.forEach(r => {
+                expect(String(r.id)).toContain('a8');
+                expect((r.display_name || '').toLowerCase()).toContain('system');
+            });
+        });
+
+        test('sorts by id asc and display_name asc', async () => {
+            let res = await request
+            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems?sort=id')
+            .set(auth.testReadSingle)
+            .expect(200);
+            let ids = res.body.data.map(r => r.id);
+            let idsSorted = [...ids].sort();
+            expect(ids).toEqual(idsSorted);
+
+            res = await request
+            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems?sort=display_name')
+            .set(auth.testReadSingle)
+            .expect(200);
+            const names = res.body.data.map(r => (r.display_name || '').toLowerCase());
+            const nonEmpty = names.filter(n => n !== '').sort();
+            const empties = names.filter(n => n === '');
+            expect(names).toEqual([...nonEmpty, ...empties]);
+        });
+
+        test('sorts by id desc and display_name desc', async () => {
+            let res = await request
+            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems?sort=-id')
+            .set(auth.testReadSingle)
+            .expect(200);
+            let ids = res.body.data.map(r => r.id);
+            let idsSortedDesc = [...ids].sort().reverse();
+            expect(ids).toEqual(idsSortedDesc);
+
+            res = await request
+            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems?sort=-display_name')
+            .set(auth.testReadSingle)
+            .expect(200);
+            const names = res.body.data.map(r => (r.display_name || '').toLowerCase());
+            const empties = names.filter(n => n === '');
+            const nonEmptyDesc = names.filter(n => n !== '').sort().reverse();
+            expect(names).toEqual([...empties, ...nonEmptyDesc]);
+        });
+
+        test('filters by hostname and display_name substrings (combined)', async () => {
+            const planSystemIds = ['9dae9304-86a8-4f66-baa3-a1b27dfdd479', '1040856f-b772-44c7-83a9-eea4813c4be8'];
+            await db.systems.destroy({ where: { id: planSystemIds }, force: true });
+
+            getSandbox().stub(inventory, 'getSystemDetailsBatch').resolves({
+                '9dae9304-86a8-4f66-baa3-a1b27dfdd479': {
+                    id: '9dae9304-86a8-4f66-baa3-a1b27dfdd479',
+                    hostname: '9dae9304-86a8-4f66-baa3-a1b27dfdd479.example.com',
+                    display_name: '9dae9304-86a8-4f66-baa3-a1b27dfdd479-system',
+                    ansible_host: null,
+                    facts: []
+                },
+                '1040856f-b772-44c7-83a9-eea4813c4be8': {
+                    id: '1040856f-b772-44c7-83a9-eea4813c4be8',
+                    hostname: '1040856f-b772-44c7-83a9-eea4813c4be8.example.com',
+                    display_name: 'some-system',
+                    ansible_host: null,
+                    facts: []
+                }
+            });
+
+            const { body } = await request
+            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems?filter[hostname]=example&filter[display_name]=system')
+            .set(auth.testReadSingle)
+            .expect(200);
+
+            expect(body.data.length).toBeGreaterThan(0);
+            body.data.forEach(r => {
+                expect((r.hostname || '').toLowerCase()).toContain('example');
+                expect((r.display_name || '').toLowerCase()).toContain('system');
+            });
+        });
+
+        test('returns empty list when plan has no systems', async () => {
+            const { body } = await request
+            .get('/v1/remediations/d1b070b5-1db8-4dac-8ecf-891dc1e9225f/systems')
+            .set(auth.testReadSingle)
+            .expect(200);
+
+            body.meta.count.should.eql(0);
+            body.meta.total.should.eql(0);
+            body.data.should.eql([]);
+        });
+
+        test('populates systems table from inventory when missing (fallback)', async () => {
+            // Clear systems table entries for this plan's systems to force fallback
+            const planSystemIds = ['9dae9304-86a8-4f66-baa3-a1b27dfdd479', '1040856f-b772-44c7-83a9-eea4813c4be8'];
+            await db.systems.destroy({ where: { id: planSystemIds }, force: true });
+
+            const initialCount = await db.systems.count({ where: { id: planSystemIds } });
+            expect(initialCount).toBe(0);
+
+            const res = await request
+            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems?sort=display_name')
+            .set(auth.testReadSingle)
+            .expect(200);
+
+            const finalCount = await db.systems.count({ where: { id: planSystemIds } });
+            expect(finalCount).toBeGreaterThan(0);
+
+            const names = res.body.data.map(r => (r.display_name || '').toLowerCase());
+            const nonEmpty = names.filter(n => n !== '').sort();
+            const empties = names.filter(n => n === '');
+            expect(names).toEqual([...nonEmpty, ...empties]);
+        });
+    });
+
     describe('remediations read RBAC', function () {
         test('permission = remediations:*:write does not allow GET /v1/remediations to be read', async () => {
             getSandbox().stub(rbac, 'getRemediationsAccess').resolves(buildRbacResponse('remediations:*:write'));

--- a/src/remediations/remediations.format.js
+++ b/src/remediations/remediations.format.js
@@ -366,6 +366,24 @@ exports.issueSystems = function (issue, total) {
     };
 };
 
+// Format distinct plan systems list with pagination links
+exports.planSystems = function (plan_id, systems, total, limit, offset, sort) {
+    const formatted = systems.map(s => ({
+        id: s.id,
+        hostname: s.hostname,
+        display_name: s.display_name
+    }));
+
+    return {
+        meta: {
+            count: formatted.length,
+            total
+        },
+        links: buildListLinks(`v1/remediations/${plan_id}/systems`, total, limit, offset, sort),
+        data: formatted
+    };
+};
+
 exports.planNames = function (names, total, limit, offset, sort, system) {
     return {
         meta: {

--- a/src/remediations/routes.js
+++ b/src/remediations/routes.js
@@ -44,6 +44,7 @@ module.exports = function (router) {
         .delete(openapi('deleteRemediationIssueSystem'), rbacWrite, write.removeIssueSystem);
 
     router.route('/remediations/:id/systems')
+        .get(openapi('getRemediationSystems'), rbacRead, read.getRemediationSystems)
         .delete(openapi('deleteRemediationSystems'), rbacWrite, write.bulkRemoveSystems);
 
     router.route('/remediations/:id/executable')


### PR DESCRIPTION
## Summary by Sourcery

Implement the GET /remediations/:id/systems endpoint to return a paginated, sorted, and filtered list of distinct systems associated with a remediation plan, with a fallback to the inventory connector for missing system records

New Features:
- Add GET /v1/remediations/:id/systems endpoint to list distinct systems for a remediation plan
- Implement fallback to inventory service to fetch and cache system details when missing in the database

Enhancements:
- Support pagination, sorting, and substring filtering by id, hostname, and display_name on plan systems
- Format plan systems response with meta, links, and data via a new formatter

Documentation:
- Update OpenAPI spec to document the new endpoint parameters (Limit50, Offset, SystemsFilter, SystemsSort)

Tests:
- Add integration tests covering pagination limits, sorting, filtering, error handling, RBAC restrictions, and inventory fallback for the new endpoint