### PR TITLE
RHINENG-9371: switch to returning hostname = null for missing systems

### DIFF
--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -722,7 +722,7 @@ exports.getPlanSystemsDetails = async function (inventoryIds, chunkSize = 50) {
     inventoryIds.forEach(inventoryId => {
         if (!result[inventoryId]) {
             result[inventoryId] = {
-                hostname: inventoryId,
+                hostname: null,
                 ansible_hostname: null,
                 display_name: null
             };

--- a/src/remediations/remediations.queries.unit.js
+++ b/src/remediations/remediations.queries.unit.js
@@ -179,7 +179,7 @@ describe('getPlanSystemsDetails', function () {
                 display_name: 'Server 1'
             },
             [missingSystemId]: {
-                hostname: missingSystemId, // Fallback to UUID
+                hostname: null,
                 ansible_hostname: null,
                 display_name: null
             }
@@ -388,7 +388,7 @@ describe('getPlanSystemsDetails', function () {
                 display_name: 'Partially Found System'
             },
             'another-missing-uuid': {
-                hostname: 'another-missing-uuid', // Fallback to UUID
+                hostname: null,
                 ansible_hostname: null,
                 display_name: null
             }


### PR DESCRIPTION
## Summary by Sourcery

Return null as hostname for missing systems instead of falling back to their IDs

Bug Fixes:
- Default to null hostname for missing systems instead of using the system ID

Tests:
- Updated unit tests to expect null hostname for missing systems