### PR TITLE
RHINENG-26507: Replace uuid dependency with crypto.randomUUID

### DIFF
--- a/db/seeders/20240326162729-scalability.js
+++ b/db/seeders/20240326162729-scalability.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const UUID = require('uuid');
 const { account_number, tenant_org_id, username: created_by } = require('../../src/connectors/users/mock').MOCK_USERS.fifi;
 const { systems } = require('../../src/connectors/inventory/impl.unit.data');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,8 +45,7 @@
         "sequelize-cli": "^6.5.2",
         "swagger-ui-express": "^5.0.0",
         "unleash-client": "^6.9.6",
-        "urijs": "^1.19.11",
-        "uuid": "^7.0.3"
+        "urijs": "^1.19.11"
       },
       "devDependencies": {
         "eslint": "9.2",
@@ -13191,16 +13190,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "sequelize-cli": "^6.5.2",
     "swagger-ui-express": "^5.0.0",
     "unleash-client": "^6.9.6",
-    "urijs": "^1.19.11",
-    "uuid": "^7.0.3"
+    "urijs": "^1.19.11"
   },
   "devDependencies": {
     "eslint": "9.2",

--- a/src/connectors/inventory/systemGenerator.js
+++ b/src/connectors/inventory/systemGenerator.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require("lodash");
-const UUID = require("uuid");
 
 const NON_EXISTENT_SYSTEM = '1040856f-b772-44c7-83a9-eeeeeeeeeeee';
 const DISCONNECTED_SATELLITE = '409dd231-6297-43a6-a726-5ce56923d624';

--- a/src/middleware/reqId.js
+++ b/src/middleware/reqId.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const uuid = require('uuid');
+const { randomUUID } = require('crypto');
 const HEADER = 'x-rh-insights-request-id';
 
 /* eslint-disable security/detect-object-injection */
 module.exports = function (req, res, next) {
     if (typeof req.headers[HEADER] === 'undefined') {
-        req.headers[HEADER] = uuid.v4();
+        req.headers[HEADER] = randomUUID();
     }
 
     next();

--- a/src/remediations/controller.write.js
+++ b/src/remediations/controller.write.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const uuid = require('uuid');
+const { randomUUID } = require('crypto');
 const _ = require('lodash');
 const P = require('bluebird');
 
@@ -162,7 +162,7 @@ exports.create = errors.async(async function (req, res) {
         systemsById = await processNewActions(add);
     }
 
-    const id = uuid.v4();
+    const id = randomUUID();
 
     const result = await db.s.transaction(async transaction => {
         const remediation = await db.remediation.create({

--- a/src/remediations/fifi.integration.js
+++ b/src/remediations/fifi.integration.js
@@ -1,5 +1,6 @@
 /*eslint-disable max-len*/
 'use strict';
+const { randomUUID } = require('crypto');
 const P = require('bluebird');
 const _ = require('lodash');
 const URI = require('urijs');
@@ -959,15 +960,13 @@ describe('FiFi', function () {
 
             test('post playbook run and store dispatcher runs', async () => {
                 const sandbox = base.getSandbox();
-                const { v4: uuidv4 } = require('uuid');
-
                 const remediationId = '0ecb5db7-2f1a-441b-8220-e5ce45066f50';
-                const fakeRunId = uuidv4();
-                sandbox.stub(fifi_2, 'uuidv4').returns(fakeRunId);
+                const fakeRunId = randomUUID();
+                sandbox.stub(fifi_2, 'generatePlaybookRunId').returns(fakeRunId);
 
                 const dispatcherResponse = [
-                    { code: 200, id: uuidv4() },
-                    { code: 200, id: uuidv4() }
+                    { code: 200, id: randomUUID() },
+                    { code: 200, id: randomUUID() }
                 ];
 
                 sandbox.stub(dispatcher, 'postV2PlaybookRunRequests').resolves(dispatcherResponse);
@@ -1001,22 +1000,20 @@ describe('FiFi', function () {
 
             test('post playbook run with dispatcher partial failure - saves all runs and returns 201', async function () {
                 const sandbox = base.getSandbox();
-                const { v4: uuidv4 } = require('uuid');
-
                 const remediationId = '0ecb5db7-2f1a-441b-8220-e5ce45066f50';
-                const fakeRunId = uuidv4();
-                sandbox.stub(fifi_2, 'uuidv4').returns(fakeRunId);
+                const fakeRunId = randomUUID();
+                sandbox.stub(fifi_2, 'generatePlaybookRunId').returns(fakeRunId);
 
                 const dispatcherResponse = [
-                    { code: 200, id: uuidv4() },
-                    { code: 200, id: uuidv4() },
-                    { code: 400, id: uuidv4() },
-                    { code: 200, id: uuidv4() },
-                    { code: 500, id: uuidv4() },
-                    { code: 200, id: uuidv4() },
-                    { code: 200, id: uuidv4() },
-                    { code: 200, id: uuidv4() },
-                    { code: 200, id: uuidv4() }
+                    { code: 200, id: randomUUID() },
+                    { code: 200, id: randomUUID() },
+                    { code: 400, id: randomUUID() },
+                    { code: 200, id: randomUUID() },
+                    { code: 500, id: randomUUID() },
+                    { code: 200, id: randomUUID() },
+                    { code: 200, id: randomUUID() },
+                    { code: 200, id: randomUUID() },
+                    { code: 200, id: randomUUID() }
                 ];
 
                 sandbox.stub(dispatcher, 'postV2PlaybookRunRequests').resolves(dispatcherResponse);
@@ -1172,8 +1169,8 @@ describe('FiFi', function () {
                 // do not create db record
                 base.getSandbox().stub(queries, 'insertRHCPlaybookRun').returns();
 
-                // force uuid for snapshot test
-                base.getSandbox().stub(fifi_2, 'uuidv4').returns('b995e750-c1d3-4c5b-a3ec-eee897ee9065');
+                // fixed playbook run ID for snapshot test
+                base.getSandbox().stub(fifi_2, 'generatePlaybookRunId').returns('b995e750-c1d3-4c5b-a3ec-eee897ee9065');
 
                 const spy = base.getSandbox().spy(dispatcher, 'postV2PlaybookRunRequests');
 
@@ -1215,8 +1212,8 @@ describe('FiFi', function () {
                 // do not create db record
                 base.getSandbox().stub(queries, 'insertRHCPlaybookRun').returns();
 
-                // force uuid for snapshot test
-                base.getSandbox().stub(fifi_2, 'uuidv4').returns('b995e750-c1d3-4c5b-a3ec-eee897ee9065');
+                // fixed playbook run ID for snapshot test
+                base.getSandbox().stub(fifi_2, 'generatePlaybookRunId').returns('b995e750-c1d3-4c5b-a3ec-eee897ee9065');
 
                 const spy = base.getSandbox().spy(dispatcher, 'postV2PlaybookRunRequests');
 
@@ -1419,16 +1416,14 @@ describe('FiFi', function () {
     describe('syncDispatcherRunsForPlaybookRuns', function () {
         test('syncDispatcherRunsForPlaybookRuns backfill', async () => {
             const sandbox = base.getSandbox();
-            const { v4: uuidv4 } = require('uuid');
-
             // Use an existing playbook run that has no dispatcher_runs
             const playbookRunId = '88d0ba73-0015-4e7d-a6d6-4b530cbfb5bc';
 
             // Mock dispatcher API response
             sandbox.stub(dispatcher, 'fetchPlaybookRuns').resolves({
                 data: [
-                    { id: uuidv4(), status: 'success' },
-                    { id: uuidv4(), status: 'pending' }
+                    { id: randomUUID(), status: 'success' },
+                    { id: randomUUID(), status: 'pending' }
                 ]
             });
 
@@ -1462,14 +1457,12 @@ describe('FiFi', function () {
 
         test('syncDispatcherRunsForPlaybookRuns status update', async () => {
             const sandbox = base.getSandbox();
-            const { v4: uuidv4 } = require('uuid');
-
             // Use an existing playbook run
             const playbookRunId = '88d0ba73-0015-4e7d-a6d6-4b530cbfb6bc';
 
             // Create some incomplete dispatcher_runs first
-            const dispatcherRunId1 = uuidv4();
-            const dispatcherRunId2 = uuidv4();
+            const dispatcherRunId1 = randomUUID();
+            const dispatcherRunId2 = randomUUID();
             
             await db.dispatcher_runs.bulkCreate([
                 {
@@ -1520,15 +1513,13 @@ describe('FiFi', function () {
 
         test('syncDispatcherRunsForPlaybookRuns skip failed', async () => {
             const sandbox = base.getSandbox();
-            const { v4: uuidv4 } = require('uuid');
-
             // Use an existing playbook run
             const playbookRunId = '11f7f24a-346b-405c-8dcc-c953511fb21c';
 
             // Create dispatcher_runs with one failed status
             await db.dispatcher_runs.bulkCreate([
                 {
-                    dispatcher_run_id: uuidv4(),
+                    dispatcher_run_id: randomUUID(),
                     remediations_run_id: playbookRunId,
                     status: 'failure',
                     created_at: new Date(),
@@ -1536,7 +1527,7 @@ describe('FiFi', function () {
                     pd_response_code: null
                 },
                 {
-                    dispatcher_run_id: uuidv4(),
+                    dispatcher_run_id: randomUUID(),
                     remediations_run_id: playbookRunId,
                     status: 'pending',
                     created_at: new Date(),

--- a/src/remediations/fifi.js
+++ b/src/remediations/fifi.js
@@ -2,7 +2,6 @@
 /* eslint-disable max-len */
 
 const _ = require('lodash');
-const {v4: uuidv4} = require('uuid');
 
 const config = require('../config');
 const errors = require('../errors');

--- a/src/remediations/fifi.unit.js
+++ b/src/remediations/fifi.unit.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const base = require('../test');
-const {v4: uuid} = require('uuid');
+const { randomUUID } = require('crypto');
 const fifi = require('./fifi');
 const fifi2 = require('./fifi_2');
 const db = require('../db');
@@ -34,21 +34,21 @@ const REMEDIATIONISSUES = [
         issue_id: 'ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled',
         resolution: null,
         systems: [
-            {system_id: uuid()}, {system_id: uuid()}, {system_id: SYSTEMS[0].id}
+            {system_id: randomUUID()}, {system_id: randomUUID()}, {system_id: SYSTEMS[0].id}
         ]
     },
     {
         issue_id: 'ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_enabled',
         resolution: null,
         systems: [
-            {system_id: uuid()}, {system_id: uuid()}, {system_id: uuid()}
+            {system_id: randomUUID()}, {system_id: randomUUID()}, {system_id: randomUUID()}
         ]
     },
     {
         issue_id: 'ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_connected',
         resolution: null,
         systems: [
-            {system_id: SYSTEMS[0].id}, {system_id: SYSTEMS[1].id}, {system_id: uuid()}
+            {system_id: SYSTEMS[0].id}, {system_id: SYSTEMS[1].id}, {system_id: randomUUID()}
         ]
     },
     {
@@ -83,9 +83,9 @@ describe('playbook run functions', function () {
 });
 
 describe('syncDispatcherRunsForPlaybookRuns', function () {
-    const mockPlaybookRunId1 = uuid();
-    const mockPlaybookRunId2 = uuid();
-    const mockPlaybookRunId3 = uuid();
+    const mockPlaybookRunId1 = randomUUID();
+    const mockPlaybookRunId2 = randomUUID();
+    const mockPlaybookRunId3 = randomUUID();
 
     test('should return empty array when no playbook run IDs provided', async () => {
         const result = await fifi2.syncDispatcherRunsForPlaybookRuns([]);
@@ -228,8 +228,8 @@ describe('syncDispatcherRunsForPlaybookRuns', function () {
     });
 
     test('should return only successfully synced playbook runs in mixed scenarios', async () => {
-        const mockPlaybookRunId4 = uuid();
-        const mockPlaybookRunId5 = uuid();
+        const mockPlaybookRunId4 = randomUUID();
+        const mockPlaybookRunId5 = randomUUID();
         
         // Mock queries.getPlaybookRunsWithDispatcherCounts - both need backfill
         base.sandbox.stub(queries, 'getPlaybookRunsWithDispatcherCounts').resolves([

--- a/src/remediations/fifi_2.js
+++ b/src/remediations/fifi_2.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { randomUUID } = require('crypto');
 const _ = require("lodash");
-const uuid = require("uuid");
 
 const format = require("./remediations.format_2");
 const errors = require("../errors");
@@ -28,9 +28,9 @@ const NONE = 'none';
 
 //======================================================================================================================
 
-// This is just so we can stub uuid.v4 to force a uuid for snapshot testing
-exports.uuidv4 = function () {
-    return uuid.v4();
+// Exported so tests can stub a fixed playbook run ID (snapshots, DB assertions)
+exports.generatePlaybookRunId = function () {
+    return randomUUID();
 };
 
 //--------------------------------------------
@@ -68,7 +68,7 @@ exports.uuidv4 = function () {
 //--------------------------------------------
 exports.createPlaybookRun = async function (recipients, exclude, remediation, username) {
     // create UUID for this run
-    const playbook_run_id = exports.uuidv4();
+    const playbook_run_id = exports.generatePlaybookRunId();
 
     // check if excludes contains anything NOT in targets
     validateExcludes(exclude, recipients);

--- a/src/remediations/read.integration.js
+++ b/src/remediations/read.integration.js
@@ -11,7 +11,7 @@ const impl = require('../connectors/dispatcher/impl');
 const dispatcher = require('../connectors/dispatcher');
 const fifi2 = require('./fifi_2');
 const db = require('../db');
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 
 function test400 (name, url, code, title) {
     test(name, async () => {
@@ -57,7 +57,7 @@ describe('remediations', function () {
         });
 
         test('v1 SSG issue id succeeds via SSG template lookup', async () => {
-            const remId = uuidv4();
+            const remId = randomUUID();
             createdIds.push(remId);
 
             await db.remediation.create({
@@ -92,7 +92,7 @@ describe('remediations', function () {
         });
 
         test('v2 SSG issue id succeeds', async () => {
-            const remId = uuidv4();
+            const remId = randomUUID();
             createdIds.push(remId);
 
             await db.remediation.create({
@@ -353,12 +353,11 @@ describe('remediations', function () {
         });
 
         test('last_playbook_run returns the actual latest playbook run per remediation', async () => {
-            const { v4: uuidv4 } = require('uuid');
             const { username: created_by } = require('../connectors/users/mock').MOCK_USERS.fifi;
             
             // Create a temporary remediation for this test
             const testRemediation = await db.remediation.create({
-                id: uuidv4(),
+                id: randomUUID(),
                 name: 'Test Latest Run Remediation',
                 created_by,
                 updated_by: created_by,
@@ -371,9 +370,9 @@ describe('remediations', function () {
             
             try {
                 // Create test playbook runs with different timestamps to verify "latest" logic
-                const testRun1Id = uuidv4();
-                const testRun2Id = uuidv4();
-                const testRun3Id = uuidv4();
+                const testRun1Id = randomUUID();
+                const testRun2Id = randomUUID();
+                const testRun3Id = randomUUID();
                 
                 // Create runs with different timestamps - testRun2 should be the latest
                 const testRun1 = await db.playbook_runs.create({
@@ -409,7 +408,7 @@ describe('remediations', function () {
                 // Create dispatcher_runs to give the playbook runs proper status
                 // testRun1: success status
                 const dispatcherRun1 = await db.dispatcher_runs.create({
-                    dispatcher_run_id: uuidv4(),
+                    dispatcher_run_id: randomUUID(),
                     remediations_run_id: testRun1Id,
                     status: 'success',
                     created_at: '2019-12-22T08:19:36.641Z',
@@ -419,7 +418,7 @@ describe('remediations', function () {
                 
                 // testRun2: running status (should be the latest)
                 const dispatcherRun2 = await db.dispatcher_runs.create({
-                    dispatcher_run_id: uuidv4(),
+                    dispatcher_run_id: randomUUID(),
                     remediations_run_id: testRun2Id,
                     status: 'running',
                     created_at: '2019-12-24T08:19:36.641Z',
@@ -429,7 +428,7 @@ describe('remediations', function () {
                 
                 // testRun3: failure status
                 const dispatcherRun3 = await db.dispatcher_runs.create({
-                    dispatcher_run_id: uuidv4(),
+                    dispatcher_run_id: randomUUID(),
                     remediations_run_id: testRun3Id,
                     status: 'failure',
                     created_at: '2019-12-23T08:19:36.641Z',
@@ -524,7 +523,6 @@ describe('remediations', function () {
                 let isolatedDispatcherRunIds = [];
 
                 beforeEach(async () => {
-                    const { v4: uuidv4 } = require('uuid');
                     const now = '2019-12-25T08:19:36.641Z'; // Fixed timestamp for snapshot consistency
                     const { username: created_by } = require('../connectors/users/mock').MOCK_USERS.fifi;
                     
@@ -562,7 +560,7 @@ describe('remediations', function () {
                         });
 
                         // Create a fresh playbook_run for r178 to use for running status
-                        const r178PlaybookRunId = uuidv4();
+                        const r178PlaybookRunId = randomUUID();
                         await db.playbook_runs.create({
                             id: r178PlaybookRunId,
                             status: 'running',
@@ -573,9 +571,9 @@ describe('remediations', function () {
                         }, { transaction });
 
                         // Create isolated dispatcher_runs with unique IDs we can track
-                        const runningDispatcherRun1 = uuidv4();
-                        const runningDispatcherRun2 = uuidv4();
-                        const failureDispatcherRun = uuidv4();
+                        const runningDispatcherRun1 = randomUUID();
+                        const runningDispatcherRun2 = randomUUID();
+                        const failureDispatcherRun = randomUUID();
                         
                         isolatedDispatcherRunIds = [runningDispatcherRun1, runningDispatcherRun2, failureDispatcherRun, r178PlaybookRunId];
 
@@ -803,8 +801,8 @@ describe('remediations', function () {
         });
 
         test('sort by id asc/desc', async () => {
-            const remId = uuidv4();
-            const systemId = uuidv4();
+            const remId = randomUUID();
+            const systemId = randomUUID();
             createdIds.push(remId);
 
             await db.remediation.create({
@@ -840,8 +838,8 @@ describe('remediations', function () {
         // removed: sort by resolved asc/desc (endpoint no longer supports resolved)
 
         test('filter by id (partial)', async () => {
-            const remId = uuidv4();
-            const systemId = uuidv4();
+            const remId = randomUUID();
+            const systemId = randomUUID();
             createdIds.push(remId);
 
             await db.remediation.create({
@@ -877,8 +875,8 @@ describe('remediations', function () {
         });
 
         test('pagination limit/offset', async () => {
-            const remId = uuidv4();
-            const systemId = uuidv4();
+            const remId = randomUUID();
+            const systemId = randomUUID();
             createdIds.push(remId);
 
             await db.remediation.create({
@@ -908,9 +906,9 @@ describe('remediations', function () {
         });
 
         test('returns 404 when system does not exist in remediation', async () => {
-            const remId = uuidv4();
-            const systemInRemediation = uuidv4();
-            const systemNotInRemediation = uuidv4();
+            const remId = randomUUID();
+            const systemInRemediation = randomUUID();
+            const systemNotInRemediation = randomUUID();
             createdIds.push(remId);
 
             await db.remediation.create({
@@ -1090,7 +1088,7 @@ describe('remediations', function () {
         // The seeded 'unknown issues' plan includes a v1 SSG id that now returns 400 (invalid identifier), so we can't use it here.
         test('get remediation with unknown issues', async () => {
             const { account_number, tenant_org_id, username: created_by } = require('../connectors/users/mock').MOCK_USERS.testReadSingleUser;
-            const remId = uuidv4();
+            const remId = randomUUID();
 
             try {
                 await db.remediation.create({
@@ -1827,7 +1825,7 @@ describe('remediations', function () {
         beforeAll(async () => {
             // Create test remediations with different users
             const { id: rem1 } = await db.remediation.create({
-                id: uuidv4(),
+                id: randomUUID(),
                 name: 'user1-remediation',
                 needs_reboot: false,
                 tenant_org_id: '0000000',
@@ -1839,7 +1837,7 @@ describe('remediations', function () {
             createdRemediationIds.push(rem1);
 
             const { id: rem2 } = await db.remediation.create({
-                id: uuidv4(),
+                id: randomUUID(),
                 name: 'user2-remediation',
                 needs_reboot: false,
                 tenant_org_id: '0000000',
@@ -1851,7 +1849,7 @@ describe('remediations', function () {
             createdRemediationIds.push(rem2);
 
             const { id: rem3 } = await db.remediation.create({
-                id: uuidv4(),
+                id: randomUUID(),
                 name: 'service-account-remediation',
                 needs_reboot: false,
                 tenant_org_id: '0000000',
@@ -2052,7 +2050,7 @@ describe('remediations', function () {
         test('normal user can only download playbooks for their own remediations', async () => {
             // First create a remediation for the test user
             const { id: testUserRemId } = await db.remediation.create({
-                id: uuidv4(),
+                id: randomUUID(),
                 name: 'test-user-remediation',
                 needs_reboot: false,
                 tenant_org_id: '4444444', // Match testReadSingleUser's tenant_org_id
@@ -2101,7 +2099,7 @@ describe('remediations', function () {
         test('service account filtering works with different org_ids', async () => {
             // Create remediation in different org
             const { id: differentOrgRemId } = await db.remediation.create({
-                id: uuidv4(),
+                id: randomUUID(),
                 name: 'different-org-remediation',
                 needs_reboot: false,
                 tenant_org_id: '1111111', // Different org
@@ -2339,10 +2337,10 @@ describe('remediations', function () {
         let missingSystemId;
 
         beforeEach(async () => {
-            createdRemediationId = uuidv4();
-            existingSystemId1 = uuidv4();
-            existingSystemId2 = uuidv4();
-            missingSystemId = uuidv4();
+            createdRemediationId = randomUUID();
+            existingSystemId1 = randomUUID();
+            existingSystemId2 = randomUUID();
+            missingSystemId = randomUUID();
 
             await db.remediation.create({
                 id: createdRemediationId,

--- a/src/remediations/write.integration.js
+++ b/src/remediations/write.integration.js
@@ -6,7 +6,7 @@ const config = require('../config');
 const rbac = require('../connectors/rbac');
 const { request, reqId, auth, getSandbox, buildRbacResponse } = require('../test');
 const { NON_EXISTENT_SYSTEM } = require('../connectors/inventory/mock');
-const uuid = require('uuid');
+const { randomUUID } = require('crypto');
 const db = require('../db');
 
 function testIssue (remediation, id, resolution, systems) {
@@ -207,7 +207,7 @@ describe('remediations', function () {
             const name = `new remediation with 20k systems`;
             const TOTAL_SYSTEMS = 20000;
             const BATCH_SIZE = 50;
-            const allSystems = _.times(TOTAL_SYSTEMS, () => uuid.v4());
+            const allSystems = _.times(TOTAL_SYSTEMS, () => randomUUID());
 
             // Create initial remediation with first batch
             const firstBatch = allSystems.slice(0, BATCH_SIZE);
@@ -255,7 +255,7 @@ describe('remediations', function () {
 
         test('does not create remediations with more than 50 unique systems', async () => {
             const name = 'remediation with too many systems';
-            const systems = _.times(51, () => uuid.v4());
+            const systems = _.times(51, () => randomUUID());
 
             const {body} = await request
             .post('/v1/remediations')

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -3,7 +3,7 @@
 require('should');
 const sinon = require('sinon');
 const supertest = require('supertest');
-const uuid = require('uuid');
+const { randomUUID } = require('crypto');
 
 const app = require('../app');
 const config = require('../config');
@@ -161,7 +161,7 @@ exports.throw404 = () => {
 };
 
 exports.reqId = () => {
-    const id = uuid.v4();
+    const id = randomUUID();
 
     return {
         header: {


### PR DESCRIPTION
## Summary by Sourcery

Replace usage of the external uuid library with Node's built-in crypto.randomUUID across remediations code, middleware, tests, and helpers, and adjust related test utilities accordingly.

Enhancements:
- Standardize UUID generation via a new generatePlaybookRunId helper that wraps crypto.randomUUID for playbook runs.
- Simplify request ID middleware and test helpers to rely on crypto.randomUUID instead of an external dependency.

Build:
- Remove the uuid dependency from package.json now that UUID generation uses the built-in crypto module.