### PR TITLE
RHINENG-21568: Use our local systems table when generating playbooks

### DIFF
--- a/db/seeders/20180101000000-systems.js
+++ b/db/seeders/20180101000000-systems.js
@@ -14,7 +14,8 @@ const SPECIAL_SYSTEMS = {
     '35f36364-6007-4ecc-9666-c4f8d354be9f': { hostname: '35e9b452-e405-499c-9c6e-120010b7b465.example.com' },
     '1040856f-b772-44c7-83a9-eea4813c4be8': { 
         hostname: '1040856f-b772-44c7-83a9-eea4813c4be8.example.com',
-        display_name: 'test-system-1'
+        display_name: 'test-system-1',
+        ansible_host: '1040856f-b772-44c7-83a9-eea4813c4be8.ansible.example.com'
     }
 };
 

--- a/src/connectors/inventory/impl.js
+++ b/src/connectors/inventory/impl.js
@@ -214,6 +214,38 @@ module.exports = new class extends Connector {
         return validate(transformed);
     }
 
+    /**
+     * Handles 404 from Inventory API gracefully by removing not_found_ids and retrying with remaining IDs.
+     * Returns partial results of found systems.
+     */
+    async getSystemDetailsBatchPartial (ids = [], refresh = false) {
+        if (ids.length === 0) {
+            return {};
+        }
+
+        try {
+            return await this.getSystemDetailsBatch(ids, refresh);
+        } catch (e) {
+            // Check if it's an UNKNOWN_SYSTEM error with notFoundIds
+            if (!e.notFoundIds) {
+                throw e;
+            }
+
+            // Some systems not found - retry with remaining IDs
+            const notFoundIds = e.notFoundIds;
+            const remainingIds = _.difference(ids, notFoundIds);
+
+            log.warn({ notFoundIds }, 'Systems not found in Inventory, filtering them out');
+
+            // No remaining systems to fetch
+            if (remainingIds.length === 0) {
+                return {};
+            }
+
+            return await this.getSystemDetailsBatch(remainingIds, refresh);
+        }
+    }
+
     async getSystemProfileBatch (ids = [], refresh = false, retries = 2) {
         if (ids.length === 0) {
             return {};

--- a/src/connectors/inventory/impl.js
+++ b/src/connectors/inventory/impl.js
@@ -214,38 +214,6 @@ module.exports = new class extends Connector {
         return validate(transformed);
     }
 
-    /**
-     * Handles 404 from Inventory API gracefully by removing not_found_ids and retrying with remaining IDs.
-     * Returns partial results of found systems.
-     */
-    async getSystemDetailsBatchPartial (ids = [], refresh = false) {
-        if (ids.length === 0) {
-            return {};
-        }
-
-        try {
-            return await this.getSystemDetailsBatch(ids, refresh);
-        } catch (e) {
-            // Check if it's an UNKNOWN_SYSTEM error with notFoundIds
-            if (!e.notFoundIds) {
-                throw e;
-            }
-
-            // Some systems not found - retry with remaining IDs
-            const notFoundIds = e.notFoundIds;
-            const remainingIds = _.difference(ids, notFoundIds);
-
-            log.warn({ notFoundIds }, 'Systems not found in Inventory, filtering them out');
-
-            // No remaining systems to fetch
-            if (remainingIds.length === 0) {
-                return {};
-            }
-
-            return await this.getSystemDetailsBatch(remainingIds, refresh);
-        }
-    }
-
     async getSystemProfileBatch (ids = [], refresh = false, retries = 2) {
         if (ids.length === 0) {
             return {};

--- a/src/generator/generator.controller.js
+++ b/src/generator/generator.controller.js
@@ -5,7 +5,9 @@ const P = require('bluebird');
 const etag = require('etag');
 
 const errors = require('../errors');
+const queries = require('../remediations/remediations.queries');
 const inventory = require('../connectors/inventory');
+const { storeSystemDetails } = require('../remediations/controller.write');
 const templates = require('../templates/static');
 const SpecialPlay = require('./plays/SpecialPlay');
 const format = require('./format');
@@ -146,28 +148,41 @@ exports.resolveSystems = async function (issues, strict = true) {
         trace.event(`System IDs: ${JSON.stringify(systemIds)}`);
     }
 
-    trace.event('Get system details...');
-    // Fetch system details from Inventory:
-    // - refresh=true: bypass cache as ansible_host may change
-    // - strict=true: throw UNKNOWN_SYSTEM error if any systems are missing
-    // - strict=false: return partial results with only known systems
-    const systems = await inventory.getSystemDetailsBatch(systemIds, true, 2, strict)
+    // Try to get systems from local systems table first then fall back to Inventory for any missing systems
+    trace.event('Get system details from local DB...');
+    let systems = await queries.getSystemDetailsForPlaybook(systemIds);
+
+    const missingIds = systemIds.filter(id => !(id in systems));
+    if (missingIds.length > 0) {
+        trace.event(`Fetching ${missingIds.length} missing systems from Inventory...`);
+        // Fetch system details from Inventory:
+        // - refresh=true: bypass cache as ansible_host may change
+        // - strict=true: throw UNKNOWN_SYSTEM error if any systems are missing
+        // - strict=false: return partial results with only known systems
+        const inventoryData = await inventory.getSystemDetailsBatch(missingIds, true, 2, strict)
         .catch(e => {
             probes.failedGeneration('unknown system(s)');
             throw e;
         });
 
-    // When strict=false, filter out missing systems from issues
+        // Store Inventory systems our in our local systems table so we don't have to fetch from Inventory next time
+        storeSystemDetails(inventoryData).catch(err => log.warn({ err }, 'Failed to store system details'));
+        systems = { ...systems, ...inventoryData };
+    }
+
+    // If strict=false and there are systems that don't exist (in our systems table or Inventory), remove them from the issues
     if (!strict) {
-        trace.event('Remove systems for which we have no inventory entry...');
+        trace.event('Remove systems for which we have no entry...');
         _.forEach(issues, issue => issue.systems = issue.systems.filter((id) => {
             // eslint-disable-next-line security/detect-object-injection
             return (systems.hasOwnProperty(id));
         }));
     }
 
-    // Map system IDs to hostnames
-    trace.event('Map system IDs to hosts...');
+    // Map system IDs to hostnames and verify all systems exist in either our systems table or Inventory
+    // With strict=false: missing systems were already filtered out above, so this should pass
+    // With strict=true: no filtering happened, so throw an error if any system is missing
+    trace.event('Verify that there are no systems for which we have no entry in our systems table or Inventory...');
     _.forEach(issues, issue => issue.hosts = issue.systems.map(id => {
         // eslint-disable-next-line security/detect-object-injection
         const system = systems[id];
@@ -175,7 +190,7 @@ exports.resolveSystems = async function (issues, strict = true) {
     }));
     trace.event('All systems mapped!');
 
-    // If strict=false, filter out issues with no systems (systems that were removed because they don't exist in Inventory)
+    // If strict=false, filter out issues with no systems (systems that were removed because they don't exist in our systems table or Inventory)
     if (!strict) {
         trace.event('Remove issues with no systems...')
         issues = _.filter(issues, (issue) => (issue.systems.length > 0));

--- a/src/generator/generator.controller.js
+++ b/src/generator/generator.controller.js
@@ -148,10 +148,10 @@ exports.resolveSystems = async function (issues, strict = true) {
         trace.event(`System IDs: ${JSON.stringify(systemIds)}`);
     }
 
-    // Try to get systems from local systems table first then fall back to Inventory for any missing systems
     trace.event('Get system details from local DB...');
     let systems = await queries.getSystemDetailsForPlaybook(systemIds);
 
+    // Fallback: if any systems missing from local table, fetch from Inventory and store
     const missingIds = systemIds.filter(id => !(id in systems));
     if (missingIds.length > 0) {
         trace.event(`Fetching ${missingIds.length} missing systems from Inventory...`);
@@ -165,36 +165,23 @@ exports.resolveSystems = async function (issues, strict = true) {
             throw e;
         });
 
-        // Store Inventory systems our in our local systems table so we don't have to fetch from Inventory next time
+        // Store Inventory systems in our local systems table so we don't have to fetch from Inventory next time
         storeSystemDetails(inventoryData).catch(err => log.warn({ err }, 'Failed to store system details'));
         systems = { ...systems, ...inventoryData };
     }
 
-    // If strict=false and there are systems that don't exist (in our systems table or Inventory), remove them from the issues
-    if (!strict) {
-        trace.event('Remove systems for which we have no entry...');
-        _.forEach(issues, issue => issue.systems = issue.systems.filter((id) => {
-            // eslint-disable-next-line security/detect-object-injection
-            return (systems.hasOwnProperty(id));
-        }));
-    }
-
-    // Map system IDs to hostnames and verify all systems exist in either our systems table or Inventory
-    // With strict=false: missing systems were already filtered out above, so this should pass
-    // With strict=true: no filtering happened, so throw an error if any system is missing
-    trace.event('Verify that there are no systems for which we have no entry in our systems table or Inventory...');
-    _.forEach(issues, issue => issue.hosts = issue.systems.map(id => {
+    // Filter out systems not found in local systems table or Inventory, then map to hosts
+    // For strict=true this is a no-op since getSystemDetailsBatch throws if any systems are missing
+    trace.event('Filter systems and map to hosts...');
+    _.forEach(issues, issue => {
+        issue.systems = issue.systems.filter(id => id in systems);
         // eslint-disable-next-line security/detect-object-injection
-        const system = systems[id];
-        return exports.systemToHost(system);
-    }));
-    trace.event('All systems mapped!');
+        issue.hosts = issue.systems.map(id => exports.systemToHost(systems[id]));
+    });
 
-    // If strict=false, filter out issues with no systems (systems that were removed because they don't exist in our systems table or Inventory)
-    if (!strict) {
-        trace.event('Remove issues with no systems...')
-        issues = _.filter(issues, (issue) => (issue.systems.length > 0));
-    }
+    // Remove issues that have no systems left after filtering
+    // For strict=true this is a no-op since all systems should exist
+    issues = _.filter(issues, issue => issue.systems.length > 0);
 
     trace.leave();
     return issues;

--- a/src/generator/generator.controller.js
+++ b/src/generator/generator.controller.js
@@ -128,17 +128,17 @@ exports.systemToHost = function (system) {
 };
 
 /**
- * Resolves system IDs to hostnames by fetching system details from Inventory.
+ * Resolves system IDs to hostnames by first checking the local systems table,
+ * then falling back to Inventory for any missing systems.
  * Adds a `hosts` property to each issue containing the resolved hostnames.
  *
  * @param {Array} issues - Array of issue objects, each containing a `systems` array of system IDs
  * @param {boolean} strict - Controls error handling for missing systems:
- *   - true (default): Throws UNKNOWN_SYSTEM error if any system ID is not found in Inventory
- *   - false: Gracefully handles missing systems by filtering them out and removing empty issues
+ *   - true (default): Throws UNKNOWN_SYSTEM error if any system ID is not found
+ *   - false: Filters out missing systems from hosts and removes issues with no valid systems/hosts
  *
- * Returns the issues array with `hosts` added to each issue
- * Or throws UNKNOWN_SYSTEM error if strict=true and some systems weren't found in Inventory.
- * When strict=false, missing systems are filtered out and issues with no remaining systems are removed.
+ * Returns the issues array with `hosts` added. Issues with no valid hosts are removed (strict=false only).
+ * Systems fetched from Inventory are stored locally for future lookups.
  */
 exports.resolveSystems = async function (issues, strict = true) {
     trace.enter('generator.controller.resolveSystems');
@@ -155,6 +155,7 @@ exports.resolveSystems = async function (issues, strict = true) {
     const missingIds = systemIds.filter(id => !(id in systems));
     if (missingIds.length > 0) {
         trace.event(`Fetching ${missingIds.length} missing systems from Inventory...`);
+
         // Fetch system details from Inventory:
         // - refresh=true: bypass cache as ansible_host may change
         // - strict=true: throw UNKNOWN_SYSTEM error if any systems are missing
@@ -170,18 +171,19 @@ exports.resolveSystems = async function (issues, strict = true) {
         systems = { ...systems, ...inventoryData };
     }
 
-    // Filter out systems not found in local systems table or Inventory, then map to hosts
+    // Map system IDs to Ansible hostnames and filters out any systems not found in local systems table or Inventory
     // For strict=true this is a no-op since getSystemDetailsBatch throws if any systems are missing
     trace.event('Filter systems and map to hosts...');
     _.forEach(issues, issue => {
-        issue.systems = issue.systems.filter(id => id in systems);
         // eslint-disable-next-line security/detect-object-injection
-        issue.hosts = issue.systems.map(id => exports.systemToHost(systems[id]));
+        issue.hosts = issue.systems
+            .filter(id => id in systems)
+            .map(id => exports.systemToHost(systems[id]));
     });
 
-    // Remove issues that have no systems left after filtering
-    // For strict=true this is a no-op since all systems should exist
-    issues = _.filter(issues, issue => issue.systems.length > 0);
+    // Remove issues that have no hosts after filtering
+    // For strict=true this is a no-op since no systems should have been filtered out
+    issues = _.filter(issues, issue => issue.hosts.length > 0);
 
     trace.leave();
     return issues;

--- a/src/generator/generator.unit.js
+++ b/src/generator/generator.unit.js
@@ -749,3 +749,141 @@ describe('host sanitation', function () {
         expect(text).toMatchSnapshot();
     });
 });
+
+describe('resolveSystems', function () {
+    const controller = require('./generator.controller');
+    const queries = require('../remediations/remediations.queries');
+    const inventory = require('../connectors/inventory');
+
+    const system1Id = '68799a02-8be9-11e8-9eb6-529269fb1459';
+    const system2Id = '936ef48c-8f05-11e8-9eb6-529269fb1459';
+    const missingSystemId = '00000000-0000-0000-0000-000000000000';
+
+    let queriesStub;
+    let inventoryStub;
+
+    beforeEach(() => {
+        queriesStub = getSandbox().stub(queries, 'getSystemDetailsForPlaybook');
+        inventoryStub = getSandbox().stub(inventory, 'getSystemDetailsBatch');
+        // Note: storeSystemDetails is imported via destructuring, so we can't stub it easily
+        // The call happens but we test it indirectly by verifying Inventory data is used
+    });
+
+    test('uses systems from local DB when all found (Inventory not called)', async () => {
+        const issues = [{ id: 'test:ping', systems: [system1Id, system2Id] }];
+        
+        // All systems found in local DB
+        queriesStub.resolves({
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' },
+            [system2Id]: { id: system2Id, hostname: 'host2.example.com', ansible_host: null, display_name: 'Host 2' }
+        });
+
+        const result = await controller.resolveSystems(issues, true);
+
+        // Should have hosts mapped
+        result[0].hosts.should.deepEqual(['host1.example.com', 'host2.example.com']);
+        
+        // Inventory should NOT be called since all systems were in local DB
+        inventoryStub.should.not.have.been.called;
+    });
+
+    test('falls back to Inventory for systems missing from local DB', async () => {
+        const issues = [{ id: 'test:ping', systems: [system1Id, system2Id] }];
+        
+        // Only system1 found in local DB
+        queriesStub.resolves({
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' }
+        });
+        
+        // system2 fetched from Inventory
+        inventoryStub.resolves({
+            [system2Id]: { id: system2Id, hostname: 'host2.example.com', ansible_host: null, display_name: 'Host 2' }
+        });
+
+        const result = await controller.resolveSystems(issues, true);
+
+        // Should have both hosts mapped
+        result[0].hosts.should.deepEqual(['host1.example.com', 'host2.example.com']);
+        
+        // Inventory should be called only for missing system
+        inventoryStub.should.have.been.calledOnce;
+        inventoryStub.firstCall.args[0].should.deepEqual([system2Id]);
+    });
+
+    test('fetches from Inventory when systems missing from local DB', async () => {
+        const issues = [{ id: 'test:ping', systems: [system1Id] }];
+        
+        // No systems in local DB
+        queriesStub.resolves({});
+        
+        // System fetched from Inventory
+        const inventoryData = {
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' }
+        };
+        inventoryStub.resolves(inventoryData);
+
+        const result = await controller.resolveSystems(issues, true);
+
+        // Inventory should be called for the missing system
+        inventoryStub.should.have.been.calledOnce;
+        inventoryStub.firstCall.args[0].should.deepEqual([system1Id]);
+        
+        // Result should have the host mapped
+        result[0].hosts.should.deepEqual(['host1.example.com']);
+    });
+
+    test('throws UNKNOWN_SYSTEM error when strict=true and system not found', async () => {
+        const issues = [{ id: 'test:ping', systems: [missingSystemId] }];
+        
+        // No systems in local DB
+        queriesStub.resolves({});
+        
+        // Inventory throws UNKNOWN_SYSTEM error
+        const unknownSystemError = new errors.BadRequest('UNKNOWN_SYSTEM', `Unknown system identifier "${missingSystemId}"`);
+        unknownSystemError.notFoundIds = [missingSystemId];
+        inventoryStub.rejects(unknownSystemError);
+
+        await expect(controller.resolveSystems(issues, true))
+            .rejects.toThrow('Unknown system identifier');
+    });
+
+    test('filters out missing systems when strict=false', async () => {
+        const issues = [{ id: 'test:ping', systems: [system1Id, missingSystemId] }];
+        
+        // Only system1 in local DB
+        queriesStub.resolves({
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' }
+        });
+        
+        // Inventory returns empty (strict=false filters out missing)
+        inventoryStub.resolves({});
+
+        const result = await controller.resolveSystems(issues, false);
+
+        // Should only have host for system1, missingSystemId filtered out
+        result[0].hosts.should.deepEqual(['host1.example.com']);
+        // systems array is NOT modified - only hosts is filtered
+        result[0].systems.should.deepEqual([system1Id, missingSystemId]);
+    });
+
+    test('removes issues with no systems when strict=false', async () => {
+        const issues = [
+            { id: 'test:ping', systems: [missingSystemId] },
+            { id: 'test:reboot', systems: [system1Id] }
+        ];
+        
+        // Only system1 in local DB
+        queriesStub.resolves({
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' }
+        });
+        
+        // Inventory returns empty for missing system
+        inventoryStub.resolves({});
+
+        const result = await controller.resolveSystems(issues, false);
+
+        // First issue should be removed (no valid hosts)
+        result.should.have.length(1);
+        result[0].id.should.equal('test:reboot');
+    });
+});

--- a/src/remediations/controller.write.js
+++ b/src/remediations/controller.write.js
@@ -511,3 +511,6 @@ exports.removeSystem = errors.async(async function (req, res) {
 
     return res.status(404).end();
 });
+
+// Export for reuse in generator.controller.js (backfill systems not in local DB)
+exports.storeSystemDetails = storeSystemDetails;

--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -909,3 +909,25 @@ exports.getPlaybookRunsWithDispatcherCounts = async function (playbookRunIds) {
         raw: true
     });
 };
+
+exports.getSystemDetailsForPlaybook = async function (systemIds) {
+    if (!systemIds || systemIds.length === 0) {
+        return {};
+    }
+
+    const systems = await db.systems.findAll({
+        attributes: ['id', 'hostname', 'ansible_hostname', 'display_name'],
+        where: { id: systemIds },
+        raw: true
+    });
+
+    return _(systems)
+        .keyBy('id')
+        .mapValues(system => ({
+            id: system.id,
+            hostname: system.hostname,
+            ansible_host: system.ansible_hostname,
+            display_name: system.display_name
+        }))
+        .value();
+};

--- a/src/remediations/remediations.queries.unit.js
+++ b/src/remediations/remediations.queries.unit.js
@@ -208,3 +208,111 @@ describe('getPlanSystemsDetails', function () {
         dbSystemsFindAllStub.should.have.been.calledOnce;
     });
 });
+
+describe('getSystemDetailsForPlaybook', function () {
+    const system1Id = 'f6b7a1c2-3d4e-5f6a-7b8c-9d0e1f2a3b4c';
+    const system2Id = 'a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d';
+    const missingSystemId = '00000000-0000-0000-0000-000000000000';
+
+    let dbSystemsFindAllStub;
+
+    beforeEach(() => {
+        dbSystemsFindAllStub = base.sandbox.stub(db.systems, 'findAll');
+    });
+
+    test('should return empty object for empty input', async () => {
+        const result = await queries.getSystemDetailsForPlaybook([]);
+        result.should.deepEqual({});
+        
+        dbSystemsFindAllStub.should.not.have.been.called;
+    });
+
+    test('should return empty object for null input', async () => {
+        const result = await queries.getSystemDetailsForPlaybook(null);
+        result.should.deepEqual({});
+        
+        dbSystemsFindAllStub.should.not.have.been.called;
+    });
+
+    test('should fetch system details from database and map to playbook format', async () => {
+        const systemIds = [system1Id, system2Id];
+        
+        dbSystemsFindAllStub.resolves([
+            {
+                id: system1Id,
+                hostname: 'server1.example.com',
+                ansible_hostname: 'ansible1.example.com',
+                display_name: 'Server 1'
+            },
+            {
+                id: system2Id,
+                hostname: 'server2.example.com', 
+                ansible_hostname: null,
+                display_name: 'Server 2'
+            }
+        ]);
+
+        const result = await queries.getSystemDetailsForPlaybook(systemIds);
+
+        // Should map ansible_hostname to ansible_host for playbook compatibility
+        result.should.deepEqual({
+            [system1Id]: {
+                id: system1Id,
+                hostname: 'server1.example.com',
+                ansible_host: 'ansible1.example.com',
+                display_name: 'Server 1'
+            },
+            [system2Id]: {
+                id: system2Id,
+                hostname: 'server2.example.com',
+                ansible_host: null,
+                display_name: 'Server 2'
+            }
+        });
+
+        dbSystemsFindAllStub.should.have.been.calledOnce;
+    });
+
+    test('should only return systems found in database (no fallback for missing)', async () => {
+        const systemIds = [system1Id, missingSystemId];
+        
+        // Only system1 found in database
+        dbSystemsFindAllStub.resolves([
+            {
+                id: system1Id,
+                hostname: 'server1.example.com',
+                ansible_hostname: 'ansible1.example.com',
+                display_name: 'Server 1'
+            }
+        ]);
+
+        const result = await queries.getSystemDetailsForPlaybook(systemIds);
+
+        // Should NOT include missingSystemId - only returns what's in DB
+        result.should.deepEqual({
+            [system1Id]: {
+                id: system1Id,
+                hostname: 'server1.example.com',
+                ansible_host: 'ansible1.example.com',
+                display_name: 'Server 1'
+            }
+        });
+
+        // missingSystemId should not be in result
+        result.should.not.have.property(missingSystemId);
+        
+        dbSystemsFindAllStub.should.have.been.calledOnce;
+    });
+
+    test('should return empty object when no systems found in database', async () => {
+        const systemIds = [missingSystemId];
+        
+        dbSystemsFindAllStub.resolves([]);
+
+        const result = await queries.getSystemDetailsForPlaybook(systemIds);
+
+        result.should.deepEqual({});
+        
+        dbSystemsFindAllStub.should.have.been.calledOnce;
+    });
+});


### PR DESCRIPTION
## Summary by Sourcery

Use the local systems table as the primary source for system details when generating playbooks, falling back to Inventory only for missing systems and caching those results locally.

New Features:
- Add a query to retrieve system details for playbook generation from the local systems table.
- Expose system detail storage for reuse when backfilling missing systems into the local database.

Enhancements:
- Update system resolution logic to combine local systems data with Inventory data and improve handling of missing systems.
- Extend seed data to include ansible_host for a test system to support the new system details flow.