### PR TITLE
RHINENG-25798: Add expires_at in responses and sort and filter options

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -797,7 +797,7 @@ paths:
         Replaces override values for organization-wide configuration fields (restricted to
         organization admins only).
 
-        Fields omitted from the request body, or set to `null`, revert to the system default (stored as null).
+        Fields omitted from the request body, or set to `null`, revert to the system default.
         To keep an existing override unchanged when updating another field, include that field in the request 
         body with its current override value. To reset all overrides, send an empty object `{}`.
 

--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -1015,6 +1015,8 @@ components:
           - -created_at
           - last_run_at
           - -last_run_at
+          - expires_at
+          - -expires_at
           - name
           - -name
           - system_count
@@ -1053,6 +1055,7 @@ components:
         - updated_after: modified on or after date-time, `filter[updated_after]=2025-03-31T08:19:36.641Z`
         - last_run_after: executed on or after date-time or 'never', `filter[last_run_after]=never` 
         - status: status matching one of [running, success, failure], `filter[status]=failure`
+        - expires_within: plans that expire within N days (expires_at date is on or before now + N days), `filter[expires_within]=30`
       required: false
       schema:
         anyOf:
@@ -1093,6 +1096,12 @@ components:
                   Filter remediations updated on or after this timestamp (ISO 8601 format)
                   Must be a valid ISO 8601 date-time string. Precision should be to the nearest second or millisecond.
                   Example: '2024-09-11T12:00:00Z' or '2024-09-11T12:00:00.123Z'
+              expires_within:
+                type: string
+                pattern: '^[1-9][0-9]*$'
+                description: >
+                  Filter remediation plans that expire within N days (expires_at date is on or before now + N days).
+                  Must be an integer >= 1 (e.g. 30).
       style: deepObject
       explode: true
 
@@ -2323,7 +2332,7 @@ components:
     RemediationDetails:
       type: object
       additionalProperties: false
-      required: [id, name, auto_reboot, created_by, created_at, updated_by, updated_at, archived]
+      required: [id, name, auto_reboot, created_by, created_at, updated_by, updated_at, archived, expires_at]
       properties:
         id:
           $ref: '#/components/schemas/RemediationId'
@@ -2342,6 +2351,8 @@ components:
         updated_by:
           $ref: '#/components/schemas/UserOut'
         updated_at:
+          $ref: '#/components/schemas/DateTime'
+        expires_at:
           $ref: '#/components/schemas/DateTime'
         resolved_count:
           $ref: '#/components/schemas/ResolvedCount'
@@ -2438,7 +2449,7 @@ components:
     RemediationListItem:
       type: object
       additionalProperties: false
-      required: [id, name, created_by, created_at, updated_by, updated_at, issue_count, system_count, resolved_count, needs_reboot, archived]
+      required: [id, name, created_by, created_at, updated_by, updated_at, issue_count, system_count, resolved_count, needs_reboot, archived, expires_at]
       properties:
         id:
           $ref: '#/components/schemas/RemediationId'
@@ -2467,6 +2478,12 @@ components:
           type: string
           format: date-time
           nullable: true
+        expires_at:
+          type: string
+          format: date-time
+          description: >
+            Timestamp when the plan expires: period of time since the plan was last updated or executed, plus the retention period
+            in effect for the organization (custom value or system default).
         playbook_runs:
           type: array
           items:

--- a/src/config/config.controller.js
+++ b/src/config/config.controller.js
@@ -4,6 +4,7 @@ const errors = require('../errors');
 const db = require('../db');
 const config = require('../config');
 const { ValidationError } = require('sequelize');
+const queries = require('../remediations/remediations.queries');
 
 function formatOverridesResponse(orgConfig) {
     const overrides = {};
@@ -154,6 +155,8 @@ exports.putOverrides = errors.async(async function (req, res) {
         }
         throw err;
     }
+
+    await queries.clearOrgConfigCache(tenant_org_id);
 
     // Return the fields that have a custom override value (i.e. not null which means they use the system default)
     return res.json(formatOverridesResponse(orgConfig));

--- a/src/remediations/__snapshots__/read.integration.js.snap
+++ b/src/remediations/__snapshots__/read.integration.js.snap
@@ -304,6 +304,7 @@ exports[`remediations get get remediation 1`] = `
         "last_name": "user"
     },
     "updated_at": "2018-12-04T08:19:36.641Z",
+    "expires_at": "2019-04-03T08:19:36.641Z",
     "needs_reboot": false,
     "resolved_count": 1,
     "issues": [
@@ -355,6 +356,7 @@ exports[`remediations get get remediation with many systems 1`] = `
         "last_name": "user"
     },
     "updated_at": "2018-11-04T04:19:36.641Z",
+    "expires_at": "2019-03-04T04:19:36.641Z",
     "needs_reboot": true,
     "resolved_count": 0,
     "issues": [
@@ -1894,6 +1896,7 @@ exports[`remediations get get remediation with test namespace resolutions 1`] = 
         "last_name": "user"
     },
     "updated_at": "2018-11-04T03:19:36.641Z",
+    "expires_at": "2019-03-04T03:19:36.641Z",
     "needs_reboot": true,
     "resolved_count": 0,
     "issues": [
@@ -1957,6 +1960,7 @@ exports[`remediations get summary format 1`] = `
     "last_name": "user",
     "username": "tuser@redhat.com",
   },
+  "expires_at": "2019-02-01T08:19:36.641Z",
   "id": "66eec356-dd06-4c72-a3b6-ef27d1508a02",
   "issue_count": 6,
   "issue_count_details": {
@@ -2119,7 +2123,8 @@ exports[`remediations list filter basic filter 1`] = `
             "issue_count": 0,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-05T08:19:36.641Z"
         },
         {
             "id": "178cf0c8-35dd-42a3-96d5-7b50f9d211f6",
@@ -2141,7 +2146,8 @@ exports[`remediations list filter basic filter 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": true,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-04T08:19:36.641Z"
         }
     ]
 }"
@@ -2180,7 +2186,8 @@ exports[`remediations list filter empty filter 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": "2024-09-10T22:00:00.000Z"
+            "last_run_at": "2024-09-10T22:00:00.000Z",
+            "expires_at": "2025-01-08T22:00:00.000Z"
         },
         {
             "id": "249f142c-2ae3-4c3f-b2ec-c8c5881f8561",
@@ -2202,7 +2209,8 @@ exports[`remediations list filter empty filter 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": "2024-09-11T12:00:00.000Z"
+            "last_run_at": "2024-09-11T12:00:00.000Z",
+            "expires_at": "2025-01-09T12:00:00.000Z"
         },
         {
             "id": "256ab1d3-58cf-1292-35e6-1a49c8b122d3",
@@ -2224,7 +2232,8 @@ exports[`remediations list filter empty filter 1`] = `
             "issue_count": 0,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-05T08:19:36.641Z"
         },
         {
             "id": "178cf0c8-35dd-42a3-96d5-7b50f9d211f6",
@@ -2246,7 +2255,8 @@ exports[`remediations list filter empty filter 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": true,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-04T08:19:36.641Z"
         },
         {
             "id": "e809526c-56f5-4cd8-a809-93328436ea23",
@@ -2268,7 +2278,8 @@ exports[`remediations list filter empty filter 1`] = `
             "issue_count": 1,
             "resolved_count": 1,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-03T08:19:36.641Z"
         },
         {
             "id": "cbc782e4-e8ae-4807-82ab-505387981d2e",
@@ -2290,7 +2301,8 @@ exports[`remediations list filter empty filter 1`] = `
             "issue_count": 2,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-03-04T08:19:36.641Z"
         },
         {
             "id": "66eec356-dd06-4c72-a3b6-ef27d1508a02",
@@ -2312,7 +2324,8 @@ exports[`remediations list filter empty filter 1`] = `
             "issue_count": 6,
             "resolved_count": 2,
             "archived": true,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-02-01T08:19:36.641Z"
         }
     ]
 }"
@@ -2351,7 +2364,8 @@ exports[`remediations list filter filter case does not matter 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": true,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-04T08:19:36.641Z"
         }
     ]
 }"
@@ -2390,7 +2404,8 @@ exports[`remediations list filter filter matches on name 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": "2024-09-10T22:00:00.000Z"
+            "last_run_at": "2024-09-10T22:00:00.000Z",
+            "expires_at": "2025-01-08T22:00:00.000Z"
         },
         {
             "id": "e809526c-56f5-4cd8-a809-93328436ea23",
@@ -2412,7 +2427,8 @@ exports[`remediations list filter filter matches on name 1`] = `
             "issue_count": 1,
             "resolved_count": 1,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-03T08:19:36.641Z"
         },
         {
             "id": "cbc782e4-e8ae-4807-82ab-505387981d2e",
@@ -2434,7 +2450,8 @@ exports[`remediations list filter filter matches on name 1`] = `
             "issue_count": 2,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-03-04T08:19:36.641Z"
         },
         {
             "id": "66eec356-dd06-4c72-a3b6-ef27d1508a02",
@@ -2456,7 +2473,8 @@ exports[`remediations list filter filter matches on name 1`] = `
             "issue_count": 6,
             "resolved_count": 2,
             "archived": true,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-02-01T08:19:36.641Z"
         }
     ]
 }"
@@ -2495,7 +2513,8 @@ exports[`remediations list filter filter matches on number 1`] = `
             "issue_count": 2,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-03-04T08:19:36.641Z"
         }
     ]
 }"
@@ -2503,29 +2522,29 @@ exports[`remediations list filter filter matches on number 1`] = `
 
 exports[`remediations list filter test new style filters supported options created_after=date/time query no match 1`] = `"{"meta":{"count":0,"total":0},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[]}"`;
 
-exports[`remediations list filter test new style filters supported options created_after=date/time query with match 1`] = `"{"meta":{"count":4,"total":4},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"efe9fd2b-fdbd-4c74-93e7-8c69f1b668f3","name":"status aggregation test","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2024-09-10T11:41:12.221Z","updated_by":{"username":"testStatus","first_name":"Test","last_name":"Status"},"updated_at":"2024-09-10T11:41:12.221Z","needs_reboot":true,"system_count":10,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-10T22:00:00.000Z"},{"id":"249f142c-2ae3-4c3f-b2ec-c8c5881f8561","name":"FiFI playbook 3","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2020-01-23T18:19:36.641Z","updated_by":{"username":"fifi","first_name":"Fi","last_name":"Fi"},"updated_at":"2020-01-23T18:19:36.641Z","needs_reboot":false,"system_count":23,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-11T12:00:00.000Z"},{"id":"256ab1d3-58cf-1292-35e6-1a49c8b122d3","name":"Remediation with zero issues","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2018-12-06T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"updated_at":"2018-12-06T08:19:36.641Z","needs_reboot":false,"system_count":0,"issue_count":0,"resolved_count":0,"archived":false,"last_run_at":null},{"id":"178cf0c8-35dd-42a3-96d5-7b50f9d211f6","name":"Remediation with suppressed reboot","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2018-12-05T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"updated_at":"2018-12-05T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":1,"resolved_count":0,"archived":true,"last_run_at":null}]}"`;
+exports[`remediations list filter test new style filters supported options created_after=date/time query with match 1`] = `"{"meta":{"count":4,"total":4},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"efe9fd2b-fdbd-4c74-93e7-8c69f1b668f3","name":"status aggregation test","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2024-09-10T11:41:12.221Z","updated_by":{"username":"testStatus","first_name":"Test","last_name":"Status"},"updated_at":"2024-09-10T11:41:12.221Z","needs_reboot":true,"system_count":10,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-10T22:00:00.000Z","expires_at":"2025-01-08T22:00:00.000Z"},{"id":"249f142c-2ae3-4c3f-b2ec-c8c5881f8561","name":"FiFI playbook 3","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2020-01-23T18:19:36.641Z","updated_by":{"username":"fifi","first_name":"Fi","last_name":"Fi"},"updated_at":"2020-01-23T18:19:36.641Z","needs_reboot":false,"system_count":23,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-11T12:00:00.000Z","expires_at":"2025-01-09T12:00:00.000Z"},{"id":"256ab1d3-58cf-1292-35e6-1a49c8b122d3","name":"Remediation with zero issues","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2018-12-06T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"updated_at":"2018-12-06T08:19:36.641Z","needs_reboot":false,"system_count":0,"issue_count":0,"resolved_count":0,"archived":false,"last_run_at":null,"expires_at":"2019-04-05T08:19:36.641Z"},{"id":"178cf0c8-35dd-42a3-96d5-7b50f9d211f6","name":"Remediation with suppressed reboot","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2018-12-05T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"updated_at":"2018-12-05T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":1,"resolved_count":0,"archived":true,"last_run_at":null,"expires_at":"2019-04-04T08:19:36.641Z"}]}"`;
 
 exports[`remediations list filter test new style filters supported options last_run_after=date/time query no match 1`] = `"{"meta":{"count":0,"total":0},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[]}"`;
 
-exports[`remediations list filter test new style filters supported options last_run_after=date/time query with match 1`] = `"{"meta":{"count":2,"total":2},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"efe9fd2b-fdbd-4c74-93e7-8c69f1b668f3","name":"status aggregation test","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2024-09-10T11:41:12.221Z","updated_by":{"username":"testStatus","first_name":"Test","last_name":"Status"},"updated_at":"2024-09-10T11:41:12.221Z","needs_reboot":true,"system_count":10,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-10T22:00:00.000Z"},{"id":"249f142c-2ae3-4c3f-b2ec-c8c5881f8561","name":"FiFI playbook 3","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2020-01-23T18:19:36.641Z","updated_by":{"username":"fifi","first_name":"Fi","last_name":"Fi"},"updated_at":"2020-01-23T18:19:36.641Z","needs_reboot":false,"system_count":23,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-11T12:00:00.000Z"}]}"`;
+exports[`remediations list filter test new style filters supported options last_run_after=date/time query with match 1`] = `"{"meta":{"count":2,"total":2},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"efe9fd2b-fdbd-4c74-93e7-8c69f1b668f3","name":"status aggregation test","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2024-09-10T11:41:12.221Z","updated_by":{"username":"testStatus","first_name":"Test","last_name":"Status"},"updated_at":"2024-09-10T11:41:12.221Z","needs_reboot":true,"system_count":10,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-10T22:00:00.000Z","expires_at":"2025-01-08T22:00:00.000Z"},{"id":"249f142c-2ae3-4c3f-b2ec-c8c5881f8561","name":"FiFI playbook 3","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2020-01-23T18:19:36.641Z","updated_by":{"username":"fifi","first_name":"Fi","last_name":"Fi"},"updated_at":"2020-01-23T18:19:36.641Z","needs_reboot":false,"system_count":23,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-11T12:00:00.000Z","expires_at":"2025-01-09T12:00:00.000Z"}]}"`;
 
-exports[`remediations list filter test new style filters supported options last_run_after=never query with match 1`] = `"{"meta":{"count":5,"total":5},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"256ab1d3-58cf-1292-35e6-1a49c8b122d3","name":"Remediation with zero issues","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-12-06T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-12-06T08:19:36.641Z","needs_reboot":false,"system_count":0,"issue_count":0,"resolved_count":0,"archived":false,"last_run_at":null},{"id":"178cf0c8-35dd-42a3-96d5-7b50f9d211f6","name":"Remediation with suppressed reboot","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-12-05T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-12-05T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":1,"resolved_count":0,"archived":true,"last_run_at":null},{"id":"e809526c-56f5-4cd8-a809-93328436ea23","name":"Test3","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-12-04T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-12-04T08:19:36.641Z","needs_reboot":false,"system_count":2,"issue_count":1,"resolved_count":1,"archived":false,"last_run_at":null},{"id":"cbc782e4-e8ae-4807-82ab-505387981d2e","name":"Test2","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-11-04T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-11-04T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":2,"resolved_count":0,"archived":false,"last_run_at":null},{"id":"66eec356-dd06-4c72-a3b6-ef27d1508a02","name":"Test1","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-10-04T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-10-04T08:19:36.641Z","needs_reboot":true,"system_count":2,"issue_count":6,"resolved_count":2,"archived":true,"last_run_at":null}]}"`;
+exports[`remediations list filter test new style filters supported options last_run_after=never query with match 1`] = `"{"meta":{"count":5,"total":5},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"256ab1d3-58cf-1292-35e6-1a49c8b122d3","name":"Remediation with zero issues","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-12-06T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-12-06T08:19:36.641Z","needs_reboot":false,"system_count":0,"issue_count":0,"resolved_count":0,"archived":false,"last_run_at":null,"expires_at":"2019-04-05T08:19:36.641Z"},{"id":"178cf0c8-35dd-42a3-96d5-7b50f9d211f6","name":"Remediation with suppressed reboot","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-12-05T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-12-05T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":1,"resolved_count":0,"archived":true,"last_run_at":null,"expires_at":"2019-04-04T08:19:36.641Z"},{"id":"e809526c-56f5-4cd8-a809-93328436ea23","name":"Test3","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-12-04T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-12-04T08:19:36.641Z","needs_reboot":false,"system_count":2,"issue_count":1,"resolved_count":1,"archived":false,"last_run_at":null,"expires_at":"2019-04-03T08:19:36.641Z"},{"id":"cbc782e4-e8ae-4807-82ab-505387981d2e","name":"Test2","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-11-04T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-11-04T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":2,"resolved_count":0,"archived":false,"last_run_at":null,"expires_at":"2019-03-04T08:19:36.641Z"},{"id":"66eec356-dd06-4c72-a3b6-ef27d1508a02","name":"Test1","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-10-04T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-10-04T08:19:36.641Z","needs_reboot":true,"system_count":2,"issue_count":6,"resolved_count":2,"archived":true,"last_run_at":null,"expires_at":"2019-02-01T08:19:36.641Z"}]}"`;
 
 exports[`remediations list filter test new style filters supported options name and created_after query no match 1`] = `"{"meta":{"count":0,"total":0},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[]}"`;
 
-exports[`remediations list filter test new style filters supported options name and created_after query with match 1`] = `"{"meta":{"count":1,"total":1},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"178cf0c8-35dd-42a3-96d5-7b50f9d211f6","name":"Remediation with suppressed reboot","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-12-05T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-12-05T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":1,"resolved_count":0,"archived":true,"last_run_at":null}]}"`;
+exports[`remediations list filter test new style filters supported options name and created_after query with match 1`] = `"{"meta":{"count":1,"total":1},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"178cf0c8-35dd-42a3-96d5-7b50f9d211f6","name":"Remediation with suppressed reboot","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-12-05T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-12-05T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":1,"resolved_count":0,"archived":true,"last_run_at":null,"expires_at":"2019-04-04T08:19:36.641Z"}]}"`;
 
 exports[`remediations list filter test new style filters supported options name and last_run_after query no match 1`] = `"{"meta":{"count":0,"total":0},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[]}"`;
 
 exports[`remediations list filter test new style filters supported options name query no match 1`] = `"{"meta":{"count":0,"total":0},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[]}"`;
 
-exports[`remediations list filter test new style filters supported options name query with match 1`] = `"{"meta":{"count":1,"total":1},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"178cf0c8-35dd-42a3-96d5-7b50f9d211f6","name":"Remediation with suppressed reboot","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-12-05T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-12-05T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":1,"resolved_count":0,"archived":true,"last_run_at":null}]}"`;
+exports[`remediations list filter test new style filters supported options name query with match 1`] = `"{"meta":{"count":1,"total":1},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"178cf0c8-35dd-42a3-96d5-7b50f9d211f6","name":"Remediation with suppressed reboot","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-12-05T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-12-05T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":1,"resolved_count":0,"archived":true,"last_run_at":null,"expires_at":"2019-04-04T08:19:36.641Z"}]}"`;
 
 exports[`remediations list filter test new style filters supported options updated_after=date/time query no match 1`] = `"{"meta":{"count":0,"total":0},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[]}"`;
 
-exports[`remediations list filter test new style filters supported options updated_after=date/time query with match 1`] = `"{"meta":{"count":4,"total":4},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"efe9fd2b-fdbd-4c74-93e7-8c69f1b668f3","name":"status aggregation test","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2024-09-10T11:41:12.221Z","updated_by":{"username":"testStatus","first_name":"Test","last_name":"Status"},"updated_at":"2024-09-10T11:41:12.221Z","needs_reboot":true,"system_count":10,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-10T22:00:00.000Z"},{"id":"249f142c-2ae3-4c3f-b2ec-c8c5881f8561","name":"FiFI playbook 3","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2020-01-23T18:19:36.641Z","updated_by":{"username":"fifi","first_name":"Fi","last_name":"Fi"},"updated_at":"2020-01-23T18:19:36.641Z","needs_reboot":false,"system_count":23,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-11T12:00:00.000Z"},{"id":"256ab1d3-58cf-1292-35e6-1a49c8b122d3","name":"Remediation with zero issues","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2018-12-06T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"updated_at":"2018-12-06T08:19:36.641Z","needs_reboot":false,"system_count":0,"issue_count":0,"resolved_count":0,"archived":false,"last_run_at":null},{"id":"178cf0c8-35dd-42a3-96d5-7b50f9d211f6","name":"Remediation with suppressed reboot","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2018-12-05T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"updated_at":"2018-12-05T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":1,"resolved_count":0,"archived":true,"last_run_at":null}]}"`;
+exports[`remediations list filter test new style filters supported options updated_after=date/time query with match 1`] = `"{"meta":{"count":4,"total":4},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"efe9fd2b-fdbd-4c74-93e7-8c69f1b668f3","name":"status aggregation test","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2024-09-10T11:41:12.221Z","updated_by":{"username":"testStatus","first_name":"Test","last_name":"Status"},"updated_at":"2024-09-10T11:41:12.221Z","needs_reboot":true,"system_count":10,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-10T22:00:00.000Z","expires_at":"2025-01-08T22:00:00.000Z"},{"id":"249f142c-2ae3-4c3f-b2ec-c8c5881f8561","name":"FiFI playbook 3","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2020-01-23T18:19:36.641Z","updated_by":{"username":"fifi","first_name":"Fi","last_name":"Fi"},"updated_at":"2020-01-23T18:19:36.641Z","needs_reboot":false,"system_count":23,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-11T12:00:00.000Z","expires_at":"2025-01-09T12:00:00.000Z"},{"id":"256ab1d3-58cf-1292-35e6-1a49c8b122d3","name":"Remediation with zero issues","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2018-12-06T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"updated_at":"2018-12-06T08:19:36.641Z","needs_reboot":false,"system_count":0,"issue_count":0,"resolved_count":0,"archived":false,"last_run_at":null,"expires_at":"2019-04-05T08:19:36.641Z"},{"id":"178cf0c8-35dd-42a3-96d5-7b50f9d211f6","name":"Remediation with suppressed reboot","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2018-12-05T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"updated_at":"2018-12-05T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":1,"resolved_count":0,"archived":true,"last_run_at":null,"expires_at":"2019-04-04T08:19:36.641Z"}]}"`;
 
-exports[`remediations list hide archived hide_archived 1`] = `"{"meta":{"count":5,"total":5},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"efe9fd2b-fdbd-4c74-93e7-8c69f1b668f3","name":"status aggregation test","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2024-09-10T11:41:12.221Z","updated_by":{"username":"testStatus","first_name":"Test","last_name":"Status"},"updated_at":"2024-09-10T11:41:12.221Z","needs_reboot":true,"system_count":10,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-10T22:00:00.000Z"},{"id":"249f142c-2ae3-4c3f-b2ec-c8c5881f8561","name":"FiFI playbook 3","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2020-01-23T18:19:36.641Z","updated_by":{"username":"fifi","first_name":"Fi","last_name":"Fi"},"updated_at":"2020-01-23T18:19:36.641Z","needs_reboot":false,"system_count":23,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-11T12:00:00.000Z"},{"id":"256ab1d3-58cf-1292-35e6-1a49c8b122d3","name":"Remediation with zero issues","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2018-12-06T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"updated_at":"2018-12-06T08:19:36.641Z","needs_reboot":false,"system_count":0,"issue_count":0,"resolved_count":0,"archived":false,"last_run_at":null},{"id":"e809526c-56f5-4cd8-a809-93328436ea23","name":"Test3","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2018-12-04T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"updated_at":"2018-12-04T08:19:36.641Z","needs_reboot":false,"system_count":2,"issue_count":1,"resolved_count":1,"archived":false,"last_run_at":null},{"id":"cbc782e4-e8ae-4807-82ab-505387981d2e","name":"Test2","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2018-11-04T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"updated_at":"2018-11-04T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":2,"resolved_count":0,"archived":false,"last_run_at":null}]}"`;
+exports[`remediations list hide archived hide_archived 1`] = `"{"meta":{"count":5,"total":5},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"efe9fd2b-fdbd-4c74-93e7-8c69f1b668f3","name":"status aggregation test","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2024-09-10T11:41:12.221Z","updated_by":{"username":"testStatus","first_name":"Test","last_name":"Status"},"updated_at":"2024-09-10T11:41:12.221Z","needs_reboot":true,"system_count":10,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-10T22:00:00.000Z","expires_at":"2025-01-08T22:00:00.000Z"},{"id":"249f142c-2ae3-4c3f-b2ec-c8c5881f8561","name":"FiFI playbook 3","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2020-01-23T18:19:36.641Z","updated_by":{"username":"fifi","first_name":"Fi","last_name":"Fi"},"updated_at":"2020-01-23T18:19:36.641Z","needs_reboot":false,"system_count":23,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-11T12:00:00.000Z","expires_at":"2025-01-09T12:00:00.000Z"},{"id":"256ab1d3-58cf-1292-35e6-1a49c8b122d3","name":"Remediation with zero issues","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2018-12-06T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"updated_at":"2018-12-06T08:19:36.641Z","needs_reboot":false,"system_count":0,"issue_count":0,"resolved_count":0,"archived":false,"last_run_at":null,"expires_at":"2019-04-05T08:19:36.641Z"},{"id":"e809526c-56f5-4cd8-a809-93328436ea23","name":"Test3","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2018-12-04T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"updated_at":"2018-12-04T08:19:36.641Z","needs_reboot":false,"system_count":2,"issue_count":1,"resolved_count":1,"archived":false,"last_run_at":null,"expires_at":"2019-04-03T08:19:36.641Z"},{"id":"cbc782e4-e8ae-4807-82ab-505387981d2e","name":"Test2","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2018-11-04T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"updated_at":"2018-11-04T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":2,"resolved_count":0,"archived":false,"last_run_at":null,"expires_at":"2019-03-04T08:19:36.641Z"}]}"`;
 
 exports[`remediations list hide archived no query 1`] = `
 "{
@@ -2560,7 +2579,8 @@ exports[`remediations list hide archived no query 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": "2024-09-10T22:00:00.000Z"
+            "last_run_at": "2024-09-10T22:00:00.000Z",
+            "expires_at": "2025-01-08T22:00:00.000Z"
         },
         {
             "id": "249f142c-2ae3-4c3f-b2ec-c8c5881f8561",
@@ -2582,7 +2602,8 @@ exports[`remediations list hide archived no query 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": "2024-09-11T12:00:00.000Z"
+            "last_run_at": "2024-09-11T12:00:00.000Z",
+            "expires_at": "2025-01-09T12:00:00.000Z"
         },
         {
             "id": "256ab1d3-58cf-1292-35e6-1a49c8b122d3",
@@ -2604,7 +2625,8 @@ exports[`remediations list hide archived no query 1`] = `
             "issue_count": 0,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-05T08:19:36.641Z"
         },
         {
             "id": "178cf0c8-35dd-42a3-96d5-7b50f9d211f6",
@@ -2626,7 +2648,8 @@ exports[`remediations list hide archived no query 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": true,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-04T08:19:36.641Z"
         },
         {
             "id": "e809526c-56f5-4cd8-a809-93328436ea23",
@@ -2648,7 +2671,8 @@ exports[`remediations list hide archived no query 1`] = `
             "issue_count": 1,
             "resolved_count": 1,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-03T08:19:36.641Z"
         },
         {
             "id": "cbc782e4-e8ae-4807-82ab-505387981d2e",
@@ -2670,7 +2694,8 @@ exports[`remediations list hide archived no query 1`] = `
             "issue_count": 2,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-03-04T08:19:36.641Z"
         },
         {
             "id": "66eec356-dd06-4c72-a3b6-ef27d1508a02",
@@ -2692,7 +2717,8 @@ exports[`remediations list hide archived no query 1`] = `
             "issue_count": 6,
             "resolved_count": 2,
             "archived": true,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-02-01T08:19:36.641Z"
         }
     ]
 }"
@@ -2731,7 +2757,8 @@ exports[`remediations list list remediations 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": "2024-09-10T22:00:00.000Z"
+            "last_run_at": "2024-09-10T22:00:00.000Z",
+            "expires_at": "2025-01-08T22:00:00.000Z"
         },
         {
             "id": "249f142c-2ae3-4c3f-b2ec-c8c5881f8561",
@@ -2753,7 +2780,8 @@ exports[`remediations list list remediations 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": "2024-09-11T12:00:00.000Z"
+            "last_run_at": "2024-09-11T12:00:00.000Z",
+            "expires_at": "2025-01-09T12:00:00.000Z"
         },
         {
             "id": "256ab1d3-58cf-1292-35e6-1a49c8b122d3",
@@ -2775,7 +2803,8 @@ exports[`remediations list list remediations 1`] = `
             "issue_count": 0,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-05T08:19:36.641Z"
         },
         {
             "id": "178cf0c8-35dd-42a3-96d5-7b50f9d211f6",
@@ -2797,7 +2826,8 @@ exports[`remediations list list remediations 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": true,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-04T08:19:36.641Z"
         },
         {
             "id": "e809526c-56f5-4cd8-a809-93328436ea23",
@@ -2819,7 +2849,8 @@ exports[`remediations list list remediations 1`] = `
             "issue_count": 1,
             "resolved_count": 1,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-03T08:19:36.641Z"
         },
         {
             "id": "cbc782e4-e8ae-4807-82ab-505387981d2e",
@@ -2841,7 +2872,8 @@ exports[`remediations list list remediations 1`] = `
             "issue_count": 2,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-03-04T08:19:36.641Z"
         },
         {
             "id": "66eec356-dd06-4c72-a3b6-ef27d1508a02",
@@ -2863,7 +2895,8 @@ exports[`remediations list list remediations 1`] = `
             "issue_count": 6,
             "resolved_count": 2,
             "archived": true,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-02-01T08:19:36.641Z"
         }
     ]
 }"
@@ -2902,7 +2935,8 @@ exports[`remediations list pagination explicit offset 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": "2024-09-10T22:00:00.000Z"
+            "last_run_at": "2024-09-10T22:00:00.000Z",
+            "expires_at": "2025-01-08T22:00:00.000Z"
         },
         {
             "id": "249f142c-2ae3-4c3f-b2ec-c8c5881f8561",
@@ -2924,7 +2958,8 @@ exports[`remediations list pagination explicit offset 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": "2024-09-11T12:00:00.000Z"
+            "last_run_at": "2024-09-11T12:00:00.000Z",
+            "expires_at": "2025-01-09T12:00:00.000Z"
         }
     ]
 }"
@@ -2963,7 +2998,8 @@ exports[`remediations list pagination offset 1 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": "2024-09-11T12:00:00.000Z"
+            "last_run_at": "2024-09-11T12:00:00.000Z",
+            "expires_at": "2025-01-09T12:00:00.000Z"
         },
         {
             "id": "256ab1d3-58cf-1292-35e6-1a49c8b122d3",
@@ -2985,7 +3021,8 @@ exports[`remediations list pagination offset 1 1`] = `
             "issue_count": 0,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-05T08:19:36.641Z"
         }
     ]
 }"
@@ -3024,7 +3061,8 @@ exports[`remediations list pagination offset 2 1`] = `
             "issue_count": 0,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-05T08:19:36.641Z"
         },
         {
             "id": "178cf0c8-35dd-42a3-96d5-7b50f9d211f6",
@@ -3046,7 +3084,8 @@ exports[`remediations list pagination offset 2 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": true,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-04T08:19:36.641Z"
         }
     ]
 }"
@@ -3085,7 +3124,8 @@ exports[`remediations list pagination offset 3 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": true,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-04T08:19:36.641Z"
         },
         {
             "id": "e809526c-56f5-4cd8-a809-93328436ea23",
@@ -3107,7 +3147,8 @@ exports[`remediations list pagination offset 3 1`] = `
             "issue_count": 1,
             "resolved_count": 1,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-03T08:19:36.641Z"
         }
     ]
 }"
@@ -3146,7 +3187,8 @@ exports[`remediations list pagination tiny page 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": "2024-09-10T22:00:00.000Z"
+            "last_run_at": "2024-09-10T22:00:00.000Z",
+            "expires_at": "2025-01-08T22:00:00.000Z"
         },
         {
             "id": "249f142c-2ae3-4c3f-b2ec-c8c5881f8561",
@@ -3168,7 +3210,8 @@ exports[`remediations list pagination tiny page 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": "2024-09-11T12:00:00.000Z"
+            "last_run_at": "2024-09-11T12:00:00.000Z",
+            "expires_at": "2025-01-09T12:00:00.000Z"
         }
     ]
 }"
@@ -3207,7 +3250,8 @@ exports[`remediations list sorting default 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": "2024-09-10T22:00:00.000Z"
+            "last_run_at": "2024-09-10T22:00:00.000Z",
+            "expires_at": "2025-01-08T22:00:00.000Z"
         },
         {
             "id": "249f142c-2ae3-4c3f-b2ec-c8c5881f8561",
@@ -3229,7 +3273,8 @@ exports[`remediations list sorting default 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": "2024-09-11T12:00:00.000Z"
+            "last_run_at": "2024-09-11T12:00:00.000Z",
+            "expires_at": "2025-01-09T12:00:00.000Z"
         },
         {
             "id": "256ab1d3-58cf-1292-35e6-1a49c8b122d3",
@@ -3251,7 +3296,8 @@ exports[`remediations list sorting default 1`] = `
             "issue_count": 0,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-05T08:19:36.641Z"
         },
         {
             "id": "178cf0c8-35dd-42a3-96d5-7b50f9d211f6",
@@ -3273,7 +3319,8 @@ exports[`remediations list sorting default 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": true,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-04T08:19:36.641Z"
         },
         {
             "id": "e809526c-56f5-4cd8-a809-93328436ea23",
@@ -3295,7 +3342,8 @@ exports[`remediations list sorting default 1`] = `
             "issue_count": 1,
             "resolved_count": 1,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-03T08:19:36.641Z"
         },
         {
             "id": "cbc782e4-e8ae-4807-82ab-505387981d2e",
@@ -3317,7 +3365,8 @@ exports[`remediations list sorting default 1`] = `
             "issue_count": 2,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-03-04T08:19:36.641Z"
         },
         {
             "id": "66eec356-dd06-4c72-a3b6-ef27d1508a02",
@@ -3339,19 +3388,20 @@ exports[`remediations list sorting default 1`] = `
             "issue_count": 6,
             "resolved_count": 2,
             "archived": true,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-02-01T08:19:36.641Z"
         }
     ]
 }"
 `;
 
-exports[`remediations list sorting status tests status and last_run_after query 1`] = `"{"meta":{"count":1,"total":1},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"178cf0c8-35dd-42a3-96d5-7b50f9d211f6","name":"Remediation with suppressed reboot","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-12-05T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-12-05T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":1,"resolved_count":0,"archived":true,"last_run_at":"2019-12-25T08:19:36.641Z"}]}"`;
+exports[`remediations list sorting status tests status and last_run_after query 1`] = `"{"meta":{"count":1,"total":1},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"178cf0c8-35dd-42a3-96d5-7b50f9d211f6","name":"Remediation with suppressed reboot","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-12-05T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-12-05T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":1,"resolved_count":0,"archived":true,"last_run_at":"2019-12-25T08:19:36.641Z","expires_at":"2020-04-23T08:19:36.641Z"}]}"`;
 
-exports[`remediations list sorting status tests status and name query 1`] = `"{"meta":{"count":1,"total":1},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"178cf0c8-35dd-42a3-96d5-7b50f9d211f6","name":"Remediation with suppressed reboot","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-12-05T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-12-05T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":1,"resolved_count":0,"archived":true,"last_run_at":"2019-12-25T08:19:36.641Z"}]}"`;
+exports[`remediations list sorting status tests status and name query 1`] = `"{"meta":{"count":1,"total":1},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"178cf0c8-35dd-42a3-96d5-7b50f9d211f6","name":"Remediation with suppressed reboot","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-12-05T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-12-05T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":1,"resolved_count":0,"archived":true,"last_run_at":"2019-12-25T08:19:36.641Z","expires_at":"2020-04-23T08:19:36.641Z"}]}"`;
 
-exports[`remediations list sorting status tests status query failure 1`] = `"{"meta":{"count":1,"total":1},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"efe9fd2b-fdbd-4c74-93e7-8c69f1b668f3","name":"status aggregation test","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2024-09-10T11:41:12.221Z","updated_by":{"username":"testStatus","first_name":"Test","last_name":"Status"},"updated_at":"2024-09-10T11:41:12.221Z","needs_reboot":true,"system_count":10,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-10T22:00:00.000Z"}]}"`;
+exports[`remediations list sorting status tests status query failure 1`] = `"{"meta":{"count":1,"total":1},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"efe9fd2b-fdbd-4c74-93e7-8c69f1b668f3","name":"status aggregation test","created_by":{"username":"tuser@redhat.com","first_name":"Test","last_name":"User"},"created_at":"2024-09-10T11:41:12.221Z","updated_by":{"username":"testStatus","first_name":"Test","last_name":"Status"},"updated_at":"2024-09-10T11:41:12.221Z","needs_reboot":true,"system_count":10,"issue_count":1,"resolved_count":0,"archived":false,"last_run_at":"2024-09-10T22:00:00.000Z","expires_at":"2025-01-08T22:00:00.000Z"}]}"`;
 
-exports[`remediations list sorting status tests status query running 1`] = `"{"meta":{"count":1,"total":1},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"178cf0c8-35dd-42a3-96d5-7b50f9d211f6","name":"Remediation with suppressed reboot","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-12-05T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-12-05T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":1,"resolved_count":0,"archived":true,"last_run_at":"2019-12-25T08:19:36.641Z"}]}"`;
+exports[`remediations list sorting status tests status query running 1`] = `"{"meta":{"count":1,"total":1},"links":{"first":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","last":"/api/remediations/v1/remediations?sort=-updated_at&limit=50&offset=0","previous":null,"next":null},"data":[{"id":"178cf0c8-35dd-42a3-96d5-7b50f9d211f6","name":"Remediation with suppressed reboot","created_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"created_at":"2018-12-05T08:19:36.641Z","updated_by":{"username":"tuser@redhat.com","first_name":"test","last_name":"user"},"updated_at":"2018-12-05T08:19:36.641Z","needs_reboot":true,"system_count":1,"issue_count":1,"resolved_count":0,"archived":true,"last_run_at":"2019-12-25T08:19:36.641Z","expires_at":"2020-04-23T08:19:36.641Z"}]}"`;
 
 exports[`remediations list system filter filters out remediations not featuring the given system (2) 1`] = `
 "{
@@ -3386,7 +3436,8 @@ exports[`remediations list system filter filters out remediations not featuring 
             "issue_count": 1,
             "resolved_count": 0,
             "archived": true,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-04T08:19:36.641Z"
         },
         {
             "id": "e809526c-56f5-4cd8-a809-93328436ea23",
@@ -3408,7 +3459,8 @@ exports[`remediations list system filter filters out remediations not featuring 
             "issue_count": 1,
             "resolved_count": 1,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-03T08:19:36.641Z"
         },
         {
             "id": "cbc782e4-e8ae-4807-82ab-505387981d2e",
@@ -3430,7 +3482,8 @@ exports[`remediations list system filter filters out remediations not featuring 
             "issue_count": 2,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-03-04T08:19:36.641Z"
         },
         {
             "id": "66eec356-dd06-4c72-a3b6-ef27d1508a02",
@@ -3452,7 +3505,8 @@ exports[`remediations list system filter filters out remediations not featuring 
             "issue_count": 6,
             "resolved_count": 2,
             "archived": true,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-02-01T08:19:36.641Z"
         }
     ]
 }"
@@ -3491,7 +3545,8 @@ exports[`remediations list system filter filters out remediations not featuring 
             "issue_count": 1,
             "resolved_count": 1,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-04-03T08:19:36.641Z"
         },
         {
             "id": "66eec356-dd06-4c72-a3b6-ef27d1508a02",
@@ -3513,7 +3568,8 @@ exports[`remediations list system filter filters out remediations not featuring 
             "issue_count": 6,
             "resolved_count": 2,
             "archived": true,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-02-01T08:19:36.641Z"
         }
     ]
 }"
@@ -3552,7 +3608,8 @@ exports[`remediations missing listing of remediations does not blow up 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-03-04T08:19:36.641Z"
         },
         {
             "id": "27e36e14-e1c2-4b5a-9382-ec80ca9a6c1a",
@@ -3574,7 +3631,8 @@ exports[`remediations missing listing of remediations does not blow up 1`] = `
             "issue_count": 2,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-03-04T07:19:36.641Z"
         },
         {
             "id": "ea5b1507-4cd3-4c87-aa5a-6c755d32a7bd",
@@ -3596,7 +3654,8 @@ exports[`remediations missing listing of remediations does not blow up 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-03-04T06:19:36.641Z"
         },
         {
             "id": "62c95092-ac83-4025-a676-362a67e68579",
@@ -3618,7 +3677,8 @@ exports[`remediations missing listing of remediations does not blow up 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-03-04T05:19:36.641Z"
         },
         {
             "id": "c3f9f751-4bcc-4222-9b83-77f5e6e603da",
@@ -3640,7 +3700,8 @@ exports[`remediations missing listing of remediations does not blow up 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-03-04T04:19:36.641Z"
         },
         {
             "id": "5e6d136e-ea32-46e4-a350-325ef41790f4",
@@ -3662,7 +3723,8 @@ exports[`remediations missing listing of remediations does not blow up 1`] = `
             "issue_count": 2,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-03-04T03:19:36.641Z"
         },
         {
             "id": "7d727f9c-7d9e-458d-a128-a9ffae1802ab",
@@ -3684,7 +3746,8 @@ exports[`remediations missing listing of remediations does not blow up 1`] = `
             "issue_count": 1,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-03-04T03:19:36.641Z"
         },
         {
             "id": "d1b070b5-1db8-4dac-8ecf-891dc1e9225f",
@@ -3706,7 +3769,8 @@ exports[`remediations missing listing of remediations does not blow up 1`] = `
             "issue_count": 0,
             "resolved_count": 0,
             "archived": false,
-            "last_run_at": null
+            "last_run_at": null,
+            "expires_at": "2019-03-04T03:19:36.641Z"
         }
     ]
 }"

--- a/src/remediations/__snapshots__/write.integration.js.snap
+++ b/src/remediations/__snapshots__/write.integration.js.snap
@@ -10,6 +10,7 @@ exports[`remediations delete bulk issues succeeds 1`] = `
     "last_name": "user",
     "username": "testWriteUser",
   },
+  "expires_at": "",
   "id": "",
   "issues": [
     {
@@ -124,6 +125,7 @@ exports[`remediations delete bulk systems does not remove systems from other pla
     "last_name": "user",
     "username": "testWriteUser",
   },
+  "expires_at": "",
   "id": "",
   "issues": [
     {
@@ -277,6 +279,7 @@ exports[`remediations delete bulk systems does not remove systems from other pla
     "last_name": "user",
     "username": "testWriteUser",
   },
+  "expires_at": "",
   "id": "",
   "issues": [
     {
@@ -430,6 +433,7 @@ exports[`remediations delete bulk systems succeeds 1`] = `
     "last_name": "user",
     "username": "testWriteUser",
   },
+  "expires_at": "",
   "id": "",
   "issues": [
     {

--- a/src/remediations/read.integration.js
+++ b/src/remediations/read.integration.js
@@ -517,6 +517,36 @@ describe('remediations', function () {
             testSorting('last_run_at', true, refe, r249, r178, r256, r66e, rcbc, re80);
             testSorting('last_run_at', false, r178, r256, r66e, rcbc, re80, r249, refe);
 
+            test('sort=expires_at orders by expires_at ascending', async () => {
+                const {body} = await request
+                    .get('/v1/remediations?pretty&sort=expires_at')
+                    .expect(200);
+
+                body.data.length.should.be.above(0);
+                body.data.forEach(r => {
+                    expect(r.expires_at).toBeTruthy();
+                    expect(Number.isNaN(Date.parse(r.expires_at))).toBe(false);
+                });
+                const times = body.data.map(r => new Date(r.expires_at).getTime());
+                const sortedAsc = [...times].sort((a, b) => a - b);
+                sortedAsc.should.eql(times);
+            });
+
+            test('sort=-expires_at orders by expires_at descending', async () => {
+                const {body} = await request
+                    .get('/v1/remediations?pretty&sort=-expires_at')
+                    .expect(200);
+
+                body.data.length.should.be.above(0);
+                body.data.forEach(r => {
+                    expect(r.expires_at).toBeTruthy();
+                    expect(Number.isNaN(Date.parse(r.expires_at))).toBe(false);
+                });
+                const times = body.data.map(r => new Date(r.expires_at).getTime());
+                const sortedDesc = [...times].sort((a, b) => b - a);
+                sortedDesc.should.eql(times);
+            });
+
             // Status tests with isolated data setup
             describe('status tests', function () {
                 // Use existing test remediations but create isolated dispatcher_runs 
@@ -710,6 +740,17 @@ describe('remediations', function () {
                     testList('last_run_after=date/time query with match', '/v1/remediations?filter[last_run_after]=2016-12-04T08:19:36.641Z', refe, r249);
                     testList('last_run_after=never query with match', '/v1/remediations?filter[last_run_after]=never', r256, r178, re80, rcbc, r66e);
                     testList('name and last_run_after query no match', '/v1/remediations?filter[last_run_after]=2018-12-04T08:19:36.641Z&filter[name]=REBootNoMatch');
+
+                    test('filter[expires_within] with a large window returns the same plans as an unfiltered list', async () => {
+                        const {body: baseline} = await request
+                            .get('/v1/remediations?pretty')
+                            .expect(200);
+                        const {body} = await request
+                            .get('/v1/remediations?pretty&filter[expires_within]=99999')
+                            .expect(200);
+
+                        _.map(body.data, 'id').should.eql(_.map(baseline.data, 'id'));
+                    });
                 });
 
                 describe('invalid options', function () {
@@ -736,6 +777,18 @@ describe('remediations', function () {
                         '/v1/remediations?filter[status]=timeout',
                         'enum.openapi.requestValidation',
                         'must be equal to one of the allowed values (location: query, path: filter.status)'
+                    );
+                    test400(
+                        'expires_within rejects zero',
+                        '/v1/remediations?filter[expires_within]=0',
+                        'pattern.openapi.requestValidation',
+                        'must match pattern "^[1-9][0-9]*$" (location: query, path: filter.expires_within)'
+                    );
+                    test400(
+                        'expires_within rejects non-numeric value',
+                        '/v1/remediations?filter[expires_within]=notanumber',
+                        'pattern.openapi.requestValidation',
+                        'must match pattern "^[1-9][0-9]*$" (location: query, path: filter.expires_within)'
                     );
                 });
             });
@@ -966,6 +1019,7 @@ describe('remediations', function () {
                     last_name: 'user'
                 },
                 created_at: '2018-12-04T08:19:36.641Z',
+                expires_at: '2019-04-03T08:19:36.641Z',
                 updated_by: {
                     username: 'tuser@redhat.com',
                     first_name: 'test',

--- a/src/remediations/remediations.format.js
+++ b/src/remediations/remediations.format.js
@@ -72,7 +72,7 @@ exports.parseSort = function (param) {
 
 exports.list = function (remediations, total, limit, offset, sort, system) {
     const formatted = _.map(remediations,
-        ({id, name, needs_reboot, created_by, created_at, updated_by, updated_at, system_count, issue_count, resolved_count, archived, last_run_at, playbook_runs}) => ({
+        ({id, name, needs_reboot, created_by, created_at, updated_by, updated_at, system_count, issue_count, resolved_count, archived, last_run_at, expires_at, playbook_runs}) => ({
             id,
             name,
             created_by: _.pick(created_by, USER),
@@ -85,6 +85,7 @@ exports.list = function (remediations, total, limit, offset, sort, system) {
             resolved_count: (resolved_count === null) ? 0 : resolved_count,
             archived,
             last_run_at: last_run_at ? last_run_at.toISOString() : null,
+            expires_at: expires_at ? expires_at.toISOString() : null,
             playbook_runs: (playbook_runs === null) ? [] : playbook_runs
         })
     );
@@ -100,7 +101,7 @@ exports.list = function (remediations, total, limit, offset, sort, system) {
 };
 
 exports.get = function ({id, name, needs_reboot, auto_reboot, created_by, created_at, updated_by, updated_at,
-                            issues, resolved_count, issue_count, issue_count_details, system_count, archived}) {
+                            issues, resolved_count, issue_count, issue_count_details, system_count, archived, expires_at}) {
     const formatted =  {
         id,
         name,
@@ -109,7 +110,8 @@ exports.get = function ({id, name, needs_reboot, auto_reboot, created_by, create
         created_by: _.pick(created_by, USER),
         created_at: created_at.toISOString(),
         updated_by: _.pick(updated_by, USER),
-        updated_at: updated_at.toISOString()
+        updated_at: updated_at.toISOString(),
+        expires_at: expires_at instanceof Date ? expires_at.toISOString() : String(expires_at)
     };
 
     // handle format='detail' items

--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -36,6 +36,30 @@ const PLAYBOOK_RUN_ATTRIBUTES = [
     'updated_at'
 ];
 
+/**
+ * Calculates the expires_at timestamp for a remediation plan
+ * expires_at = last remediation plan activity + org retention period
+ * last remediation plan activity is the last time the plan was updated or executed
+ * org retention period comes is the retention period from org_config or falls back to the default retention period
+ */
+function remediationExpiresAtSql () {
+    const defaultRetentionDays = config.plan_retention.retentionDays;
+
+    const lastActivityTimestamp = `
+        GREATEST(
+            "remediation"."updated_at",
+            (SELECT MAX("pr"."created_at") FROM "playbook_runs" AS "pr" WHERE "pr"."remediation_id" = "remediation"."id")
+        )`;
+
+    const retentionDays = `
+        COALESCE(
+            (SELECT "oc"."plan_retention_days" FROM "org_config" AS "oc" WHERE "oc"."org_id" = "remediation"."tenant_org_id"),
+            ${defaultRetentionDays}
+        )`;
+
+    return `(${lastActivityTimestamp} + (${retentionDays}) * INTERVAL '1 day')`;
+}
+
 function aggregateStatusSQL() {
     return `CASE
         WHEN COUNT(*) FILTER (WHERE "playbook_runs->dispatcher_runs"."status" IN ('failure', 'timeout')) > 0 THEN 'failure'
@@ -126,6 +150,10 @@ exports.list = async function (
             sortOrder.push([literal('MAX(playbook_runs.created_at)'), asc ? 'ASC NULLS LAST' : 'DESC NULLS FIRST']);
             break;
 
+        case 'expires_at':
+            sortOrder.push([literal(remediationExpiresAtSql()), asc ? 'ASC' : 'DESC']);
+            break;
+
         case 'issue_count':
             sortOrder.push([col('issue_count'), asc ? 'ASC' : 'DESC']);
             break;
@@ -147,7 +175,8 @@ exports.list = async function (
             [cast(COUNT(DISTINCT(col('issues.id'))), 'int'), 'issue_count'],
             [cast(COUNT(DISTINCT(col('issues->systems.system_id'))), 'int'), 'system_count'],
             [resolvedCountSubquery(), 'resolved_count'],
-            [MAX(col('playbook_runs.created_at')), 'last_run_at']
+            [MAX(col('playbook_runs.created_at')), 'last_run_at'],
+            [literal(remediationExpiresAtSql()), 'expires_at']
         ],
         include: [{
             attributes: [],
@@ -261,6 +290,18 @@ exports.list = async function (
                 literal(aggregateStatusSQL()), 
                 { [Op.eq]: filter.status }
             );
+        }
+
+        // expires_within filter
+        if (filter.expires_within) {
+            const days = Number(filter.expires_within);
+            query.where[Op.and] = [
+                ...(query.where[Op.and] || []),
+                where(
+                    literal(remediationExpiresAtSql()),
+                    {[Op.lte]: literal(`(NOW() + (${days}::integer * INTERVAL '1 day'))`)}
+                )
+            ];
         }
     }
 
@@ -388,6 +429,8 @@ exports.get = async function (id, tenant_org_id, created_by = null, includeResol
     // Remediation plan changes during a playbook run are undesireable anyway so allow for caching these results
     // to ease the load on the database.
 
+    const {s: {literal}} = db;
+
     const query = {
         attributes: [
             ...REMEDIATION_ATTRIBUTES
@@ -417,6 +460,8 @@ exports.get = async function (id, tenant_org_id, created_by = null, includeResol
             [db.issue, db.issue.associations.systems, 'system_id']
         ]
     };
+
+    query.attributes.push([literal(remediationExpiresAtSql()), 'expires_at']);
 
     if (includeResolvedCount) {
         query.attributes.push([resolvedCountSubquery(), 'resolved_count']);
@@ -497,10 +542,13 @@ exports.get = async function (id, tenant_org_id, created_by = null, includeResol
  * usernames until the controller runs `resolveUsers`.)
  */
 exports.getSummary = async function (id, tenant_org_id, created_by = null) {
-    const { fn, col } = db.s;
+    const { fn, col, literal } = db.s;
 
     const remediation = await db.remediation.findOne({
-        attributes: REMEDIATION_ATTRIBUTES,
+        attributes: [
+            ...REMEDIATION_ATTRIBUTES,
+            [literal(remediationExpiresAtSql()), 'expires_at']
+        ],
         where: {
             id,
             tenant_org_id,
@@ -1067,3 +1115,5 @@ exports.getPlaybookRunsWithDispatcherCounts = async function (playbookRunIds) {
         raw: true
     });
 };
+
+exports.remediationExpiresAtSql = remediationExpiresAtSql;

--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -8,6 +8,7 @@ const db = require('../db');
 const inventory = require('../connectors/inventory');
 const {NULL_NAME_VALUE} = require('./models/remediation');
 const _ = require('lodash');
+const log = require('../util/log');
 const trace = require('../util/trace');
 const dispatcher = require('../connectors/dispatcher');
 const fifi2 = require('./fifi_2');
@@ -43,9 +44,13 @@ const PLAYBOOK_RUN_ATTRIBUTES = [
  */
 async function getEffectiveRetentionDays(tenant_org_id) {
     if (config.redis.enabled && cache.get().status === 'ready') {
-        const cached = await cache.get().get(ORG_CONFIG_CACHE_KEY(tenant_org_id));
-        if (cached !== null) {
-            return Number(cached);
+        try {
+            const cached = await cache.get().get(ORG_CONFIG_CACHE_KEY(tenant_org_id));
+            if (cached !== null) {
+                return Number(cached);
+            }
+        } catch (err) {
+            log.warn(err, 'failed to read org config retention from cache');
         }
     }
 
@@ -53,7 +58,11 @@ async function getEffectiveRetentionDays(tenant_org_id) {
     const retentionDays = orgConfig?.plan_retention_days ?? config.plan_retention.retentionDays;
 
     if (config.redis.enabled && cache.get().status === 'ready') {
-        await cache.get().setex(ORG_CONFIG_CACHE_KEY(tenant_org_id), CACHE_TTL, String(retentionDays));
+        try {
+            await cache.get().setex(ORG_CONFIG_CACHE_KEY(tenant_org_id), CACHE_TTL, String(retentionDays));
+        } catch (err) {
+            log.warn(err, 'failed to write org config retention to cache');
+        }
     }
 
     return retentionDays;
@@ -1186,6 +1195,10 @@ exports.remediationExpiresAtSql = remediationExpiresAtSql;
 
 exports.clearOrgConfigCache = async function (tenant_org_id) {
     if (config.redis.enabled && cache.get().status === 'ready') {
-        await cache.get().del(ORG_CONFIG_CACHE_KEY(tenant_org_id));
+        try {
+            await cache.get().del(ORG_CONFIG_CACHE_KEY(tenant_org_id));
+        } catch (err) {
+            log.warn(err, 'failed to clear org config retention cache');
+        }
     }
 };

--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -13,6 +13,7 @@ const dispatcher = require('../connectors/dispatcher');
 const fifi2 = require('./fifi_2');
 
 const CACHE_TTL = config.db.cache.ttl;
+const ORG_CONFIG_CACHE_KEY = org_id => `remediations|db-cache|org-config|${org_id}`;
 
 const REMEDIATION_ATTRIBUTES = [
     'id',
@@ -37,24 +38,38 @@ const PLAYBOOK_RUN_ATTRIBUTES = [
 ];
 
 /**
- * Calculates the expires_at timestamp for a remediation plan
- * expires_at = last remediation plan activity + org retention period
- * last remediation plan activity is the last time the plan was updated or executed
- * org retention period comes is the retention period from org_config or falls back to the default retention period
+ * Fetches the effective plan retention period for the given org, with Redis caching.
+ * Falls back to the system default when no org override exists.
  */
-function remediationExpiresAtSql () {
-    const defaultRetentionDays = config.plan_retention.retentionDays;
+async function getEffectiveRetentionDays(tenant_org_id) {
+    if (config.redis.enabled && cache.get().status === 'ready') {
+        const cached = await cache.get().get(ORG_CONFIG_CACHE_KEY(tenant_org_id));
+        if (cached !== null) {
+            return Number(cached);
+        }
+    }
 
+    const orgConfig = await db.org_config.findByPk(tenant_org_id);
+    const retentionDays = orgConfig?.plan_retention_days ?? config.plan_retention.retentionDays;
+
+    if (config.redis.enabled && cache.get().status === 'ready') {
+        await cache.get().setex(ORG_CONFIG_CACHE_KEY(tenant_org_id), CACHE_TTL, String(retentionDays));
+    }
+
+    return retentionDays;
+}
+
+/**
+ * Builds the expires_at SQL expression for a remediation plan.
+ * expires_at = GREATEST(updated_at, last_run_at) + retentionDays
+ * retentionDays is resolved once per request via getEffectiveRetentionDays rather than
+ * as a per-row correlated subquery.
+ */
+function remediationExpiresAtSql (retentionDays) {
     const lastActivityTimestamp = `
         GREATEST(
             "remediation"."updated_at",
             (SELECT MAX("pr"."created_at") FROM "playbook_runs" AS "pr" WHERE "pr"."remediation_id" = "remediation"."id")
-        )`;
-
-    const retentionDays = `
-        COALESCE(
-            (SELECT "oc"."plan_retention_days" FROM "org_config" AS "oc" WHERE "oc"."org_id" = "remediation"."tenant_org_id"),
-            ${defaultRetentionDays}
         )`;
 
     return `(${lastActivityTimestamp} + (${retentionDays}) * INTERVAL '1 day')`;
@@ -122,6 +137,51 @@ function resolvedCountSubquery () {
     );
 }
 
+/*
+  Fetches a paginated, sorted, optionally filtered list of remediation plan summaries for the
+  given org (and optionally a single user). Returns lightweight aggregate rows — no issue or
+  system detail. Callers pass this result to loadDetails() to merge in name, created_by, etc.,
+  then to format.list() to shape the HTTP response.
+
+  Sorting: updated_at (default), name, issue_count, system_count, last_run_at, expires_at, status.
+  All sort keys have id as a stable tie-breaker. Sorting by status or filtering by status triggers
+  a dispatcher-run sync before the query so status values are current.
+
+  Filtering (via the filter object):
+    name          — case-insensitive substring match on plan name
+    status        — one of 'pending' | 'running' | 'success' | 'failure'
+    last_run_after — ISO timestamp, or the string 'never' for plans with no runs
+    created_after  — ISO timestamp
+    updated_after  — ISO timestamp
+    expires_within — integer N: plans whose expires_at is on or before now + N days
+
+  expires_at is calculated as GREATEST(updated_at, last_run_at) + effective retention days,
+  where the retention period is resolved once per call via getEffectiveRetentionDays (cached).
+
+  Returns the result of findAndCountAll:
+
+  {
+    count: 2,
+    rows: [
+      {
+        id: "66eec356-dd06-4c72-a3b6-ef27d1508a02",
+        issue_count: 3,
+        system_count: 5,
+        resolved_count: 1,
+        last_run_at: "2025-11-01T14:23:00.000Z",
+        expires_at: "2026-03-01T14:23:00.000Z"
+      },
+      {
+        id: "9197ba55-0abc-4028-9bbe-269e530f8bd5",
+        issue_count: 1,
+        system_count: 2,
+        resolved_count: 0,
+        last_run_at: null,
+        expires_at: "2026-04-15T08:00:00.000Z"
+      }
+    ]
+  }
+*/
 exports.list = async function (
     tenant_org_id,
     created_by,
@@ -134,6 +194,8 @@ exports.list = async function (
     offset) {
 
     const {Op, s: {literal, where, col, cast}, fn: { DISTINCT, COUNT, MAX }} = db;
+
+    const retentionDays = await getEffectiveRetentionDays(tenant_org_id);
 
     // Check if we need to sync dispatcher runs to accurately sort/filter by status
     const needsStatusSync = primaryOrder === 'status' || (filter && filter.status);
@@ -151,7 +213,7 @@ exports.list = async function (
             break;
 
         case 'expires_at':
-            sortOrder.push([literal(remediationExpiresAtSql()), asc ? 'ASC' : 'DESC']);
+            sortOrder.push([literal(remediationExpiresAtSql(retentionDays)), asc ? 'ASC' : 'DESC']);
             break;
 
         case 'issue_count':
@@ -176,7 +238,7 @@ exports.list = async function (
             [cast(COUNT(DISTINCT(col('issues->systems.system_id'))), 'int'), 'system_count'],
             [resolvedCountSubquery(), 'resolved_count'],
             [MAX(col('playbook_runs.created_at')), 'last_run_at'],
-            [literal(remediationExpiresAtSql()), 'expires_at']
+            [literal(remediationExpiresAtSql(retentionDays)), 'expires_at']
         ],
         include: [{
             attributes: [],
@@ -298,7 +360,7 @@ exports.list = async function (
             query.where[Op.and] = [
                 ...(query.where[Op.and] || []),
                 where(
-                    literal(remediationExpiresAtSql()),
+                    literal(remediationExpiresAtSql(retentionDays)),
                     {[Op.lte]: literal(`(NOW() + (${days}::integer * INTERVAL '1 day'))`)}
                 )
             ];
@@ -431,6 +493,8 @@ exports.get = async function (id, tenant_org_id, created_by = null, includeResol
 
     const {s: {literal}} = db;
 
+    const retentionDays = await getEffectiveRetentionDays(tenant_org_id);
+
     const query = {
         attributes: [
             ...REMEDIATION_ATTRIBUTES
@@ -461,7 +525,7 @@ exports.get = async function (id, tenant_org_id, created_by = null, includeResol
         ]
     };
 
-    query.attributes.push([literal(remediationExpiresAtSql()), 'expires_at']);
+    query.attributes.push([literal(remediationExpiresAtSql(retentionDays)), 'expires_at']);
 
     if (includeResolvedCount) {
         query.attributes.push([resolvedCountSubquery(), 'resolved_count']);
@@ -544,10 +608,12 @@ exports.get = async function (id, tenant_org_id, created_by = null, includeResol
 exports.getSummary = async function (id, tenant_org_id, created_by = null) {
     const { fn, col, literal } = db.s;
 
+    const retentionDays = await getEffectiveRetentionDays(tenant_org_id);
+
     const remediation = await db.remediation.findOne({
         attributes: [
             ...REMEDIATION_ATTRIBUTES,
-            [literal(remediationExpiresAtSql()), 'expires_at']
+            [literal(remediationExpiresAtSql(retentionDays)), 'expires_at']
         ],
         where: {
             id,
@@ -1117,3 +1183,9 @@ exports.getPlaybookRunsWithDispatcherCounts = async function (playbookRunIds) {
 };
 
 exports.remediationExpiresAtSql = remediationExpiresAtSql;
+
+exports.clearOrgConfigCache = async function (tenant_org_id) {
+    if (config.redis.enabled && cache.get().status === 'ready') {
+        await cache.get().del(ORG_CONFIG_CACHE_KEY(tenant_org_id));
+    }
+};

--- a/src/remediations/remediations.queries.unit.js
+++ b/src/remediations/remediations.queries.unit.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const base = require('../test');
+const config = require('../config');
 const queries = require('./remediations.queries');
 const db = require('../db');
 const inventory = require('../connectors/inventory');
@@ -392,5 +393,47 @@ describe('getPlanSystemsDetails', function () {
                 display_name: null
             }
         });
+    });
+});
+
+describe('remediationExpiresAtSql', function () {
+    test('uses org_config and plan retention default', function () {
+        const sql = queries.remediationExpiresAtSql();
+        sql.includes('org_config').should.equal(true);
+        sql.includes('plan_retention_days').should.equal(true);
+        sql.includes('playbook_runs').should.equal(true);
+        sql.includes(String(config.plan_retention.retentionDays)).should.equal(true);
+    });
+});
+
+describe('list filter expires_within', function () {
+    let findAndCountAllStub;
+
+    beforeEach(() => {
+        findAndCountAllStub = base.sandbox.stub(db.remediation, 'findAndCountAll').resolves({count: [], rows: []});
+    });
+
+    async function listWithFilter (expires_within) {
+        return queries.list(
+            '0000000',
+            null,
+            false,
+            'updated_at',
+            true,
+            {expires_within},
+            false,
+            50,
+            0
+        );
+    }
+
+    test('accepts whole number as string and queries', async () => {
+        await listWithFilter('30');
+        findAndCountAllStub.should.have.been.calledOnce;
+    });
+
+    test('accepts whole number and queries', async () => {
+        await listWithFilter(30);
+        findAndCountAllStub.should.have.been.calledOnce;
     });
 });

--- a/src/remediations/remediations.queries.unit.js
+++ b/src/remediations/remediations.queries.unit.js
@@ -397,12 +397,11 @@ describe('getPlanSystemsDetails', function () {
 });
 
 describe('remediationExpiresAtSql', function () {
-    test('uses org_config and plan retention default', function () {
-        const sql = queries.remediationExpiresAtSql();
-        sql.includes('org_config').should.equal(true);
-        sql.includes('plan_retention_days').should.equal(true);
+    test('injects retention days and uses playbook_runs', function () {
+        const sql = queries.remediationExpiresAtSql(120);
+        sql.includes('org_config').should.equal(false);
         sql.includes('playbook_runs').should.equal(true);
-        sql.includes(String(config.plan_retention.retentionDays)).should.equal(true);
+        sql.includes('120').should.equal(true);
     });
 });
 
@@ -411,6 +410,7 @@ describe('list filter expires_within', function () {
 
     beforeEach(() => {
         findAndCountAllStub = base.sandbox.stub(db.remediation, 'findAndCountAll').resolves({count: [], rows: []});
+        base.sandbox.stub(db.org_config, 'findByPk').resolves(null);
     });
 
     async function listWithFilter (expires_within) {

--- a/src/remediations/write.integration.js
+++ b/src/remediations/write.integration.js
@@ -1631,6 +1631,7 @@ describe('remediations', function () {
                 r2.body.id = '';
                 r2.body.created_at = '';
                 r2.body.updated_at = '';
+                r2.body.expires_at = '';
 
                 expect(r2.body).toMatchSnapshot();
             });
@@ -1920,6 +1921,7 @@ describe('remediations', function () {
                 r3.body.id = '';
                 r3.body.created_at = '';
                 r3.body.updated_at = '';
+                r3.body.expires_at = '';
 
                 expect(r3.body).toMatchSnapshot();
             });
@@ -1957,6 +1959,7 @@ describe('remediations', function () {
                 r2.body.id = '';
                 r2.body.created_at = '';
                 r2.body.updated_at = '';
+                r2.body.expires_at = '';
 
                 expect(r2.body).toMatchSnapshot();
 
@@ -1967,6 +1970,7 @@ describe('remediations', function () {
                 r3.body.id = '';
                 r3.body.created_at = '';
                 r3.body.updated_at = '';
+                r3.body.expires_at = '';
 
                 expect(r3.body).toMatchSnapshot();
             });


### PR DESCRIPTION
[RHINENG-25798](https://redhat.atlassian.net/browse/RHINENG-25798) - Include expires_at in GET /remediations response
[RHINENG-25799](https://redhat.atlassian.net/browse/RHINENG-25799) - Include expires_at in GET /remediations/:id response
[RHINENG-25795](https://redhat.atlassian.net/browse/RHINENG-25795) - Calculates expires_at in queries
[RHINENG-25797](https://redhat.atlassian.net/browse/RHINENG-25797) - Support expires_within filtering
[RHINENG-25796](https://redhat.atlassian.net/browse/RHINENG-25796) - Support expires_at sorting

It felt like it made sense to just include all of this in one PR.. 

## Summary by Sourcery

Add remediation plan expiry metadata to API responses and enable querying remediations by their calculated expiration time.

New Features:
- Expose an expires_at timestamp on remediation list and detail endpoints based on last activity and org retention settings.
- Support sorting remediation lists by expires_at in both ascending and descending order.
- Add a filter[expires_within] query parameter to return plans expiring within a specified number of days.

Enhancements:
- Define a reusable SQL expression for computing remediation plan expiry using org_config or a default retention period.
- Normalize date serialization for expires_at fields to safely handle Date objects and ISO timestamp strings in formatters.

Documentation:
- Update OpenAPI documentation to describe the new expires_at field, supported sort options, and the expires_within filter on remediation plan queries.

Tests:
- Extend integration tests to cover expires_at presence, sorting, and expires_within filtering behavior, including validation errors for invalid filter values.
- Add a unit test to assert that the remediation expiry SQL references org_config, playbook_runs, and the default retention configuration.

[RHINENG-25798]: https://redhat.atlassian.net/browse/RHINENG-25798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHINENG-25799]: https://redhat.atlassian.net/browse/RHINENG-25799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHINENG-25795]: https://redhat.atlassian.net/browse/RHINENG-25795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHINENG-25797]: https://redhat.atlassian.net/browse/RHINENG-25797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHINENG-25796]: https://redhat.atlassian.net/browse/RHINENG-25796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add remediation plan expiry metadata to remediation APIs and enable querying based on calculated expiration time.

New Features:
- Expose an expires_at timestamp on remediation list, detail, and summary responses.
- Support sorting remediation lists by expires_at in ascending or descending order.
- Introduce a filter[expires_within] query parameter to return remediation plans expiring within a specified number of days.

Enhancements:
- Define a reusable SQL expression to compute remediation plan expiry using last activity and organization-specific or default retention settings.
- Normalize expires_at formatting in response serializers to handle Date objects consistently.

Documentation:
- Extend OpenAPI specifications to document the expires_at field, expires_at sort options, and the expires_within filter on remediation queries.

Tests:
- Expand integration tests to cover expires_at presence, sorting, and expires_within filtering, including validation of invalid filter values.
- Add unit tests for the remediation expiry SQL helper and for accepting numeric expires_within values.