### PR TITLE
RHINENG-25820: Fetch all run hosts in 1 call in formatRHCRuns

### DIFF
--- a/src/remediations/fifi.integration.js
+++ b/src/remediations/fifi.integration.js
@@ -4,6 +4,7 @@ const P = require('bluebird');
 const _ = require('lodash');
 const URI = require('urijs');
 const queryString = require('querystring');
+const qs = require('qs');
 
 const { request, auth, mockDate, buildRbacResponse, sandbox} = require('../test');
 const sinon = require('sinon');
@@ -80,27 +81,59 @@ function fake_dispatcher_runs(req) {
     return Promise.resolve(resp);
 }
 
-// For now, this just fakes a single run host for direct targets
+const FAKE_RUN_HOST_STDOUT = "[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'\r\nPLAY [Set owner and permissions on /etc/sshd/sshd_config to root:root 0600] ****\r\nTASK [Gathering Facts] *********************************************************ok: [localhost]\r\nTASK [Set the owner and permissions of ssh config file to root:root 0600] ******changed: [localhost]\r\nPLAY [run insights] ************************************************************\r\nTASK [run insights] ************************************************************ok: [localhost]\r\nPLAY RECAP *********************************************************************\r\nlocalhost                  : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   \r\n";
+
+// Fakes playbook-dispatcher /v1/run_hosts. Per-run queries use filter.run.id; batched formatRHCRuns/formatRunHosts
+// use filter.run.labels['playbook-run'] only — each returned row must include run.id so hosts can be grouped by dispatcher run.
 function fake_dispatcher_run_hosts(req) {
     const uri = new URI(req.uri);
-    const params = queryString.parse(uri.query());
+    const parsed = qs.parse(uri.query(), { depth: 10 });
+    const runFilter = parsed.filter?.run || {};
+    const runId = runFilter.id;
+    const playbookRunLabel = runFilter.labels?.['playbook-run'];
 
-    // construct response
-    const resp = {
+    if (runId) {
+        return Promise.resolve({
+            data: [{
+                host: 'localhost',
+                inventory_id: runId,
+                status: 'success',
+                stdout: FAKE_RUN_HOST_STDOUT,
+                run: { id: runId }
+            }],
+            links: {},
+            meta: { count: 1, total: 1 }
+        });
+    }
+
+    if (playbookRunLabel) {
+        const data = systems.map((systemId) => ({
+            host: 'localhost',
+            inventory_id: systemId,
+            status: 'success',
+            stdout: FAKE_RUN_HOST_STDOUT,
+            run: { id: systemId }
+        }));
+        return Promise.resolve({
+            data,
+            links: {},
+            meta: { count: data.length, total: data.length }
+        });
+    }
+
+    const flat = queryString.parse(uri.query());
+    const legacyRunId = flat['filter[run][id]'];
+    return Promise.resolve({
         data: [{
-            "host": "localhost",
-            "inventory_id": params['filter[run][id]'],
-            "status": "success",
-            "stdout": "[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'\r\nPLAY [Set owner and permissions on /etc/sshd/sshd_config to root:root 0600] ****\r\nTASK [Gathering Facts] *********************************************************ok: [localhost]\r\nTASK [Set the owner and permissions of ssh config file to root:root 0600] ******changed: [localhost]\r\nPLAY [run insights] ************************************************************\r\nTASK [run insights] ************************************************************ok: [localhost]\r\nPLAY RECAP *********************************************************************\r\nlocalhost                  : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   \r\n"
+            host: 'localhost',
+            inventory_id: legacyRunId,
+            status: 'success',
+            stdout: FAKE_RUN_HOST_STDOUT,
+            run: { id: legacyRunId }
         }],
         links: {},
-        meta: {
-            count: 1,
-            total:1
-        }
-    };
-
-    return Promise.resolve(resp);
+        meta: { count: 1, total: 1 }
+    });
 }
 
 

--- a/src/remediations/fifi.js
+++ b/src/remediations/fifi.js
@@ -148,8 +148,8 @@ async function formatRHCRuns (dispatcherRuns, playbook_run_id) {
     for (const run of dispatcherRuns.data) {
         const hostList = hostsByRunId[run.id];
 
-        // For RHC direct there should be one run_host per dispatcher run (localhost) but still using _.some just to be safe.
-        if (_.some(hostList, ['host', 'localhost'])) {
+        // For RHC direct there should be one run_host per dispatcher run where host === 'localhost'
+        if (hostList?.length === 1 && hostList[0].host === 'localhost') {
             rhcDirect.playbook = run.url;
             rhcDirect.updated_at = run.updated_at;
             rhcDirect.system_count += hostList.length; // should always be 1, but...

--- a/src/remediations/fifi.js
+++ b/src/remediations/fifi.js
@@ -138,25 +138,31 @@ async function formatRHCRuns (dispatcherRuns, playbook_run_id) {
 
     trace.event(`processing ${dispatcherRuns.data.length} runs...`);
 
+    // Fetch every run host for this playbook run from playbook-dispatcher
+    const runHostsFilter = createDispatcherRunHostsFilter(playbook_run_id);
+    const allRunHosts = await dispatcher.fetchPlaybookRunHosts(runHostsFilter, RHCRUNFIELDS);
+
+    // Index run hosts by dispatcher run id (skip rows missing run.id so they aren't grouped under undefined)
+    const hostsByRunId = _.groupBy(_.filter(allRunHosts?.data ?? [], 'run.id'), 'run.id');
+
     for (const run of dispatcherRuns.data) {
-        // get dispatcher run hosts
-        const runHostsFilter = createDispatcherRunHostsFilter(run.labels['playbook-run'], run.id);
-        const rhcRunHosts = await dispatcher.fetchPlaybookRunHosts(runHostsFilter, RHCRUNFIELDS);
-        // If host === 'localhost' then add to RHCDirect
-        if (_.get(rhcRunHosts, 'data[0][host]') === 'localhost') {
+        const hostList = hostsByRunId[run.id];
+
+        // For RHC direct there should be one run_host per dispatcher run (localhost) but still using _.some just to be safe.
+        if (_.some(hostList, ['host', 'localhost'])) {
             rhcDirect.playbook = run.url;
             rhcDirect.updated_at = run.updated_at;
-            rhcDirect.system_count += rhcRunHosts.meta.count; // should always be 1, but...
+            rhcDirect.system_count += hostList.length; // should always be 1, but...
             rhcDirect[`count_${run.status}`]++;
         }
 
         // else create a new sat executor
-        else if (!_.isEmpty(rhcRunHosts)) {
+        else if (!_.isEmpty(hostList)) {
             let satExecutor = {
                 name: 'RHC Satellite',
                 executor_id: run.id,
                 status: null,
-                system_count: rhcRunHosts.meta.count,
+                system_count: hostList.length,
                 playbook_run_id: playbook_run_id,
                 playbook: run.url,
                 updated_at: run.updated_at,
@@ -169,7 +175,7 @@ async function formatRHCRuns (dispatcherRuns, playbook_run_id) {
 
             // Assign each status count
             RHCSTATUSES.forEach(status => {
-                satExecutor[`count_${status}`] = _.size(_.filter(rhcRunHosts.data, run => run.status === status));
+                satExecutor[`count_${status}`] = _.size(_.filter(hostList, runHost => runHost.status === status));
             });
 
             // timeouts also count as errors since count_timeout doesn't get propogated
@@ -195,7 +201,6 @@ async function formatRHCRuns (dispatcherRuns, playbook_run_id) {
     trace.leave();
     return executors;
 }
-
 
 /**
  * Format RHC (Red Hat Connect) run hosts data by fetching proper system names (display_name || hostname)

--- a/src/remediations/fifi.unit.js
+++ b/src/remediations/fifi.unit.js
@@ -397,6 +397,76 @@ describe('formatRunHosts and formatRHCHostDetails', function () {
         });
     });
 
+    describe('combineRuns', function () {
+        const playbookRunId = '88d0ba73-0015-4e7d-a6d6-4b530cbfb5bc';
+
+        test('fetches run hosts once per playbook run (batch)', async () => {
+            const fetchHostsStub = base.sandbox.stub(dispatcher, 'fetchPlaybookRunHosts').resolves({
+                data: [
+                    {
+                        inventory_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+                        host: 'localhost',
+                        status: 'success',
+                        run: { id: 'dispatcher-run-direct' }
+                    },
+                    {
+                        inventory_id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+                        host: 'sat-host',
+                        status: 'success',
+                        run: { id: 'dispatcher-run-sat' }
+                    },
+                    {
+                        inventory_id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+                        host: 'sat-host2',
+                        status: 'failure',
+                        run: { id: 'dispatcher-run-sat' }
+                    }
+                ],
+                meta: { count: 3 }
+            });
+
+            const dispatcherRuns = {
+                data: [
+                    {
+                        id: 'dispatcher-run-direct',
+                        labels: { 'playbook-run': playbookRunId },
+                        url: 'http://direct',
+                        updated_at: '2023-10-01T12:00:00.000Z',
+                        status: 'success'
+                    },
+                    {
+                        id: 'dispatcher-run-sat',
+                        labels: { 'playbook-run': playbookRunId },
+                        url: 'http://sat',
+                        updated_at: '2023-10-01T13:00:00.000Z',
+                        status: 'success'
+                    }
+                ]
+            };
+
+            base.sandbox.stub(fifi, 'getRHCRuns').resolves(dispatcherRuns);
+
+            const remediation = {
+                iteration: 0,
+                playbook_runs: [{ id: playbookRunId, executors: [] }]
+            };
+
+            await fifi.combineRuns(remediation);
+
+            fetchHostsStub.callCount.should.equal(1);
+            const executors = remediation.playbook_runs[0].executors;
+            executors.should.have.length(2);
+            const direct = executors.find(e => e.executor_name === 'Direct connected');
+            const sat = executors.find(e => e.executor_name === 'RHC Satellite');
+            direct.should.exist;
+            direct.system_count.should.equal(1);
+            sat.should.exist;
+            sat.system_count.should.equal(2);
+            sat.count_success.should.equal(1);
+            sat.count_failure.should.equal(1);
+        });
+    });
+
     describe('formatRHCHostDetails', function () {
         test('should use display_name as system_name when available', async () => {
             // Mock system details with display_name available

--- a/src/remediations/read.integration.js
+++ b/src/remediations/read.integration.js
@@ -530,6 +530,19 @@ describe('remediations', function () {
                     
                     // Use transaction for atomic setup
                     await db.s.transaction(async (transaction) => {
+                        // r249 (FiFI playbook 3): stray dispatcher_runs on any of its playbook runs change
+                        // aggregate status vs seeded expectations — clear them before applying isolated fixtures.
+                        await db.dispatcher_runs.destroy({
+                            where: {
+                                remediations_run_id: [
+                                    '31a70e85-378a-4436-96e9-677cd6fba660',
+                                    '88d0ba73-0015-4e7d-a6d6-4b530cbfb5bc'
+                                ]
+                            },
+                            force: true,
+                            transaction
+                        });
+
                         // Clean up any existing dispatcher runs and playbook_runs for our test
                         await db.dispatcher_runs.destroy({
                             where: { 
@@ -604,8 +617,8 @@ describe('remediations', function () {
                     
                     // Verify data was created correctly
                     const createdRuns = await db.dispatcher_runs.findAll({
-                        where: { 
-                            dispatcher_run_id: isolatedDispatcherRunIds 
+                        where: {
+                            dispatcher_run_id: isolatedDispatcherRunIds.slice(0, 3)
                         },
                         attributes: ['dispatcher_run_id', 'remediations_run_id', 'status']
                     });
@@ -621,22 +634,20 @@ describe('remediations', function () {
                 });
 
                 afterEach(async () => {
-                    // Clean up by dispatcher_run_id to ensure we only remove our test data
-                    await db.dispatcher_runs.destroy({
-                        where: { 
-                            dispatcher_run_id: isolatedDispatcherRunIds.filter(id => id.length < 36) // Only dispatcher_run_ids
-                        },
-                        force: true
-                    });
-                    
-                    // Clean up any playbook_runs we created
-                    await db.playbook_runs.destroy({
-                        where: {
-                            id: isolatedDispatcherRunIds.filter(id => id.length === 36) // Only playbook_run_ids (UUIDs)
-                        },
-                        force: true
-                    });
-                    
+                    const dispatcherIds = isolatedDispatcherRunIds.slice(0, 3);
+                    const playbookRunId = isolatedDispatcherRunIds[3];
+                    if (dispatcherIds.length) {
+                        await db.dispatcher_runs.destroy({
+                            where: { dispatcher_run_id: dispatcherIds },
+                            force: true
+                        });
+                    }
+                    if (playbookRunId) {
+                        await db.playbook_runs.destroy({
+                            where: { id: playbookRunId },
+                            force: true
+                        });
+                    }
                     isolatedDispatcherRunIds = [];
                 });
 


### PR DESCRIPTION
## Endpoints that use this function
- GET /remediations/{id}/playbook_runs
- GET /remediations/{id}/playbook_runs/{playbook_run_id}
- GET /remediations?fields=playbook_runs
- GET /remediations?fields=last_playbook_run

## Summary by Sourcery

Batch run host retrieval in RHC run formatting to reduce duplicate dispatcher calls.

Enhancements:
- Change RHC run formatting to fetch all hosts for a playbook run in a single dispatcher call and group them by run id before aggregating executor statistics.

Tests:
- Add unit coverage for combining dispatcher runs to ensure hosts are fetched once per playbook run and executor counts are correctly aggregated.