### PR TITLE
fix(deps): override dottie to 2.0.7 for CVE-2026-27837

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4135,9 +4135,11 @@
       "dev": true
     },
     "node_modules/dottie": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.6.tgz",
-      "integrity": "sha512-iGCHkfUc5kFekGiqhe8B/mdaurD+lakO9txNnTvKtA6PISrw86LgqHvRzWYPyoE2Ph5aMIrCw9/uko6XHTKCwA=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.7.tgz",
+      "integrity": "sha512-7lAK2A0b3zZr3UC5aE69CPdCFR4RHW1o2Dr74TqFykxkUCBXSRJum/yPc7g8zRHJqWKomPLHwFLLoUnn8PXXRg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -19668,9 +19670,9 @@
       "dev": true
     },
     "dottie": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.6.tgz",
-      "integrity": "sha512-iGCHkfUc5kFekGiqhe8B/mdaurD+lakO9txNnTvKtA6PISrw86LgqHvRzWYPyoE2Ph5aMIrCw9/uko6XHTKCwA=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.7.tgz",
+      "integrity": "sha512-7lAK2A0b3zZr3UC5aE69CPdCFR4RHW1o2Dr74TqFykxkUCBXSRJum/yPc7g8zRHJqWKomPLHwFLLoUnn8PXXRg=="
     },
     "dunder-proto": {
       "version": "1.0.1",
@@ -26967,7 +26969,7 @@
         "@types/debug": "^4.1.8",
         "@types/validator": "^13.7.17",
         "debug": "^4.3.4",
-        "dottie": "^2.0.6",
+        "dottie": "^2.0.7",
         "inflection": "^1.13.4",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "request": {
       "form-data": "2.5.4",
       "qs": "^6.14.1"
-    }
+    },
+    "dottie": "^2.0.7"
   },
   "scripts": {
     "build": "gulp build",


### PR DESCRIPTION
## Summary
- Adds npm `overrides` entry to pin dottie >= 2.0.7, resolving CVE-2026-27837 / GHSA-r5mx-6wc6-7h9w (prototype pollution bypass)
- dottie is a transitive dependency via sequelize; sequelize's `^2.0.6` range is compatible with 2.0.7
- Proactive fix for satellite-6.19 — no JIRA ticket exists yet for this release, but foreman-3.18 has the same vulnerable dottie 2.0.6
- Mirror of foreman-3.16 PR #1133 (SAT-43385)

## Verification
- Before/after container image builds scanned with grype: CVE present in before (dottie 2.0.6), absent in after (dottie 2.0.7)
- Full test suite (docker-compose `test:ci`): 620 passed, 1 failed (pre-existing date flake in `read.integration.js`), 19 skipped

## Test plan
- [ ] Verify Konflux build succeeds
- [ ] Confirm grype/ACS scan shows no dottie CVEs
- [ ] Validate no functional regressions in staging

## Summary by Sourcery

Build:
- Add an npm overrides entry to force dottie to version 2.0.7 across the project.