### PR TITLE
RHINENG-20307: Improve efficiency of sorting/filtering by status

### DIFF
--- a/db/migrations/20250901120000-add-index-latest-playbook-run.js
+++ b/db/migrations/20250901120000-add-index-latest-playbook-run.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+    async up (q) {
+        await q.addIndex('playbook_runs', ['remediation_id', 'created_at', 'id'], {
+            name: 'idx_pr_rem_created_id'
+        });
+    },
+
+    async down (q) {
+        await q.removeIndex('playbook_runs', 'idx_pr_rem_created_id');
+    }
+};
+
+

--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -44,6 +44,10 @@ function aggregateStatusSQL() {
     END`;
 }
 
+// This subquery selects the latest playbook_run per remediation
+// We added a composite index on playbook_runs (remediation_id, created_at, id)
+// So the database can jump straight to the latest playbook_run for a given remediation_id
+// instead of reading through lots of rows and sorting them and picking the first
 function mostRecentPlaybookRunSubquery(remediationIdColumn = '"remediation"."id"') {
     return `(
         SELECT "pr2"."id"


### PR DESCRIPTION
## Summary by Sourcery

Optimize remediation listing by status by adding a helper subquery and database index, and refactoring the query to only join and sync dispatcher_runs when necessary

New Features:
- Introduce mostRecentPlaybookRunSubquery helper to fetch the latest playbook run per remediation
- Add a composite index on playbook_runs (remediation_id, created_at, id) to accelerate lookup of the latest runs

Enhancements:
- Refactor remediation list query to conditionally include and sync dispatcher_runs only when sorting or filtering by status
- Only add status attribute and related joins when needed to reduce query overhead
- Reuse and adjust the existing playbook_runs include for last_run_after filtering instead of adding a separate include