### PR TITLE
RHINENG-25792: Create org_config DB table and model

### DIFF
--- a/db/migrations/20260414105049-add-org-config-table.js
+++ b/db/migrations/20260414105049-add-org-config-table.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+    async up (q, {DATE, INTEGER, TEXT, fn}) {
+        await q.createTable('org_config', {
+            org_id: {
+                type: TEXT,
+                primaryKey: true,
+                allowNull: false,
+                comment: 'Organization ID'
+            },
+            retention_period_days: {
+                type: INTEGER,
+                allowNull: false,
+                defaultValue: 120,
+                comment: 'Days of inactivity before remediation plan expiration'
+            },
+            retention_warning_days: {
+                type: INTEGER,
+                allowNull: false,
+                defaultValue: 30,
+                comment: 'Days before expiration to show warning'
+            },
+            created_at: {
+                type: DATE,
+                allowNull: false,
+                defaultValue: fn('now')
+            },
+            updated_at: {
+                type: DATE,
+                allowNull: false,
+                defaultValue: fn('now')
+            }
+        });
+    },
+
+    async down (q) {
+        await q.dropTable('org_config');
+    }
+};

--- a/db/migrations/20260414105049-add-org-config-table.js
+++ b/db/migrations/20260414105049-add-org-config-table.js
@@ -9,13 +9,13 @@ module.exports = {
                 allowNull: false,
                 comment: 'Organization ID'
             },
-            retention_period_days: {
+            plan_retention_days: {
                 type: INTEGER,
                 allowNull: false,
                 defaultValue: 120,
                 comment: 'Days of inactivity before remediation plan expiration'
             },
-            retention_warning_days: {
+            plan_warning_days: {
                 type: INTEGER,
                 allowNull: false,
                 defaultValue: 30,

--- a/src/config/__snapshots__/config.unit.js.snap
+++ b/src/config/__snapshots__/config.unit.js.snap
@@ -149,6 +149,10 @@ exports[`Configuration Verify app-common-js function 1`] = `
     "enabled": false,
   },
   "requestTimeout": 10000,
+  "retention": {
+    "periodDays": 120,
+    "warningDays": 30,
+  },
   "sources": {
     "host": "http://localhost:8080",
     "impl": undefined,

--- a/src/config/__snapshots__/config.unit.js.snap
+++ b/src/config/__snapshots__/config.unit.js.snap
@@ -137,6 +137,10 @@ exports[`Configuration Verify app-common-js function 1`] = `
     "base": "/api/remediations",
     "prefix": "/api",
   },
+  "plan_retention": {
+    "retentionDays": 120,
+    "warningDays": 30,
+  },
   "platformHostname": "hostname",
   "port": undefined,
   "rbac": {
@@ -149,10 +153,6 @@ exports[`Configuration Verify app-common-js function 1`] = `
     "enabled": false,
   },
   "requestTimeout": 10000,
-  "retention": {
-    "periodDays": 120,
-    "warningDays": 30,
-  },
   "sources": {
     "host": "http://localhost:8080",
     "impl": undefined,

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -244,6 +244,11 @@ function Config() {
             appName: env.FEATURE_FLAGS_APP_NAME || 'remediations',
             refreshInterval: parseIntEnv('FEATURE_FLAGS_REFRESH_INTERVAL', 15000), // 15 seconds
             metricsInterval: parseIntEnv('FEATURE_FLAGS_METRICS_INTERVAL', 60000) // 60 seconds
+        },
+
+        retention: {
+            periodDays: parseIntEnv('RETENTION_PERIOD_DAYS', 120), // days of inactivity before expiration
+            warningDays: parseIntEnv('RETENTION_WARNING_DAYS', 30) // days before expiration to show warning
         }
     };
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -246,9 +246,9 @@ function Config() {
             metricsInterval: parseIntEnv('FEATURE_FLAGS_METRICS_INTERVAL', 60000) // 60 seconds
         },
 
-        retention: {
-            periodDays: parseIntEnv('RETENTION_PERIOD_DAYS', 120), // days of inactivity before expiration
-            warningDays: parseIntEnv('RETENTION_WARNING_DAYS', 30) // days before expiration to show warning
+        plan_retention: {
+            retentionDays: parseIntEnv('PLAN_RETENTION_DAYS', 120), // days of inactivity before plan expiration
+            warningDays: parseIntEnv('PLAN_WARNING_DAYS', 30) // days before expiration to show warning
         }
     };
 

--- a/src/remediations/models/orgConfig.js
+++ b/src/remediations/models/orgConfig.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = (sequelize, {DATE, INTEGER, TEXT}) => {
+    const OrgConfig = sequelize.define('org_config', {
+        org_id: {
+            type: TEXT,
+            primaryKey: true,
+            allowNull: false
+        },
+        retention_period_days: {
+            type: INTEGER,
+            allowNull: false
+        },
+        retention_warning_days: {
+            type: INTEGER,
+            allowNull: false
+        },
+        created_at: {
+            type: DATE,
+            allowNull: false
+        },
+        updated_at: {
+            type: DATE,
+            allowNull: false
+        }
+    }, {
+        timestamps: true,
+        createdAt: 'created_at',
+        updatedAt: 'updated_at'
+    });
+
+    return OrgConfig;
+};

--- a/src/remediations/models/orgConfig.js
+++ b/src/remediations/models/orgConfig.js
@@ -7,11 +7,11 @@ module.exports = (sequelize, {DATE, INTEGER, TEXT}) => {
             primaryKey: true,
             allowNull: false
         },
-        retention_period_days: {
+        plan_retention_days: {
             type: INTEGER,
             allowNull: false
         },
-        retention_warning_days: {
+        plan_warning_days: {
             type: INTEGER,
             allowNull: false
         },


### PR DESCRIPTION
## Summary by Sourcery

Introduce organization-level retention configuration with database persistence and expose corresponding application config options.

New Features:
- Add retention configuration section to application config with defaults for expiration and warning periods.
- Create org_config database table to store per-organization retention settings, including timestamps.
- Add Sequelize model for org_config to interact with organization retention configuration data.