### PR TITLE
RHINENG-26206: Add getSummary query func for format=summary endpoint

### DIFF
--- a/src/remediations/controller.read.js
+++ b/src/remediations/controller.read.js
@@ -316,6 +316,58 @@ function orderSystems (systems, column, asc = true) {
     return _.orderBy(systems, [column, 'id'], [asc ? 'asc' : 'desc']);
 }
 
+/**
+ * GET /v1/remediations/:id — sends `res.json(format.get(remediation))`.
+ *
+ * Default (`format` omitted or `detail`) loads full issues/systems and returns `needs_reboot`, `resolved_count`,
+ * and `issues`. `?format=summary` uses `queries.getSummary` and returns counts only (no `issues`).
+ *
+ * @example Summary (`?format=summary`) response body
+ * {
+ *   "id": "9197ba55-0abc-4028-9bbe-269e530f8bd5",
+ *   "name": "Fix Critical CVEs",
+ *   "auto_reboot": true,
+ *   "archived": false,
+ *   "created_by": { "username": "user@redhat.com", "first_name": "Jane", "last_name": "Doe" },
+ *   "created_at": "2018-12-05T08:19:36.641Z",
+ *   "updated_by": { "username": "user@redhat.com", "first_name": "Jane", "last_name": "Doe" },
+ *   "updated_at": "2018-12-05T08:19:36.641Z",
+ *   "issue_count": 8,
+ *   "issue_count_details": { "advisor": 1, "ssg": 1, "patch-advisory": 1, "vulnerabilities": 2 },
+ *   "system_count": 12
+ * }
+ *
+ * @example Detail (default) response body — `issues[]` shaped by `remediations.format.get`
+ * {
+ *   "id": "66eec356-dd06-4c72-a3b6-ef27d1508a02",
+ *   "name": "remediation 1",
+ *   "auto_reboot": true,
+ *   "archived": false,
+ *   "created_by": { "username": "tuser@redhat.com", "first_name": "T", "last_name": "User" },
+ *   "created_at": "2018-10-04T08:19:36.641Z",
+ *   "updated_by": { "username": "tuser@redhat.com", "first_name": "T", "last_name": "User" },
+ *   "updated_at": "2018-10-04T08:19:36.641Z",
+ *   "needs_reboot": false,
+ *   "resolved_count": 1,
+ *   "issues": [
+ *     {
+ *       "id": "advisor:CVE_2017_6074_kernel|KERNEL_CVE_2017_6074",
+ *       "description": "Kernel CVE description",
+ *       "resolution": {
+ *         "id": "fix",
+ *         "description": "Apply security errata",
+ *         "resolution_risk": 1,
+ *         "needs_reboot": true
+ *       },
+ *       "resolutions_available": [],
+ *       "precedence": 1,
+ *       "systems": [
+ *         { "id": "fc94beb8-21ee-403d-99b1-949ef7adb762", "hostname": "host1", "display_name": "Host 1", "resolved": false }
+ *       ]
+ *     }
+ *   ]
+ * }
+ */
 exports.get = errors.async(async function (req, res) {
     // are we just summarizing?
     const summarize = req.query['format'] == 'summary';

--- a/src/remediations/controller.read.js
+++ b/src/remediations/controller.read.js
@@ -325,7 +325,9 @@ exports.get = errors.async(async function (req, res) {
     // otherwise use creator
     const creator_sa_filter = req.type == "ServiceAccount" ? null : req.user.username;
 
-    let remediation = await queries.get(req.params.id, req.user.tenant_org_id, creator_sa_filter);
+    const remediation = summarize
+        ? await queries.getSummary(req.params.id, req.user.tenant_org_id, creator_sa_filter)
+        : await queries.get(req.params.id, req.user.tenant_org_id, creator_sa_filter);
 
     if (!remediation) {
         return notFound(res);
@@ -334,15 +336,7 @@ exports.get = errors.async(async function (req, res) {
     // look up user details
     await resolveUsers(req, remediation);
 
-    if (summarize) {
-        remediation.issue_count = remediation.issues.length;
-        remediation.system_count = _(remediation.issues).flatMap('systems').map('system_id').uniq().value().length;
-        remediation.issue_count_details = _.countBy(remediation.issues, issue => issue.issue_id.split(':')[0]);
-        remediation.issues = undefined;
-        remediation.resolved_count = undefined;
-    }
-
-    else {
+    if (!summarize) {
         // fetch plan issue and system details
         await P.all([
             resolveSystems(remediation),

--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -466,6 +466,68 @@ exports.get = async function (id, tenant_org_id, created_by = null, includeResol
     }
 };
 
+/**
+ * Gets counts and remediation metadata for `GET /v1/remediations/:id?format=summary`.
+ *
+ * Loads the remediation row plus aggregates: total issue count, distinct system count across those issues,
+ * and per-issue-type counts (issue_id prefix before `:`).
+ *
+ * Lightweight because it does not load issues or issue-system rows.
+ */
+exports.getSummary = async function (id, tenant_org_id, created_by = null) {
+    const { fn, col } = db.s;
+
+    const remediation = await db.remediation.findOne({
+        attributes: REMEDIATION_ATTRIBUTES,
+        where: {
+            id,
+            tenant_org_id,
+            ...(created_by ? { created_by } : {})
+        }
+    });
+
+    if (!remediation) {
+        return null;
+    }
+
+    const [issue_count, system_count, issueCountsGroupedByType] = await Promise.all([
+        db.issue.count({ where: { remediation_id: id } }),
+        db.issue_system.count({
+            distinct: true,
+            col: 'system_id',
+            include: [{
+                model: db.issue,
+                attributes: [],
+                required: true,
+                where: { remediation_id: id }
+            }]
+        }),
+        db.issue.findAll({
+            attributes: [
+                [fn('split_part', col('issue_id'), ':', 1), 'issue_type'],
+                [fn('COUNT', col('id')), 'count']
+            ],
+            where: { remediation_id: id },
+            group: [fn('split_part', col('issue_id'), ':', 1)],
+            raw: true
+        })
+    ]);
+
+    const issue_count_details = {};
+    for (const row of issueCountsGroupedByType) {
+        issue_count_details[row.issue_type] = Number(row.count);
+    }
+
+    return {
+        ...remediation.toJSON(),
+        issue_count,
+        system_count,
+        issue_count_details,
+        issues: undefined,
+        resolved_count: undefined
+    };
+};
+
 // Fetch issues and systems from the specified remediation plan, with optional sorting and filtering by issue name
 exports.getIssues = async function (remediation_plan_id, tenant_org_id, created_by = null, issue_name = null, asc = true) {
     const query = {

--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -473,6 +473,28 @@ exports.get = async function (id, tenant_org_id, created_by = null, includeResol
  * and per-issue-type counts (issue_id prefix before `:`).
  *
  * Lightweight because it does not load issues or issue-system rows.
+ *
+ * @returns {Promise<object|null>} `null` if no remediation matches. Otherwise a plain object like:
+ * @example
+ * {
+ *   id: '9197ba55-0abc-4028-9bbe-269e530f8bd5',
+ *   name: 'Fix Critical CVEs',
+ *   auto_reboot: true,
+ *   archived: false,
+ *   account_number: '1234567',
+ *   tenant_org_id: '5318290',
+ *   created_by: 'user@redhat.com',
+ *   created_at: '2018-12-05T08:19:36.641Z',
+ *   updated_by: 'user@redhat.com',
+ *   updated_at: '2018-12-05T08:19:36.641Z',
+ *   issue_count: 8,
+ *   system_count: 12,
+ *   issue_count_details: { advisor: 1, ssg: 1, 'patch-advisory': 1, vulnerabilities: 2 },
+ *   issues: undefined,
+ *   resolved_count: undefined
+ * }
+ * (`created_at` / `updated_at` are whatever `remediation.toJSON()` emits; `created_by` / `updated_by` are
+ * usernames until the controller runs `resolveUsers`.)
  */
 exports.getSummary = async function (id, tenant_org_id, created_by = null) {
     const { fn, col } = db.s;


### PR DESCRIPTION
## Summary by Sourcery

Add a lightweight summary retrieval path for remediations and wire it to the existing read controller when format=summary is requested.

New Features:
- Introduce a getSummary query that returns remediation metadata and aggregated issue and system counts without loading full issue details.

Enhancements:
- Refine the remediation read controller to delegate summary responses to the new query instead of computing aggregates in-memory.