### PR TITLE
RHINENG-26058: Add systems table fallback back in systems queries

### DIFF
--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -535,6 +535,27 @@ exports.getIssueSystems = function (id, tenant_org_id, created_by, issueId) {
     });
 };
 
+// Fetch missing system details from inventory service and store in systems table
+async function fetch_missing_system_data(missingIds) {
+    // just being diligent and validating our input parameters...
+    if (missingIds.length === 0) {
+        return;
+    }
+
+    const systemDetails = await inventory.getSystemDetailsBatch(missingIds);
+    const remediationSystems = Object.values(systemDetails).map(system => ({
+        id: system.id,
+        hostname: system.hostname || null,
+        display_name: system.display_name || null,
+        ansible_hostname: system.ansible_host || null
+    }));
+
+    if (remediationSystems.length > 0) {
+        await db.systems.bulkCreate(remediationSystems, {
+            updateOnDuplicate: ['hostname', 'display_name', 'ansible_hostname', 'updated_at']
+        });
+    }
+}
 
 // Return a paginated, sorted list of distinct systems for a remediation plan
 exports.getPlanSystems = async function (
@@ -572,6 +593,19 @@ exports.getPlanSystems = async function (
     if (distinctSystemIds.length === 0) {
         return { count: 0, rows: [] };
     }
+
+    // If there are systems that don't exist in the systems table yet,
+    // fall back to calling Inventory to retrieve and store system info first
+    const existingSystems = await db.systems.findAll({
+        attributes: ['id'],
+        where: { id: { [Op.in]: distinctSystemIds } },
+        raw: true
+    });
+    const existingIds = _.map(existingSystems, 'id');
+    const missingIds = _.difference(distinctSystemIds, existingIds);
+
+    // If there are missing systems, fetch their details from inventory service
+    await fetch_missing_system_data(missingIds);
 
     const where = { [Op.and]: [{ id: { [Op.in]: distinctSystemIds } }] };
 
@@ -689,6 +723,18 @@ exports.getPlanSystemsDetails = async function (inventoryIds, chunkSize = 50) {
     if (!inventoryIds || inventoryIds.length === 0) {
         return {};
     }
+
+    // Check which systems already exist in the systems table
+    const existingSystems = await db.systems.findAll({
+        attributes: ['id'],
+        where: { id: inventoryIds },
+        raw: true
+    });
+    const existingIds = existingSystems.map(s => s.id);
+    const missingIds = _.difference(inventoryIds, existingIds);
+
+    // Fetch missing system details from inventory service and store them
+    await fetch_missing_system_data(missingIds);
 
     const result = {};
 

--- a/src/remediations/remediations.queries.unit.js
+++ b/src/remediations/remediations.queries.unit.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const base = require('../test');
-const {v4: uuid} = require('uuid');
 const queries = require('./remediations.queries');
 const db = require('../db');
+const inventory = require('../connectors/inventory');
 
 describe('getPlanSystemsDetails', function () {
     const system1Id = 'f6b7a1c2-3d4e-5f6a-7b8c-9d0e1f2a3b4c';
@@ -13,32 +13,44 @@ describe('getPlanSystemsDetails', function () {
     const missingSystemId = '00000000-0000-0000-0000-000000000000';
 
     let dbSystemsFindAllStub;
+    let dbSystemsBulkCreateStub;
+    let inventoryGetSystemDetailsBatchStub;
 
     beforeEach(() => {
         dbSystemsFindAllStub = base.sandbox.stub(db.systems, 'findAll');
+        dbSystemsBulkCreateStub = base.sandbox.stub(db.systems, 'bulkCreate');
+        inventoryGetSystemDetailsBatchStub = base.sandbox.stub(inventory, 'getSystemDetailsBatch');
     });
 
     test('should return empty object for empty input', async () => {
         const result = await queries.getPlanSystemsDetails([]);
         result.should.deepEqual({});
-        
+
         // No database calls should be made
         dbSystemsFindAllStub.should.not.have.been.called;
+        inventoryGetSystemDetailsBatchStub.should.not.have.been.called;
     });
 
     test('should return empty object for null input', async () => {
         const result = await queries.getPlanSystemsDetails(null);
         result.should.deepEqual({});
-        
+
         // No database calls should be made
         dbSystemsFindAllStub.should.not.have.been.called;
+        inventoryGetSystemDetailsBatchStub.should.not.have.been.called;
     });
 
-    test('should fetch system details from database', async () => {
+    test('should fetch system details from database when all systems exist', async () => {
         const inventoryIds = [system1Id, system2Id];
-        
-        // Mock system details fetch from database  
-        dbSystemsFindAllStub.resolves([
+
+        // Mock existing systems check - all systems exist
+        dbSystemsFindAllStub.onFirstCall().resolves([
+            { id: system1Id },
+            { id: system2Id }
+        ]);
+
+        // Mock system details fetch from database
+        dbSystemsFindAllStub.onSecondCall().resolves([
             {
                 id: system1Id,
                 hostname: 'server1.example.com',
@@ -47,7 +59,7 @@ describe('getPlanSystemsDetails', function () {
             },
             {
                 id: system2Id,
-                hostname: 'server2.example.com', 
+                hostname: 'server2.example.com',
                 ansible_hostname: 'ansible2',
                 display_name: 'Server 2'
             }
@@ -63,20 +75,92 @@ describe('getPlanSystemsDetails', function () {
             },
             [system2Id]: {
                 hostname: 'server2.example.com',
-                ansible_hostname: 'ansible2', 
+                ansible_hostname: 'ansible2',
                 display_name: 'Server 2'
             }
         });
 
-        // Should call database once
-        dbSystemsFindAllStub.should.have.been.calledOnce;
+        // Should not call inventory service since all systems exist
+        inventoryGetSystemDetailsBatchStub.should.not.have.been.called;
+        dbSystemsBulkCreateStub.should.not.have.been.called;
     });
 
-    test('should handle systems not found in database with fallback values', async () => {
+    test('should fetch missing systems from inventory service', async () => {
         const inventoryIds = [system1Id, missingSystemId];
-        
-        // Mock system details fetch - only system1 found in database
-        dbSystemsFindAllStub.resolves([
+
+        // Mock existing systems check - only system1 exists
+        dbSystemsFindAllStub.onFirstCall().resolves([
+            { id: system1Id }
+        ]);
+
+        // Mock inventory service response for missing system
+        inventoryGetSystemDetailsBatchStub.resolves({
+            [missingSystemId]: {
+                id: missingSystemId,
+                hostname: 'missing-server.example.com',
+                display_name: 'Missing Server',
+                ansible_host: 'missing-ansible'
+            }
+        });
+
+        // Mock system details fetch after inventory call
+        dbSystemsFindAllStub.onSecondCall().resolves([
+            {
+                id: system1Id,
+                hostname: 'server1.example.com',
+                ansible_hostname: 'ansible1',
+                display_name: 'Server 1'
+            },
+            {
+                id: missingSystemId,
+                hostname: 'missing-server.example.com',
+                ansible_hostname: 'missing-ansible',
+                display_name: 'Missing Server'
+            }
+        ]);
+
+        const result = await queries.getPlanSystemsDetails(inventoryIds);
+
+        result.should.deepEqual({
+            [system1Id]: {
+                hostname: 'server1.example.com',
+                ansible_hostname: 'ansible1',
+                display_name: 'Server 1'
+            },
+            [missingSystemId]: {
+                hostname: 'missing-server.example.com',
+                ansible_hostname: 'missing-ansible',
+                display_name: 'Missing Server'
+            }
+        });
+
+        // Should call inventory service for missing system
+        inventoryGetSystemDetailsBatchStub.calledOnceWith([missingSystemId]).should.equal(true);
+
+        // Should bulk create missing system in database
+        dbSystemsBulkCreateStub.calledOnceWith([{
+            id: missingSystemId,
+            hostname: 'missing-server.example.com',
+            display_name: 'Missing Server',
+            ansible_hostname: 'missing-ansible'
+        }], {
+            updateOnDuplicate: ['hostname', 'display_name', 'ansible_hostname', 'updated_at']
+        }).should.equal(true);
+    });
+
+    test('should handle systems not found anywhere with fallback values', async () => {
+        const inventoryIds = [system1Id, missingSystemId];
+
+        // Mock existing systems check - only system1 exists
+        dbSystemsFindAllStub.onFirstCall().resolves([
+            { id: system1Id }
+        ]);
+
+        // Mock inventory service returns empty (system not found)
+        inventoryGetSystemDetailsBatchStub.resolves({});
+
+        // Mock system details fetch - still only system1 found
+        dbSystemsFindAllStub.onSecondCall().resolves([
             {
                 id: system1Id,
                 hostname: 'server1.example.com',
@@ -100,16 +184,27 @@ describe('getPlanSystemsDetails', function () {
             }
         });
 
-        // Should call database once
-        dbSystemsFindAllStub.should.have.been.calledOnce;
+        // Should try inventory service but system wasn't found
+        inventoryGetSystemDetailsBatchStub.calledOnceWith([missingSystemId]).should.equal(true);
+
+        // Should not bulk create since no systems returned from inventory
+        dbSystemsBulkCreateStub.called.should.equal(false);
     });
 
     test('should handle chunking with custom chunk size', async () => {
         const inventoryIds = [system1Id, system2Id, system3Id, system4Id];
         const chunkSize = 2; // Force chunking
-        
-        // Mock system details fetch for first chunk
+
+        // Mock existing systems check - all systems exist
         dbSystemsFindAllStub.onFirstCall().resolves([
+            { id: system1Id },
+            { id: system2Id },
+            { id: system3Id },
+            { id: system4Id }
+        ]);
+
+        // Mock system details fetch for first chunk
+        dbSystemsFindAllStub.onSecondCall().resolves([
             {
                 id: system1Id,
                 hostname: 'server1.example.com',
@@ -125,7 +220,7 @@ describe('getPlanSystemsDetails', function () {
         ]);
 
         // Mock system details fetch for second chunk
-        dbSystemsFindAllStub.onSecondCall().resolves([
+        dbSystemsFindAllStub.onThirdCall().resolves([
             {
                 id: system3Id,
                 hostname: 'server3.example.com',
@@ -165,31 +260,64 @@ describe('getPlanSystemsDetails', function () {
             }
         });
 
-        // Should make 2 database calls (one per chunk)
-        dbSystemsFindAllStub.should.have.been.calledTwice;
-        
+        // Should make 3 database calls total (1 for existing check + 2 chunks)
+        dbSystemsFindAllStub.should.have.been.calledThrice;
+
         // Verify chunk sizes
-        const firstCall = dbSystemsFindAllStub.getCall(0);
         const secondCall = dbSystemsFindAllStub.getCall(1);
-        
-        firstCall.args[0].where.id.should.have.length(2); // First chunk
-        secondCall.args[0].where.id.should.have.length(2);  // Second chunk
+        const thirdCall = dbSystemsFindAllStub.getCall(2);
+
+        secondCall.args[0].where.id.should.have.length(2); // First chunk
+        thirdCall.args[0].where.id.should.have.length(2);  // Second chunk
     });
 
-    test('should handle partial results from database', async () => {
-        const inventoryIds = [system1Id, missingSystemId];
-        
-        // Mock system details fetch - only system1 found in database
-        dbSystemsFindAllStub.resolves([
+    test('should handle mixed scenario with chunking and missing systems', async () => {
+        const inventoryIds = [system1Id, missingSystemId, system3Id];
+        const chunkSize = 2;
+
+        // Mock existing systems check - system1 and system3 exist, missingSystemId doesn't
+        dbSystemsFindAllStub.onFirstCall().resolves([
+            { id: system1Id },
+            { id: system3Id }
+        ]);
+
+        // Mock inventory service response for missing system
+        inventoryGetSystemDetailsBatchStub.resolves({
+            [missingSystemId]: {
+                id: missingSystemId,
+                hostname: 'fetched-missing.example.com',
+                display_name: 'Fetched Missing System',
+                ansible_host: 'fetched-ansible'
+            }
+        });
+
+        // Mock system details fetch for first chunk
+        dbSystemsFindAllStub.onSecondCall().resolves([
             {
                 id: system1Id,
                 hostname: 'server1.example.com',
                 ansible_hostname: 'ansible1',
                 display_name: 'Server 1'
+            },
+            {
+                id: missingSystemId,
+                hostname: 'fetched-missing.example.com',
+                ansible_hostname: 'fetched-ansible',
+                display_name: 'Fetched Missing System'
             }
         ]);
 
-        const result = await queries.getPlanSystemsDetails(inventoryIds);
+        // Mock system details fetch for second chunk
+        dbSystemsFindAllStub.onThirdCall().resolves([
+            {
+                id: system3Id,
+                hostname: 'server3.example.com',
+                ansible_hostname: 'ansible3',
+                display_name: 'Server 3'
+            }
+        ]);
+
+        const result = await queries.getPlanSystemsDetails(inventoryIds, chunkSize);
 
         result.should.deepEqual({
             [system1Id]: {
@@ -198,13 +326,71 @@ describe('getPlanSystemsDetails', function () {
                 display_name: 'Server 1'
             },
             [missingSystemId]: {
+                hostname: 'fetched-missing.example.com',
+                ansible_hostname: 'fetched-ansible',
+                display_name: 'Fetched Missing System'
+            },
+            [system3Id]: {
+                hostname: 'server3.example.com',
+                ansible_hostname: 'ansible3',
+                display_name: 'Server 3'
+            }
+        });
+
+        // Should call inventory service for missing system
+        inventoryGetSystemDetailsBatchStub.calledOnceWith([missingSystemId]).should.equal(true);
+
+        // Should bulk create the fetched system
+        dbSystemsBulkCreateStub.calledOnceWith([{
+            id: missingSystemId,
+            hostname: 'fetched-missing.example.com',
+            display_name: 'Fetched Missing System',
+            ansible_hostname: 'fetched-ansible'
+        }], {
+            updateOnDuplicate: ['hostname', 'display_name', 'ansible_hostname', 'updated_at']
+        }).should.equal(true);
+    });
+
+    test('should handle inventory service returning partial results', async () => {
+        const inventoryIds = [missingSystemId, 'another-missing-uuid'];
+
+        // Mock existing systems check - no systems exist
+        dbSystemsFindAllStub.onFirstCall().resolves([]);
+
+        // Mock inventory service returns only one of the missing systems
+        inventoryGetSystemDetailsBatchStub.resolves({
+            [missingSystemId]: {
+                id: missingSystemId,
+                hostname: 'partially-found.example.com',
+                display_name: 'Partially Found System',
+                ansible_host: 'partially-found-ansible'
+            }
+            // 'another-missing-uuid' not returned by inventory
+        });
+
+        // Mock system details fetch - only the one found in inventory
+        dbSystemsFindAllStub.onSecondCall().resolves([
+            {
+                id: missingSystemId,
+                hostname: 'partially-found.example.com',
+                ansible_hostname: 'partially-found-ansible',
+                display_name: 'Partially Found System'
+            }
+        ]);
+
+        const result = await queries.getPlanSystemsDetails(inventoryIds);
+
+        result.should.deepEqual({
+            [missingSystemId]: {
+                hostname: 'partially-found.example.com',
+                ansible_hostname: 'partially-found-ansible',
+                display_name: 'Partially Found System'
+            },
+            'another-missing-uuid': {
                 hostname: null,
                 ansible_hostname: null,
                 display_name: null
             }
         });
-
-        // Should call database once
-        dbSystemsFindAllStub.should.have.been.calledOnce;
     });
 });


### PR DESCRIPTION
## Summary by Sourcery

Restore and extend the fallback mechanism for remediation plan system queries by populating missing system records from the Inventory service before querying the local systems table.

New Features:
- Add a helper to fetch missing system details from the Inventory service and upsert them into the local systems table for remediation plans.

Bug Fixes:
- Ensure getPlanSystems and getPlanSystemsDetails return data for systems absent from the local systems table by backfilling them from Inventory, with null-based fallbacks when not found anywhere.

Enhancements:
- Expand and refine unit test coverage for getPlanSystemsDetails to cover inventory backfill, chunking behavior, partial and missing results, and to verify database and Inventory interactions.