### PR TITLE
RHINENG-26209: Only check remediation existence and ownership for GET /executable

### DIFF
--- a/src/remediations/controller.fifi.js
+++ b/src/remediations/controller.fifi.js
@@ -16,9 +16,13 @@ const notMatching = res => res.sendStatus(412);
 const notFound = res => res.sendStatus(404);
 
 exports.checkExecutable = errors.async(async function (req, res) {
-    const remediation = await queries.get(req.params.id, req.user.tenant_org_id, req.user.username);
+    const exists = await queries.checkExecutable(
+        req.params.id,
+        req.user.tenant_org_id,
+        req.user.username
+    );
 
-    if (!remediation) {
+    if (!exists) {
         return notFound(res);
     }
 

--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -550,6 +550,20 @@ exports.getSummary = async function (id, tenant_org_id, created_by = null) {
     };
 };
 
+// Return `{ id }` when id, tenant_org_id, and created_by match (remediation exists).
+// Return null if no remediation matches (does not exist or wrong scope).
+exports.checkExecutable = async function (id, tenant_org_id, created_by) {
+    return db.remediation.findOne({
+        attributes: ['id'],
+        where: {
+            id,
+            tenant_org_id,
+            created_by
+        },
+        raw: true
+    });
+};
+
 // Fetch issues and systems from the specified remediation plan, with optional sorting and filtering by issue name
 exports.getIssues = async function (remediation_plan_id, tenant_org_id, created_by = null, issue_name = null, asc = true) {
     const query = {


### PR DESCRIPTION
## Summary by Sourcery

Ensure GET /executable only verifies remediation existence and ownership via a direct database lookup rather than the previous query helper.