### PR TITLE
RHINENG-4887: Clean up and optimize getRunHostDetails (one run_hosts query)

### DIFF
--- a/src/remediations/fifi.js
+++ b/src/remediations/fifi.js
@@ -25,7 +25,7 @@ const MIN_SAT_RHC_VERSION = [6, 11, 0];
 const SYSTEM_FIELDS = Object.freeze(['id', 'ansible_host', 'hostname', 'display_name', 'rhc_client']);
 
 const RUNSFIELDS = Object.freeze({fields: {data: ['id', 'labels', 'status', 'service', 'created_at', 'updated_at', 'url']}});
-const RUNHOSTFIELDS = Object.freeze({fields: {data: ['host', 'stdout', 'inventory_id']}});
+const RUNHOSTFIELDS = Object.freeze({fields: {data: ['host', 'stdout', 'inventory_id', 'run']}});
 const RHCRUNFIELDS = Object.freeze({fields: {data: ['host', 'status', 'inventory_id', 'run']}});
 const RHCSTATUSES = ['timeout', 'failure', 'success', 'running', 'canceled'];
 
@@ -341,52 +341,42 @@ exports.getRHCRuns = async function (playbook_run_id = null) {
 
 exports.getRunHostDetails = async function (playbook_run_id, system_id) {
     trace.enter('fifi.getRunHostDetails');
-    // So... given the remediations playbook_run_id and a system_id find the matching
-    // dispatcher run_hosts entry.  /dispatcher/runs?playbook_run_id will return an
-    // entry for every RHC-direct host that was part of the playbook run, and one for
-    // each <satellite,org> with one or more systems.  We need the *dispatcher* run_id
-    // and the system_id to query dispatcher run_hosts...
+    // Fetch the run_host for the given playbook_run_id and system_id
+    const runHostsFilter = createDispatcherRunHostsFilter(playbook_run_id, null, system_id);
+    trace.event(`fetch playbook-dispatcher/v1/run_hosts with filter: ${JSON.stringify(runHostsFilter)}`);
+    const rhcRunHosts = await dispatcher.fetchPlaybookRunHosts(runHostsFilter, RUNHOSTFIELDS);
+    trace.event(`playbook-dispatcher/v1/run_hosts returned: ${JSON.stringify(rhcRunHosts)}`);
 
-    const runsFilter = createDispatcherRunsFilter(playbook_run_id);
-    trace.event(`fetch playbook-dispatcher/v1/runs with filter: ${JSON.stringify(runsFilter)}`);
-    const rhcRuns = await dispatcher.fetchPlaybookRuns(runsFilter, RUNSFIELDS);
-    trace.event(`playbook-dispatcher returned: ${JSON.stringify(rhcRuns)}`);
-
-    if (!rhcRuns || !rhcRuns.data) {
-        trace.leave('playbook-dispatcher returned nothing useful!');
-        return null; // didn't find any dispatcher runs for playbook_run_id...
+    // rhcRunHosts will always have one row for the given playbook_run_id and system_id
+    // For direct: one dispatcher run per host 
+    // For satellite: many systems can share one dispatcher run but each system will still
+    // have its own run_host (same run.id, different inventory_id)
+    const dispatcherRunId = rhcRunHosts?.data?.[0]?.run?.id;
+    if (!dispatcherRunId) {
+        trace.leave(rhcRunHosts?.data?.length ? 'run_hosts row missing run.id' : 'data for system not found');
+        return null;
     }
 
-    // TODO: Don't do this; it's really inefficient.  Determine the
-    //  playbook-dispatcher run_id for this host/playbook run and fetch the
-    //  results that way.
-
-    // For each dispatcher run in rhcRuns
-    //   get run_hosts for this run_id and system_id
-    //   return the first match found
-
-    for (const run of rhcRuns.data) {
-        const runHostsFilter = createDispatcherRunHostsFilter(playbook_run_id, run.id, system_id);
-        trace.event(`fetch playbook-dispatcher/v1/run_hosts with filter: ${JSON.stringify(runHostsFilter)}`);
-        const rhcRunHosts = await dispatcher.fetchPlaybookRunHosts(runHostsFilter, RUNHOSTFIELDS)
-        trace.event(`playbook-dispatcher/v1/run_hosts returned: ${JSON.stringify(rhcRunHosts)}`);
-
-        if (!rhcRunHosts || !rhcRunHosts.data) {
-            trace.event('No data for host in this run - continuing...');
-            continue; // didn't find any runHosts for dispatcher_run_id + system_id...
+    // Try to find the dispatcher run in the local dispatcher_runs table
+    let run = await queries.getDispatcherRunForPlaybookRun(playbook_run_id, dispatcherRunId);
+    if (!run) {
+        trace.event(`dispatcher_runs miss for dispatcher_run_id=${dispatcherRunId}; fetch playbook-dispatcher/v1/runs`);
+        // If we couldn't find the dispatcher run in the local dispatcher_runs table, fetch it from playbook-dispatcher
+        const rhcRuns = await exports.getRHCRuns(playbook_run_id);
+        trace.event(`playbook-dispatcher returned: ${JSON.stringify(rhcRuns)}`);
+        // Find the dispatcher run that has id == dispatcherRunId
+        run = _.find(rhcRuns?.data, { id: dispatcherRunId });
+        if (!run) {
+            trace.leave('dispatcher run not found for run_host');
+            return null;
         }
-
-        if (rhcRunHosts.data) {
-            // there should only ever be one run_hosts entry for a given system_id in a
-            // dispatcher run, right?  Just grab the first entry...
-            const result = await exports.formatRHCHostDetails(run, rhcRunHosts, playbook_run_id);
-            trace.leave(`Found a match - returning: ${JSON.stringify(result)}`);
-            return result;
-        }
+    } else {
+        trace.event(`dispatcher_runs hit for dispatcher_run_id=${dispatcherRunId}`);
     }
 
-    trace.leave('data for system not found');
-    return null; // didn't find any systems...
+    const result = await exports.formatRHCHostDetails(run, rhcRunHosts, playbook_run_id);
+    trace.leave(`Found a match - returning: ${JSON.stringify(result)}`);
+    return result;
 };
 
 exports.combineHosts = async function (rhcRunHosts, systems, playbook_run_id, filter_hostname = null) {

--- a/src/remediations/fifi.unit.js
+++ b/src/remediations/fifi.unit.js
@@ -513,4 +513,86 @@ describe('formatRunHosts and formatRHCHostDetails', function () {
             result.should.have.property('status', 'failure'); // timeout mapped to failure
         });
     });
+
+    describe('getRunHostDetails', function () {
+        const prId = '8ff5717a-cce8-4738-907b-a89eaa559275';
+        const inventoryId = 'c8aea8e7-cce7-4d2c-b45c-97408158fa44';
+        const dispatcherRunId = '14cdbad8-94e7-44ba-bff3-ba365bc3184a';
+
+        test('calls fetchPlaybookRunHosts then fetchPlaybookRuns when dispatcher_runs row is missing', async () => {
+            const fetchHosts = base.sandbox.stub(dispatcher, 'fetchPlaybookRunHosts').resolves({
+                data: [{
+                    inventory_id: inventoryId,
+                    host: 'localhost',
+                    stdout: 'log',
+                    run: { id: dispatcherRunId }
+                }]
+            });
+            const fetchRuns = base.sandbox.stub(dispatcher, 'fetchPlaybookRuns').resolves({
+                data: [{
+                    id: dispatcherRunId,
+                    status: 'running',
+                    updated_at: '2024-09-10T22:00:01.000Z',
+                    url: 'https://example.com/p'
+                }]
+            });
+            base.sandbox.stub(queries, 'getDispatcherRunForPlaybookRun').resolves(null);
+            getPlanSystemsDetailsStub.resolves({
+                [inventoryId]: { display_name: 'Sys', hostname: 'h.example.com' }
+            });
+
+            const result = await fifi.getRunHostDetails(prId, inventoryId);
+
+            result.should.have.property('system_id', inventoryId);
+            fetchHosts.callCount.should.equal(1);
+            fetchRuns.callCount.should.equal(1);
+        });
+
+        test('uses dispatcher_runs and skips fetchPlaybookRuns when row exists', async () => {
+            base.sandbox.stub(dispatcher, 'fetchPlaybookRunHosts').resolves({
+                data: [{
+                    inventory_id: inventoryId,
+                    host: 'localhost',
+                    stdout: 'log',
+                    run: { id: dispatcherRunId }
+                }]
+            });
+            const fetchRuns = base.sandbox.stub(dispatcher, 'fetchPlaybookRuns');
+            base.sandbox.stub(queries, 'getDispatcherRunForPlaybookRun').resolves({
+                status: 'success',
+                updated_at: new Date('2024-09-10T22:00:01.000Z')
+            });
+            getPlanSystemsDetailsStub.resolves({
+                [inventoryId]: { display_name: 'Sys', hostname: 'h.example.com' }
+            });
+
+            const result = await fifi.getRunHostDetails(prId, inventoryId);
+
+            result.should.have.property('system_id', inventoryId);
+            result.should.have.property('status', 'success');
+            fetchRuns.called.should.be.false();
+        });
+
+        test('returns null when run_hosts is empty and does not call fetchPlaybookRuns', async () => {
+            base.sandbox.stub(dispatcher, 'fetchPlaybookRunHosts').resolves({ data: [] });
+            const fetchRuns = base.sandbox.stub(dispatcher, 'fetchPlaybookRuns');
+
+            const result = await fifi.getRunHostDetails(prId, inventoryId);
+
+            (result === null).should.be.true();
+            fetchRuns.called.should.be.false();
+        });
+
+        test('returns null when run_hosts row has no run.id', async () => {
+            base.sandbox.stub(dispatcher, 'fetchPlaybookRunHosts').resolves({
+                data: [{ inventory_id: inventoryId, host: 'localhost', stdout: '' }]
+            });
+            const fetchRuns = base.sandbox.stub(dispatcher, 'fetchPlaybookRuns');
+
+            const result = await fifi.getRunHostDetails(prId, inventoryId);
+
+            (result === null).should.be.true();
+            fetchRuns.called.should.be.false();
+        });
+    });
 });

--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -869,6 +869,20 @@ exports.updateDispatcherRuns = async function (dispatcherRunId, remediationsRunI
     );
 };
 
+/**
+ * Status and timestamps for a dispatcher run when we already know its id (e.g. from run_hosts).
+ */
+exports.getDispatcherRunForPlaybookRun = async function (remediations_run_id, dispatcher_run_id) {
+    const row = await db.dispatcher_runs.findOne({
+        where: { remediations_run_id, dispatcher_run_id },
+        attributes: ['status', 'updated_at']
+    });
+    if (!row) {
+        return null;
+    }
+    return { status: row.status, updated_at: row.updated_at };
+};
+
 exports.getPlaybookRunsWithDispatcherCounts = async function (playbookRunIds) {
     return db.playbook_runs.findAll({
         where: {


### PR DESCRIPTION
## Extra summary explaining the refactoring/improvements 
How `getRunHostDetails` used to work:
1. Call `GET /v1/runs` using playbook-run label → all dispatcher runs for that remediation playbook run (could be dozens or hundreds)
2. Loop through each dispatcher run
3. For each dispatcher run, call `GET /v1/run_hosts` with playbook-run + run.id + inventory_id
4. If there's no data... that means there was no match for that playbook-run + run.id + inventory_id so keep looking... 
5. When you finally hit a match(`data` is not empty), you know that's the dispatcher run for that system
6. `formatRHCHostDetails(fullRun, rhcRunHosts, playbook_run_id)`

Performance before: 
- `GET /v1/run_hosts` - O(N)
In the worst case we had to call it once per dispatcher run until one returned a row for that system.
- `GET /v1/runs` - O(1)
We called it once, but that single response listed every dispatcher run for the playbook. 

New `getRunHostDetails` after this PR: 
1. Call `GET /v1/run_hosts` endpoint with playbook-run (remediation playbook_run_id) + inventory_id → at most one row; nested run.id is the dispatcher run id for that host
2. Read `dispatcherRunId` from `data[0].run.id`. If it’s missing, return `null` (no /runs call).
3. Check the local `dispatcher_runs` table for the dispatcher run (remediations_run_id = playbook_run_id, dispatcher_run_id = dispatcherRunId) 
4. If that row is missing (e.g. not synced yet), fallback: call `GET /v1/runs` with the playbook-run label, then `_.find` the dispatcher run whose id equals `dispatcherRunId`.
5. ` formatRHCHostDetails(fullRun, rhcRunHosts, playbook_run_id)`

Performance after: 
- `GET /v1/run_hosts` - O(1) - One request per lookup, filtered by playbook-run label and inventory_id. The response supplies the per-host payload (e.g. console output) and the nested run.id, which is the dispatcher run id for that host.
- `dispatcher_runs` (database) - Primary source for run-level fields needed for the API response. This avoids listing all dispatcher runs for the playbook when the row exists.
- `GET /v1/runs` (fallback) - O(1) - Used only when no dispatcher_runs row is found (e.g. not synced yet). 


## Summary by Sourcery

Optimize retrieval of run host details for a playbook run by querying run_hosts once per request and simplifying dispatcher run lookup.

Bug Fixes:
- Handle cases where run_hosts returns no data or entries missing run.id by returning null without querying dispatcher runs.

Enhancements:
- Include dispatcher run reference in run_host field selection to avoid multiple run_hosts queries.
- Refactor getRunHostDetails to derive the dispatcher run from run_hosts and then fetch the corresponding run record once.
- Improve tracing messages for clearer diagnostics around run_hosts and run lookups.

Tests:
- Add unit tests covering successful host detail retrieval and edge cases where run_hosts is empty or missing run.id.