### PR TITLE
RHINENG-25338: Optimize formatRunHosts to get all hosts in 1 API call

### DIFF
--- a/src/connectors/dispatcher/mock.js
+++ b/src/connectors/dispatcher/mock.js
@@ -360,12 +360,31 @@ module.exports = new class extends Connector {
                 };
             }
 
-            if (!_.isUndefined(filter.filter.run.id)) {
+            if (!_.isUndefined(filter.filter.run?.id)) {
                 return {
                     meta: {
                         count: 1
                     },
                     data: [RUNHOSTS[filter.filter.run.id]]
+                };
+            }
+
+            // Handle filtering by playbook-run label (returns all hosts for that playbook run)
+            if (!_.isUndefined(filter.filter.run?.labels?.['playbook-run'])) {
+                const playbookRunId = filter.filter.run.labels['playbook-run'];
+                const runs = RUNS[playbookRunId];
+                if (!runs) {
+                    return { meta: { count: 0 }, data: [] };
+                }
+                // Get all run IDs that have this playbook-run label
+                const runIds = runs.map(run => run.id);
+                // Return all hosts whose run.id is in that list
+                const hostsData = runIds.map(runId => RUNHOSTS[runId]).filter(Boolean);
+                return {
+                    meta: {
+                        count: hostsData.length
+                    },
+                    data: hostsData
                 };
             }
         }

--- a/src/remediations/fifi.js
+++ b/src/remediations/fifi.js
@@ -245,8 +245,8 @@ exports.formatRunHosts = async function (dispatcherRuns, playbook_run_id) {
             return hosts;
         }
 
-        // Collect all inventory IDs for batch system details lookup
-        const allInventoryIds = allRunHosts.data.map(host => host.inventory_id);
+        // Collect unique inventory IDs for batch system details lookup
+        const allInventoryIds = _.uniq(allRunHosts.data.map(host => host.inventory_id));
 
         // Fetch system details for all inventory IDs in batch
         const systemDetails = await queries.getPlanSystemsDetails(allInventoryIds);

--- a/src/remediations/fifi.js
+++ b/src/remediations/fifi.js
@@ -26,7 +26,7 @@ const SYSTEM_FIELDS = Object.freeze(['id', 'ansible_host', 'hostname', 'display_
 
 const RUNSFIELDS = Object.freeze({fields: {data: ['id', 'labels', 'status', 'service', 'created_at', 'updated_at', 'url']}});
 const RUNHOSTFIELDS = Object.freeze({fields: {data: ['host', 'stdout', 'inventory_id']}});
-const RHCRUNFIELDS = Object.freeze({fields: {data: ['host', 'status', 'inventory_id']}});
+const RHCRUNFIELDS = Object.freeze({fields: {data: ['host', 'status', 'inventory_id', 'run']}});
 const RHCSTATUSES = ['timeout', 'failure', 'success', 'running', 'canceled'];
 
 const DIFF_MODE = false;
@@ -232,41 +232,39 @@ exports.formatRunHosts = async function (dispatcherRuns, playbook_run_id) {
     let hosts = [];
 
     if (dispatcherRuns?.data) {
-        // Collect all inventory IDs to fetch system details in batch
-        const allInventoryIds = [];
-        const allHosts = [];
+        // Build a map of run.id -> run for looking up updated_at
+        const runsMap = _.keyBy(dispatcherRuns.data, 'id');
 
-        for (const run of dispatcherRuns.data) {
-            // get dispatcher run hosts...
-            const runHostsFilter = createDispatcherRunHostsFilter(playbook_run_id, run.id);
-            const rhcRunHosts = await dispatcher.fetchPlaybookRunHosts(runHostsFilter, RHCRUNFIELDS);
+        // Fetch all hosts for this playbook run in a single API call.
+        // We filter by the 'playbook-run' label (set to the remediation's playbook_run_id when runs are created).
+        // Playbook-dispatcher returns all hosts across all dispatcher runs that have this label.
+        const runHostsFilter = createDispatcherRunHostsFilter(playbook_run_id);
+        const allRunHosts = await dispatcher.fetchPlaybookRunHosts(runHostsFilter, RHCRUNFIELDS);
 
-            // Collect hosts and inventory IDs for batch processing
-            for (const host of rhcRunHosts.data) {
-                allInventoryIds.push(host.inventory_id);
-                allHosts.push({
-                    host,
-                    run,
-                    playbook_run_id
-                });
-            }
+        if (!allRunHosts?.data) {
+            return hosts;
         }
+
+        // Collect all inventory IDs for batch system details lookup
+        const allInventoryIds = allRunHosts.data.map(host => host.inventory_id);
 
         // Fetch system details for all inventory IDs in batch
         const systemDetails = await queries.getPlanSystemsDetails(allInventoryIds);
 
         // Format hosts with proper system names
-        hosts = allHosts.map(({ host, run, playbook_run_id }) => {
+        hosts = allRunHosts.data.map(host => {
             const details = systemDetails[host.inventory_id];
             // Use display_name if available, fallback to hostname, then to host.host
             const systemName = details?.display_name || details?.hostname || host.host;
             const isDirect = (host.host === 'localhost');
+            // Look up the parent run to get updated_at
+            const run = runsMap[host.run?.id] || {};
             return {
                 system_id: host.inventory_id,
                 system_name: systemName,
                 status: (host.status === 'timeout' ? 'failure' : host.status),
                 updated_at: run.updated_at,
-                playbook_run_executor_id: isDirect ? playbook_run_id : run.id,
+                playbook_run_executor_id: isDirect ? playbook_run_id : host.run?.id,
                 executor_type: isDirect ? 'direct' : 'satellite'
             };
         });

--- a/src/remediations/fifi.unit.js
+++ b/src/remediations/fifi.unit.js
@@ -311,11 +311,15 @@ describe('formatRunHosts and formatRHCHostDetails', function () {
                 data: [
                     {
                         inventory_id: system1Id,
-                        status: 'success'
+                        host: 'localhost',
+                        status: 'success',
+                        run: { id: 'run1' }
                     },
                     {
                         inventory_id: system2Id,
-                        status: 'running'
+                        host: 'localhost',
+                        status: 'running',
+                        run: { id: 'run1' }
                     }
                 ]
             });
@@ -325,6 +329,7 @@ describe('formatRunHosts and formatRHCHostDetails', function () {
             result.should.have.length(2);
             result[0].should.have.property('system_id', system1Id);
             result[0].should.have.property('system_name', 'Production Server 1'); // Uses display_name
+            result[0].should.have.property('updated_at', '2023-10-01T12:00:00.000Z');
             result[1].should.have.property('system_id', system2Id);
             result[1].should.have.property('system_name', 'Production Server 2'); // Uses display_name
         });
@@ -350,7 +355,9 @@ describe('formatRunHosts and formatRHCHostDetails', function () {
             base.sandbox.stub(dispatcher, 'fetchPlaybookRunHosts').resolves({
                 data: [{
                     inventory_id: system1Id,
-                    status: 'success'
+                    host: 'localhost',
+                    status: 'success',
+                    run: { id: 'run1' }
                 }]
             });
 
@@ -377,7 +384,8 @@ describe('formatRunHosts and formatRHCHostDetails', function () {
                 data: [{
                     inventory_id: system3Id,
                     status: 'success',
-                    host: 'dispatcher-host-name'
+                    host: 'dispatcher-host-name',
+                    run: { id: 'run1' }
                 }]
             });
 


### PR DESCRIPTION
## Summary by Sourcery

Optimize remediation run host formatting to retrieve all playbook run hosts in a single dispatcher API call and align mocks/tests with the new behavior.

Enhancements:
- Aggregate remediation hosts for a playbook run via a single dispatcher fetch filtered by playbook-run label and derive executor metadata from the associated run map.

Tests:
- Update and extend formatRunHosts unit tests to cover the new host payload shape, updated_at propagation, and playbook-run label handling in the dispatcher mock.