### PR TITLE
Build source image sat 6 18 Tekton

### DIFF
--- a/.tekton/iop-remediations-sat-6-18-pull-request.yaml
+++ b/.tekton/iop-remediations-sat-6-18-pull-request.yaml
@@ -38,6 +38,8 @@ spec:
     value: .
   - name: prefetch-dev-package-managers
     value: "true"
+  - name: build-source-image
+    value: "true"
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:

--- a/.tekton/iop-remediations-sat-6-18-push.yaml
+++ b/.tekton/iop-remediations-sat-6-18-push.yaml
@@ -35,6 +35,8 @@ spec:
     value: .
   - name: prefetch-dev-package-managers
     value: "true"
+  - name: build-source-image
+    value: "true"
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:


### PR DESCRIPTION
## Summary by Sourcery

Enable building the source image by setting the build-source-image parameter to true in the SAT 6.18 pull-request and push Tekton pipeline configurations.

Enhancements:
- Enable build-source-image flag in iop-remediations-sat-6-18 pull-request Tekton pipeline
- Enable build-source-image flag in iop-remediations-sat-6-18 push Tekton pipeline