### PR TITLE
RHINENG-20788: Gracefully handle v1 issue ids in SSGResolver

### DIFF
--- a/src/issues/SSGHandler.js
+++ b/src/issues/SSGHandler.js
@@ -2,6 +2,7 @@
 
 const Handler = require('./Handler');
 const errors = require('../errors');
+const log = require('../util/log');
 
 const compliance = require('../connectors/compliance');
 const complianceFactory = new(require('../generator/factories/ComplianceFactory'))();
@@ -11,8 +12,17 @@ const identifiers = require('../util/identifiers');
 module.exports = class ComplianceHandler extends Handler {
     async getIssueDetails (id) {
         const ssgId = identifiers.parseSSG(id);
+
+        // TODO: If/when we start calling the Compliance API again to get rule descriptions (via getRule),
+        // add a fallback rule description when:
+        //   - The Compliance API call fails and we can't get the description, or
+        //   - A Compliance v1 issue id is used and we don't have enough info for the API call.
+        // Use the SCAP URL we build below (scapUrl) as the fallback description.
+        if (!ssgId.ssgVersion) {
+            log.warn({ issueId: id.full }, 'Compliance v1 issue identifier detected; Using fallback rule description');
+        }
     
-        // Build SCAP Security Guide link for the rule
+        // For now, always build SCAP Security Guide link for the rule and use it as the rule description
         // Example: https://static.open-scap.org/ssg-guides/ssg-rhel8-guide-cis_server_l1.html#rule_selinux_policytype
         const platform = ssgId.platform; // e.g., rhel7, rhel8
         const profile = ssgId.profile;   // e.g., pci-dss, standard, ospp, cis_server_l1

--- a/src/remediations/playbook/__snapshots__/playbook.integration.js.snap
+++ b/src/remediations/playbook/__snapshots__/playbook.integration.js.snap
@@ -1482,6 +1482,72 @@ exports[`playbooks generate playbook with pydata and playbook support 1`] = `
           with_dict: "{{ pydata.bond_config }}"
 
 
+# To learn more about this rule: https://static.open-scap.org/ssg-guides/ssg-rhel7-guide-standard.html#xccdf_org.ssgproject.content_rule_service_autofs_disabled
+# Identifier: (ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled,fix)
+# Version: NORMALIZED_PLACEHOLDER
+# platform = multi_platform_all
+# complexity = low
+# strategy = disable
+# reboot = false
+# disruption = low
+- name: Disable the Automounter
+  hosts: 'fc94beb8-21ee-403d-99b1-949ef7adb762'
+  become: true
+  tags:
+    - CCE-27498-5
+    - DISA-STIG-RHEL-07-020110
+    - NIST-800-171-3.4.6
+    - NIST-800-53-AC-19(a)
+    - NIST-800-53-AC-19(d)
+    - NIST-800-53-AC-19(e)
+    - NIST-800-53-IA-3
+    - disable_strategy
+    - low_complexity
+    - low_disruption
+    - medium_severity
+    - no_reboot_needed
+    - service_autofs_disabled
+  tasks:
+
+    - name: Unit Service Exists - autofs.service
+      command: systemctl list-unit-files autofs.service
+      register: service_file_exists
+      changed_when: false
+      ignore_errors: true
+      when: ansible_virtualization_role != "guest" or ansible_virtualization_type
+        != "docker"
+
+    - name: Disable service autofs
+      systemd:
+        name: autofs.service
+        enabled: 'no'
+        state: stopped
+        masked: 'yes'
+      when:
+        - '"autofs.service" in service_file_exists.stdout_lines[1]'
+        - ansible_virtualization_role != "guest" or ansible_virtualization_type !=
+          "docker"
+
+    - name: Unit Socket Exists - autofs.socket
+      command: systemctl list-unit-files autofs.socket
+      register: socket_file_exists
+      changed_when: false
+      ignore_errors: true
+      when: ansible_virtualization_role != "guest" or ansible_virtualization_type
+        != "docker"
+
+    - name: Disable socket autofs
+      systemd:
+        name: autofs.socket
+        enabled: 'no'
+        state: stopped
+        masked: 'yes'
+      when:
+        - '"autofs.socket" in socket_file_exists.stdout_lines[1]'
+        - ansible_virtualization_role != "guest" or ansible_virtualization_type !=
+          "docker"
+
+
 # Upgrade packages affected by CVE-2017-5715
 # Identifier: (vulnerabilities:CVE-2017-5715,fix)
 # Version: test
@@ -1600,6 +1666,38 @@ exports[`playbooks generate playbook with pydata and playbook support 1`] = `
       name: set reboot fact
       set_fact:
         insights_needs_reboot: "{{requires_reboot}}"
+
+- name: generate Compliance report
+  hosts: "1f12bdfc-8267-492d-a930-92f498fe65b9.ansible.example.com,fc94beb8-21ee-403d-99b1-949ef7adb762"
+  become: true
+  gather_facts: false
+  vars:
+    insights_signature_exclude: /hosts,/vars/insights_signature
+    insights_signature: !!binary |
+      TFMwdExTMUNSVWRKVGlCUVIxQWdVMGxIVGtGVVZWSkZMUzB0TFMwS1ZtVnljMmx2YmpvZ1IyNTFV
+      RWNnZGpFS0NtbFJTV05DUVVGQ1EwRkJSMEpSU213elMyZFlRVUZ2U2tWTmRuYzFPRVFyYWpWd1Rq
+      a3djMUZCU1dwWVVsWklhUzh5WkdRclFrdzRhRnBCVXlzNGJrd0tjbUp5WkhobWRra3ZhM1p3TWxj
+      eGNrMWtNbkJ0YmpsV1owOURXVll6YzI5Nk1FNURjRTVKZUhsUFFuZFpXVmhOYkdwYU5XcGhOSE5F
+      TkZVME5HbzFRUXBQUmxWTE1IQmxaR3QwVTJseVVsbDJhbTFsVm1oU1YyRnhURzE0VnpJeFFVdDNN
+      bmR5YTBRM1EwNVRjM1JtYmxWMlRtUkJabU5LYjFGV2NHODJOM2RyQ2sxUFNUaFJZMlo2ZFdJMWNu
+      aHlTSFV3ZUM5eFZqVnROa3RPZVZORFptaFlLelo0SzFkMWFqQk1ibEZqYTJ4WVYyVkZVM2hQV1N0
+      blRrMUJNMFkxYkU4S1dXcHdSMmhVU25oeFkzSXpTRWh0TURsV1RWTk1aeTkwTjNFNGRqaERWMlp1
+      Wms1M2VVcDBOazVsYVV0MGFVYzVUa2hKV1d0M1NFZ3lOMFZZTlhORk9Rb3pSakEyWWs5NlpsQkdT
+      RWRaUzBzeFlYTmplamhvTDNOMVRtMDRiWFJ4Ym5CQmIycHNkM1JZVDNKWmFVaG1hV1JsTWtSaWEz
+      VjNOUzl0ZDBGSFFXZFVDbGhtTWtJMGMybFBVSHBpWWxvMVUzUjJSbFk0YzBaMVVrMTFjWEpHVTJj
+      M2FsSkpkbkpQT1ZjeE5YQTBiV04xUnpkSWVDOVJRMVpvUmpkb1FuUkZUMG9LVFhCdmFYVjBOVlpx
+      ZGxsVFkwcEJUM05tTUdsYU5FaFlRWEZtVEVWWWVtdzFja1ZzUmtoek1GSnlWRkJsWVZoSmRqTmti
+      bkpUV0dkNFNUZFVTVUpUYVFwYWJtTkNZalpMVUdkNWFVSXJibWRQV0ZCbFEyMUhNbmRMVm5CSGVI
+      ZDFkV0pXTWtScE5FdGxhWHB0V25KcWNtMVFPRlJLWjJWb2QyRktSMmt5TlZwakNrcFpVMlpGTVU5
+      T1pucDVaR2gxVmxscVltSnhabkppZGxKWU4zaExlV1JNTVhWQlRucG9Ua05wY2pSRk0xcHRaRloy
+      UlVSd04wNVNhalIwTmpReldrY0tTVGxSYnpGRldEazNlR001YmtwYU0wMDVWME5zYVhSa2MwUTJh
+      V1JQWlhCU1FuRlBhSFJIU0hoRlkxVkJUMHgxWkUwelNVNDNNM1pDVlRCa1dsbFVXQXByYVhwNVRV
+      VXJibGxEUmxKSk9XWjFaemx2ZGdvOVVtcGxWZ290TFMwdExVVk9SQ0JRUjFBZ1UwbEhUa0ZVVlZK
+      RkxTMHRMUzBL
+  tasks:
+    - name: generate Compliance report
+      command: insights-client --compliance
+      changed_when: false
 
 # Reboots a system if any of the preceeding plays sets the 'insights_needs_reboot' variable to true.
 # The variable can be overridden to suppress this behavior.

--- a/src/remediations/read.integration.js
+++ b/src/remediations/read.integration.js
@@ -56,7 +56,7 @@ describe('remediations', function () {
             createdIds = [];
         });
 
-        test('v1 SSG issue id fails with INVALID_ISSUE_IDENTIFIER', async () => {
+        test('v1 SSG issue id succeeds via SSG template lookup', async () => {
             const remId = uuidv4();
             createdIds.push(remId);
 
@@ -81,15 +81,14 @@ describe('remediations', function () {
                 system_id: '1f12bdfc-8267-492d-a930-92f498fe65b9'
             }]);
 
-            const { id, header } = reqId();
             const { body } = await request
                 .get(`/v1/remediations/${remId}`)
-                .set(header)
-                .expect(400);
+                .expect(200);
 
-            body.errors.should.be.Array();
-            body.errors[0].code.should.equal('INVALID_ISSUE_IDENTIFIER');
-            body.errors[0].id.should.equal(id);
+            body.should.have.property('issues');
+            body.issues.should.have.length(1);
+            body.issues[0].should.have.property('resolution');
+            body.issues[0].resolution.should.have.property('id', 'fix');
         });
 
         test('v2 SSG issue id succeeds', async () => {

--- a/src/resolutions/resolutions.unit.js
+++ b/src/resolutions/resolutions.unit.js
@@ -144,34 +144,38 @@ describe('resolve advisor resolutions', function () {
 });
 
 describe('resolve ssg resolutions', function () {
-    test('v1 SSG id is rejected', async () => {
-        const {id, header} = reqId();
+    test('v1 SSG id returns resolution info via SSG template lookup', async () => {
         const {body} = await request
         .get('/v1/resolutions/ssg:rhel7|pci-dss|xccdf_org.ssgproject.content_rule_disable_prelink')
-        .set(header)
-        .expect(400);
+        .expect(200);
 
-        body.errors.should.eql([{
-            id,
-            status: 400,
-            code: 'INVALID_ISSUE_IDENTIFIER',
-            title: 'Compliance v1 issue identifiers have been retired. Please update your v1 issue ID, "ssg:<platform>|<profile>|xccdf_org.ssgproject.content_rule_disable_prelink", to the v2 format of "ssg:xccdf_org.ssgproject.content_benchmark_RHEL-X|<version>|<profile>|xccdf_org.ssgproject.content_rule_disable_prelink"'
-        }]);
+        body.should.eql({
+            id: 'ssg:rhel7|pci-dss|xccdf_org.ssgproject.content_rule_disable_prelink',
+            resolution_risk: -1,
+            resolutions: [{
+                description: 'Disable Prelinking',
+                id: 'fix',
+                needs_reboot: true,
+                resolution_risk: -1
+            }]
+        });
     });
 
-    test('v1 SSG id (uppercase profile) is rejected', async () => {
-        const {id, header} = reqId();
+    test('v1 SSG id (uppercase profile) returns resolution info via SSG template lookup', async () => {
         const {body} = await request
             .get('/v1/resolutions/ssg:rhel7|C2S|xccdf_org.ssgproject.content_rule_disable_host_auth')
-            .set(header)
-            .expect(400);
+            .expect(200);
 
-        body.errors.should.eql([{
-            id,
-            status: 400,
-            code: 'INVALID_ISSUE_IDENTIFIER',
-            title: 'Compliance v1 issue identifiers have been retired. Please update your v1 issue ID, "ssg:<platform>|<profile>|xccdf_org.ssgproject.content_rule_disable_host_auth", to the v2 format of "ssg:xccdf_org.ssgproject.content_benchmark_RHEL-X|<version>|<profile>|xccdf_org.ssgproject.content_rule_disable_host_auth"'
-        }]);
+        body.should.eql({
+            id: 'ssg:rhel7|C2S|xccdf_org.ssgproject.content_rule_disable_host_auth',
+            resolution_risk: -1,
+            resolutions: [{
+                description: 'Disable Host-Based Authentication',
+                id: 'fix',
+                needs_reboot: true,
+                resolution_risk: -1
+            }]
+        });
     });
 
     test('v2 SSG id returns resolution info', async () => {

--- a/src/resolutions/resolvers/SSGResolver.unit.js
+++ b/src/resolutions/resolvers/SSGResolver.unit.js
@@ -37,9 +37,10 @@ describe('SSGResolved', function () {
             resolutions[0].description.should.equal('Disable Prelinking');
         });
 
-        test('throws UNKNOWN_ISSUE if the rule does not exist at all', async () => {
+        test('returns no resolutions if the issue does not exist at all', async () => {
             const id = identifiers.parse('ssg:xccdf_org.ssgproject.content_benchmark_RHEL-7|1.0.0|standard|xccdf_org.ssgproject.content_rule_this_is_nonsense');
-            await expect(resolver.resolveResolutions(id)).rejects.toThrow(/Unknown issue identifier/);
+            const resolutions = await resolver.resolveResolutions(id);
+            resolutions.should.have.size(0);
         });
 
         test('returns 0 if the rule id is rsyslog_remote_loghost', async () => {


### PR DESCRIPTION
## Summary by Sourcery

Enable graceful handling of legacy v1 SSG issue identifiers by falling back to template lookup instead of rejecting them

Enhancements:
- Allow SSGResolver to accept v1 issue ids with a warning and lookup templates rather than throwing an error
- Return an empty resolutions array for unknown rules instead of treating them as errors
- Update playbook generator to accept v1 issue ids and return a non-empty playbook
- Change unsupported issue error code in playbook endpoint from UNKNOWN_ISSUE to UNSUPPORTED_ISSUE
- Add warning logs in SSGHandler and SSGResolver when a v1 issue identifier is used

Tests:
- Revise unit and integration tests for /v1/resolutions/ssg, /v1/playbook, and /v1/remediations to expect 200 responses and resolution data for v1 ids
- Update SSGResolver unit tests to expect an empty array for non-existent rules