### PR TITLE
RHINENG-26731: Update config endpoints

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -727,13 +727,15 @@ paths:
         - configuration
       summary: Get organization-wide configuration
       description: |
-        Returns the current and default configuration values for the caller's organization.
+        Returns the effective value of each organization-wide configuration field for the
+        caller's organization.
 
-        Each field has an `override` value (custom setting) and a `default` value (system default).
-        - `override: null` means no custom value is set; the system default is used
-        - `override: <value>` means a custom value has been explicitly configured
+        Each field reflects a custom override value when one has been set, or the system default
+        value when no override exists. All configuration fields are always included in the response.
 
-        The effective value for a field is: `override ?? default`
+        To see only the system default value for each field, use **GET /config/defaults**.
+
+        To see only fields with custom override values, use **GET /config/overrides**.
       operationId: getConfig
       responses:
         200:
@@ -743,37 +745,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/ConfigResponse'
               example:
-                plan_retention_days:
-                  override: null
-                  default: 120
-                plan_warning_days:
-                  override: 14
-                  default: 30
-    patch:
+                plan_retention_days: 120
+                plan_warning_days: 14
+
+  /config/defaults:
+    get:
       tags:
         - configuration
-      summary: Update organization configuration
-      description: |
-        Updates organization-wide configurable items for the caller's organization (restricted to organization admins only).
-
-        Sets custom values that override the system defaults. Use DELETE /config/{field} to reset a field back to its default value.  Alternately, send `null` to clear an override.
-
-        **Valid ranges:**
-        - `plan_retention_days`: 1-365 days (or `null` to use default)
-        - `plan_warning_days`: 1-365 days (or `null` to use default)
-
-        **Validation rules:**
-        - `plan_warning_days` must be less than `plan_retention_days` (using effective values after resolving nulls to system defaults)
-      operationId: updateConfig
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ConfigInput'
-            example:
-              plan_retention_days: 90
-              plan_warning_days: null
+      summary: Get system default values for organization-wide configuration fields
+      description: Returns the system default value for each organization-wide configuration field.
+      operationId: getConfigDefaults
       responses:
         200:
           description: OK
@@ -782,12 +763,79 @@ paths:
               schema:
                 $ref: '#/components/schemas/ConfigResponse'
               example:
-                plan_retention_days:
-                  override: 90
-                  default: 120
-                plan_warning_days:
-                  override: null
-                  default: 30
+                plan_retention_days: 120
+                plan_warning_days: 30
+
+  /config/overrides:
+    get:
+      tags:
+        - configuration
+      summary: Get custom override values for organization-wide configuration fields
+      description: |
+        Returns the custom override value for each organization-wide configuration field that
+        has been overridden for the caller's organization.
+
+        Only fields with a custom override value are included. Fields using the system default
+        are omitted from the response.
+
+        To see only the system default value for each field, use **GET /config/defaults**.
+      operationId: getConfigOverrides
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigResponse'
+              example:
+                plan_warning_days: 14
+    put:
+      tags:
+        - configuration
+      summary: Replace organization-wide configuration overrides
+      description: |
+        Replaces override values for organization-wide configuration fields (restricted to
+        organization admins only).
+
+        Fields omitted from the request body, or set to `null`, revert to the system default (stored as null).
+        To keep an existing override unchanged when updating another field, include that field in the request 
+        body with its current override value. To reset all overrides, send an empty object `{}`.
+
+        Only fields with a custom override value are included in the response.
+
+        **Valid ranges:**
+        - `plan_retention_days`: 1–366 days (omit from request body or set to `null` to use system default)
+        - `plan_warning_days`: 1–366 days (omit from request body or set to `null` to use system default)
+
+        **Validation:** `plan_warning_days` must be less than `plan_retention_days`. The validation
+        compares the effective value of each field based on the request body, so make sure the
+        **new** values are valid (When a field is omitted or set to null, the system default is used). 
+      operationId: putConfigOverrides
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfigInput'
+            examples:
+              single_field:
+                summary: Override one field and reset the other to system default
+                value:
+                  plan_warning_days: 14
+              both_fields:
+                summary: Override both fields **or** override one field and leave the other override value unchanged by using its current value
+                value:
+                  plan_retention_days: 90
+                  plan_warning_days: 14
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigResponse'
+              example:
+                plan_warning_days: 14
         400:
           description: Bad Request
           content:
@@ -813,57 +861,6 @@ paths:
                         title: Data validation error
                         details:
                           message: Warning period (30 days) must be less than retention period (20 days)
-
-  /config/{field}:
-    delete:
-      tags:
-        - configuration
-      summary: Reset an organization-wide config field to its default value
-      description: |
-        Resets an organization-wide config field to its default value (restricted to organization admins only).
-
-        After reset, the field's `override` will be `null` in the GET /config response, indicating the system default is in use.
-
-        **Note:** The reset will be rejected if it would violate the constraint that `plan_warning_days` must be less than `plan_retention_days`.
-      operationId: deleteConfigField
-      parameters:
-        - name: field
-          in: path
-          required: true
-          description: Config field to reset to the default value (`plan_retention_days` or `plan_warning_days`)
-          schema:
-            type: string
-            enum:
-              - plan_retention_days
-              - plan_warning_days
-      responses:
-        200:
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ConfigResponse'
-              example:
-                plan_retention_days:
-                  override: null
-                  default: 120
-                plan_warning_days:
-                  override: 14
-                  default: 30
-        400:
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RequestError'
-              example:
-                errors:
-                  - id: 550e8400-e29b-41d4-a716-446655440000
-                    status: 400
-                    code: INVALID_CONFIG
-                    title: Data validation error
-                    details:
-                      message: Warning period (30 days) must be less than retention period (25 days)
 
   /diagnosis/{system}:
     get:
@@ -1725,30 +1722,31 @@ components:
       additionalProperties: false
       x-remediations-strict: false
       description: |
-        Updates one or more organization-wide config values. Include only the properties you want to change.
+        Override values for organization-wide configuration fields.
 
-        **Important:**
-        - Omitted properties remain unchanged
-        - Set to null to clear an override and use system default
-        - Set to a value (1-365) to create/update a custom override
+        **Important:** Fields omitted from the request body, or set to `null`, revert to the system default (stored as null).
+        To keep an existing override unchanged when updating another field, include that field in the request 
+        body with its current override value. To reset all overrides, send an empty object `{}`.
       properties:
         plan_retention_days:
           type: integer
           nullable: true
           minimum: 1
-          maximum: 365
+          maximum: 366
           description: >
-            If a plan isn't updated or executed within this many days, it will be treated as expired.
-            Set to null to use system default (120 days). Set to 1-365 to override.
+            Organization-wide configuration field. If a plan isn't updated or executed within this
+            many days, it will be treated as expired. Omit this field from the request body or set
+            to `null` to use the system default. Must be greater than `plan_warning_days`.
           example: 90
         plan_warning_days:
           type: integer
           nullable: true
           minimum: 1
-          maximum: 365
+          maximum: 366
           description: >
-            If a plan is within this many days of being expired, a warning will be shown.
-            Set to null to use system default (30 days). Set to 1-365 to override.
+            Organization-wide configuration field. If a plan is within this many days of being
+            expired, a warning will be shown. Omit this field from the request body or set to
+            `null` to use the system default. Must be less than `plan_retention_days`.
           example: 14
 
     RemediationsList:
@@ -1830,54 +1828,25 @@ components:
     ConfigResponse:
       type: object
       additionalProperties: false
-      description: >
-        Configuration values for this organization. Each setting includes an optional override
-        and the system default. null override = using system default, non-null = custom override.
-      required:
-        - plan_retention_days
-        - plan_warning_days
+      x-remediations-strict: false # suppress validation since none of the properties is required
+      description: Values for organization-wide configuration fields.
       properties:
         plan_retention_days:
-          type: object
+          type: integer
+          minimum: 1
+          maximum: 366
           description: >
-            Remediation plans that haven't been updated or executed within this many days
-            will be considered expired.
-          additionalProperties: false
-          required: [override, default]
-          properties:
-            override:
-              type: integer
-              nullable: true
-              minimum: 1
-              maximum: 365
-              description: Custom override value, or null to use system default
-              example: 90
-            default:
-              type: integer
-              minimum: 1
-              maximum: 365
-              description: System default value
-              example: 120
+            Organization-wide configuration field. Remediation plans that haven't been updated or
+            executed within this many days will be treated as expired.
+          example: 120
         plan_warning_days:
-          type: object
+          type: integer
+          minimum: 1
+          maximum: 366
           description: >
-            Show warning when a remediation plan is within this many days of expiring.
-          additionalProperties: false
-          required: [override, default]
-          properties:
-            override:
-              type: integer
-              nullable: true
-              minimum: 1
-              maximum: 365
-              description: Custom override value, or null to use system default
-              example: 14
-            default:
-              type: integer
-              minimum: 1
-              maximum: 365
-              description: System default value
-              example: 30
+            Organization-wide configuration field. Show a warning when a plan is within this many
+            days of being expired.
+          example: 30
 
     RequestError:
       type: object

--- a/src/config/config.controller.js
+++ b/src/config/config.controller.js
@@ -5,144 +5,118 @@ const db = require('../db');
 const config = require('../config');
 const { ValidationError } = require('sequelize');
 
-function formatConfigResponse(orgConfig) {
-    const plan_retention_days = orgConfig?.plan_retention_days ?? null;
-    const plan_warning_days = orgConfig?.plan_warning_days ?? null;
-
-    return {
-        plan_retention_days: {
-            override: plan_retention_days,
-            default: config.plan_retention.retentionDays
-        },
-        plan_warning_days: {
-            override: plan_warning_days,
-            default: config.plan_retention.warningDays
-        }
-    };
+function formatOverridesResponse(orgConfig) {
+    const overrides = {};
+    if (orgConfig?.plan_retention_days != null) {
+        overrides.plan_retention_days = orgConfig.plan_retention_days;
+    }
+    if (orgConfig?.plan_warning_days != null) {
+        overrides.plan_warning_days = orgConfig.plan_warning_days;
+    }
+    return overrides;
 }
 
 /**
  * GET /v1/config
  *
- * Retrieves the organization's configuration settings for plan retention and warning periods.
- * Returns both the custom override values (null if not set) and system defaults.
+ * Returns the organization-wide configuration values in use for plan retention and warning
+ * periods. Each field reflects a custom override value when set, or the system default when
+ * no override exists. All configuration fields are always included in the response.
  *
- * Sample response:
+ * To see only system default values, use GET /v1/config/defaults.
+ * To see only custom overrides, use GET /v1/config/overrides.
+ *
+ * Sample response (retention uses default, warning overridden):
  * {
- *   "plan_retention_days": {
- *     "override": null,     // null = using system default
- *     "default": 120
- *   },
- *   "plan_warning_days": {
- *     "override": 14,       // custom value set
- *     "default": 30
- *   }
+ *   "plan_retention_days": 120,
+ *   "plan_warning_days": 14
+ * }
+ *
+ * Sample response (no overrides):
+ * {
+ *   "plan_retention_days": 120,
+ *   "plan_warning_days": 30
  * }
  */
 exports.get = errors.async(async function (req, res) {
     const { tenant_org_id } = req.user;
     const orgConfig = await db.org_config.findByPk(tenant_org_id);
 
-    // Return null for override when no custom value is set
-    return res.json(formatConfigResponse(orgConfig));
+    return res.json({
+        plan_retention_days: orgConfig?.plan_retention_days ?? config.plan_retention.retentionDays,
+        plan_warning_days: orgConfig?.plan_warning_days ?? config.plan_retention.warningDays
+    });
 });
 
 /**
- * PATCH /v1/config
+ * GET /v1/config/defaults
  *
- * Updates organization configuration settings. Only organization admins can call this endpoint.
- * Omitted fields remain unchanged. Set a field to null to clear the override and use the system default.
- * Validates that plan_warning_days < plan_retention_days (using effective values).
- *
- * Sample input:
- * {
- *   "plan_retention_days": 90,
- *   "plan_warning_days": null    // Clear override, use system default (30)
- * }
+ * Returns the system default value for each organization-wide configuration field.
+ * All configuration fields are always included in the response.
  *
  * Sample response:
  * {
- *   "plan_retention_days": {
- *     "override": 90,
- *     "default": 120
- *   },
- *   "plan_warning_days": {
- *     "override": null,
- *     "default": 30
- *   }
- * }
- *
- * Sample error (validation failure):
- * {
- *   "errors": [{
- *     "status": 400,
- *     "code": "INVALID_CONFIG",
- *     "title": "Data validation error",
- *     "details": {
- *       "message": "Warning period (30 days) must be less than retention period (20 days)"
- *     }
- *   }]
+ *   "plan_retention_days": 120,
+ *   "plan_warning_days": 30
  * }
  */
-exports.patch = errors.async(async function (req, res) {
-    const { tenant_org_id } = req.user;
-    const body = req.body ?? {};
-    const { plan_retention_days: bodyRetentionDays, plan_warning_days: bodyWarningDays } = body;
-
-    const current = await db.org_config.findByPk(tenant_org_id);
-
-    // For each field:
-    // - If present in request body (including null), use that value
-    // - Otherwise, keep current value (including null)
-    // - If no row in table, use null (meaning use system default)
-    const plan_retention_days = ('plan_retention_days' in body) ? bodyRetentionDays : (current?.plan_retention_days ?? null);
-    const plan_warning_days = ('plan_warning_days' in body) ? bodyWarningDays : (current?.plan_warning_days ?? null);
-
-    // We're creating a new object here because "current" will be null if there are no existing overrides
-    const orgConfig = {
-        org_id: tenant_org_id,
-        plan_retention_days,
-        plan_warning_days
-    };
-
-    try {
-        await db.org_config.upsert(orgConfig);
-    } catch (err) {
-        if (err instanceof ValidationError) {
-            throw new errors.BadRequest(
-                'INVALID_CONFIG',
-                'Data validation error',
-                { message: err.errors[0].message }
-            );
-        }
-        throw err;
-    }
-
-    return res.json(formatConfigResponse(orgConfig));
+exports.getDefaults = errors.async(async function (req, res) {
+    return res.json({
+        plan_retention_days: config.plan_retention.retentionDays,
+        plan_warning_days: config.plan_retention.warningDays
+    });
 });
 
 /**
- * DELETE /v1/config/:field
+ * GET /v1/config/overrides
  *
- * Resets a specific configuration field to null (use system default). Only organization admins can call this endpoint.
- * Validates that the reset won't violate the rule: plan_warning_days < plan_retention_days.
+ * Returns the custom override value for each organization-wide configuration field that
+ * has been overridden for the caller's organization. Only fields with a custom override
+ * value are included; fields using the system default are omitted.
  *
- * Path parameter:
- *   field: "plan_retention_days" or "plan_warning_days"
- *
- * Sample request:
- *   DELETE /v1/config/plan_warning_days
- *
- * Sample response:
+ * Sample response (one field overridden):
  * {
- *   "plan_retention_days": {
- *     "override": 90,
- *     "default": 120
- *   },
- *   "plan_warning_days": {
- *     "override": null,      // Reset to system default
- *     "default": 30
- *   }
+ *   "plan_warning_days": 14
+ * }
+ *
+ * Sample response (no overrides):
+ * {}
+ */
+exports.getOverrides = errors.async(async function (req, res) {
+    const { tenant_org_id } = req.user;
+    const orgConfig = await db.org_config.findByPk(tenant_org_id);
+
+    return res.json(formatOverridesResponse(orgConfig));
+});
+
+/**
+ * PUT /v1/config/overrides
+ *
+ * Replaces organization-wide configuration override values. Only organization admins can call this endpoint.
+ * Omitted fields are cleared (override set to null; system default is used). To change one override while
+ * keeping another, include the current value for the field that should stay overridden.
+ * Validates that plan_warning_days < plan_retention_days (using effective values).
+ *
+ * Sample input (override one field; other reverts to default):
+ * {
+ *   "plan_warning_days": 14
+ * }
+ *
+ * Sample input (override both, or update one while preserving the other):
+ * {
+ *   "plan_retention_days": 90,
+ *   "plan_warning_days": 14
+ * }
+ *
+ * Sample response (single field in request):
+ * {
+ *   "plan_warning_days": 14
+ * }
+ *
+ * Sample response (both fields in request, including an unchanged override):
+ * {
+ *   "plan_retention_days": 90,
+ *   "plan_warning_days": 14
  * }
  *
  * Sample error (validation failure):
@@ -157,19 +131,19 @@ exports.patch = errors.async(async function (req, res) {
  *   }]
  * }
  */
-exports.deleteConfig = errors.async(async function (req, res) {
+exports.putOverrides = errors.async(async function (req, res) {
     const { tenant_org_id } = req.user;
-    const { field } = req.params;
+    const { plan_retention_days, plan_warning_days } = req.body ?? {};
 
-    const existing = await db.org_config.findByPk(tenant_org_id);
-    if (!existing) {
-        // No org config row exists, return all nulls
-        return res.json(formatConfigResponse(null));
-    }
+    const orgConfigRow = {
+        org_id: tenant_org_id,
+        plan_retention_days: plan_retention_days !== undefined ? plan_retention_days : null,
+        plan_warning_days: plan_warning_days !== undefined ? plan_warning_days : null
+    };
 
+    let orgConfig;
     try {
-        // Set the specified field to null (use system default)
-        await existing.update({ [field]: null });
+        [orgConfig] = await db.org_config.upsert(orgConfigRow);
     } catch (err) {
         if (err instanceof ValidationError) {
             throw new errors.BadRequest(
@@ -181,6 +155,6 @@ exports.deleteConfig = errors.async(async function (req, res) {
         throw err;
     }
 
-    // After update(), the instance is updated in memory
-    return res.json(formatConfigResponse(existing));
+    // Return the fields that have a custom override value (i.e. not null which means they use the system default)
+    return res.json(formatOverridesResponse(orgConfig));
 });

--- a/src/config/config.controller.unit.js
+++ b/src/config/config.controller.unit.js
@@ -8,19 +8,17 @@ const controller = require('./config.controller');
 const db = require('../db');
 const config = require('../config');
 
-function expectedConfigData(orgConfig) {
-    const plan_retention_days = orgConfig?.plan_retention_days ?? null;
-    const plan_warning_days = orgConfig?.plan_warning_days ?? null;
-
+function expectedEffective(orgConfig) {
     return {
-        plan_retention_days: {
-            override: plan_retention_days,
-            default: config.plan_retention.retentionDays
-        },
-        plan_warning_days: {
-            override: plan_warning_days,
-            default: config.plan_retention.warningDays
-        }
+        plan_retention_days: orgConfig?.plan_retention_days ?? config.plan_retention.retentionDays,
+        plan_warning_days: orgConfig?.plan_warning_days ?? config.plan_retention.warningDays
+    };
+}
+
+function expectedDefaults() {
+    return {
+        plan_retention_days: config.plan_retention.retentionDays,
+        plan_warning_days: config.plan_retention.warningDays
     };
 }
 
@@ -40,7 +38,7 @@ describe('config controller unit tests', function () {
     });
 
     describe('get', function () {
-        test('returns organization values when configured', async () => {
+        test('returns effective values when configured', async () => {
             db.org_config.findByPk.resolves({
                 plan_retention_days: 90,
                 plan_warning_days: 14
@@ -56,10 +54,10 @@ describe('config controller unit tests', function () {
 
             await controller.get(req, res);
 
-            sinon.assert.calledWithExactly(res.json, expectedConfigData({ plan_retention_days: 90, plan_warning_days: 14 }));
+            sinon.assert.calledWithExactly(res.json, expectedEffective({ plan_retention_days: 90, plan_warning_days: 14 }));
         });
 
-        test('returns null overrides when org has no config', async () => {
+        test('returns defaults when org has no config', async () => {
             db.org_config.findByPk.resolves(null);
             const req = {
                 user: {
@@ -72,14 +70,55 @@ describe('config controller unit tests', function () {
 
             await controller.get(req, res);
 
-            sinon.assert.calledWithExactly(res.json, expectedConfigData(null));
+            sinon.assert.calledWithExactly(res.json, expectedEffective(null));
         });
     });
 
-    describe('patch', function () {
-        test('creates or updates org config and returns payload', async () => {
+    describe('getDefaults', function () {
+        test('returns system defaults', async () => {
+            const res = { json: sandbox.stub() };
+
+            await controller.getDefaults({}, res);
+
+            sinon.assert.calledWithExactly(res.json, expectedDefaults());
+        });
+    });
+
+    describe('getOverrides', function () {
+        test('returns only non-null override fields', async () => {
+            db.org_config.findByPk.resolves({
+                plan_retention_days: null,
+                plan_warning_days: 14
+            });
+            const req = {
+                user: { tenant_org_id: '5318290' }
+            };
+            const res = { json: sandbox.stub() };
+
+            await controller.getOverrides(req, res);
+
+            sinon.assert.calledWithExactly(res.json, { plan_warning_days: 14 });
+        });
+
+        test('returns empty object when org has no config', async () => {
             db.org_config.findByPk.resolves(null);
-            db.org_config.upsert.resolves();
+            const req = {
+                user: { tenant_org_id: '5318290' }
+            };
+            const res = { json: sandbox.stub() };
+
+            await controller.getOverrides(req, res);
+
+            sinon.assert.calledWithExactly(res.json, {});
+        });
+    });
+
+    describe('putOverrides', function () {
+        test('creates or updates org config and returns persisted override values', async () => {
+            db.org_config.upsert.resolves([{
+                plan_retention_days: 100,
+                plan_warning_days: 20
+            }, true]);
             const req = {
                 user: {
                     tenant_org_id: '5318290'
@@ -93,98 +132,103 @@ describe('config controller unit tests', function () {
                 json: sandbox.stub()
             };
 
-            await controller.patch(req, res);
+            await controller.putOverrides(req, res);
 
             sinon.assert.calledWithExactly(db.org_config.upsert, {
                 org_id: '5318290',
                 plan_retention_days: 100,
                 plan_warning_days: 20
             });
-            sinon.assert.calledWithExactly(res.json, expectedConfigData({ plan_retention_days: 100, plan_warning_days: 20 }));
+            sinon.assert.notCalled(db.org_config.findByPk);
+            sinon.assert.calledWithExactly(res.json, { plan_retention_days: 100, plan_warning_days: 20 });
         });
 
-        test('fills omitted field from existing org row', async () => {
-            db.org_config.findByPk.resolves({
-                plan_retention_days: 90,
-                plan_warning_days: 14
-            });
-            db.org_config.upsert.resolves();
-            const req = {
-                user: { tenant_org_id: '5318290' },
-                body: { plan_retention_days: 60 }
-            };
-            const res = { json: sandbox.stub() };
-
-            await controller.patch(req, res);
-
-            sinon.assert.calledWithExactly(db.org_config.upsert, {
-                org_id: '5318290',
-                plan_retention_days: 60,
-                plan_warning_days: 14
-            });
-        });
-
-        test('fills omitted field with null when no org row', async () => {
-            db.org_config.findByPk.resolves(null);
-            db.org_config.upsert.resolves();
+        test('clears omitted fields to null and omits them from response', async () => {
+            db.org_config.upsert.resolves([{
+                plan_retention_days: 50,
+                plan_warning_days: null
+            }, false]);
             const req = {
                 user: { tenant_org_id: '5318290' },
                 body: { plan_retention_days: 50 }
             };
             const res = { json: sandbox.stub() };
 
-            await controller.patch(req, res);
+            await controller.putOverrides(req, res);
 
             sinon.assert.calledWithExactly(db.org_config.upsert, {
                 org_id: '5318290',
                 plan_retention_days: 50,
                 plan_warning_days: null
             });
+            sinon.assert.calledWithExactly(res.json, { plan_retention_days: 50 });
         });
 
-        test('when body omits both fields and no org row, upserts nulls and returns them', async () => {
-            db.org_config.findByPk.resolves(null);
-            db.org_config.upsert.resolves();
+        test('omits null values from response', async () => {
+            db.org_config.upsert.resolves([{
+                plan_retention_days: null,
+                plan_warning_days: 14
+            }, false]);
+            const req = {
+                user: { tenant_org_id: '5318290' },
+                body: {
+                    plan_retention_days: null,
+                    plan_warning_days: 14
+                }
+            };
+            const res = { json: sandbox.stub() };
+
+            await controller.putOverrides(req, res);
+
+            sinon.assert.calledWithExactly(db.org_config.upsert, {
+                org_id: '5318290',
+                plan_retention_days: null,
+                plan_warning_days: 14
+            });
+            sinon.assert.calledWithExactly(res.json, { plan_warning_days: 14 });
+        });
+
+        test('empty body clears all overrides', async () => {
+            db.org_config.upsert.resolves([{
+                plan_retention_days: null,
+                plan_warning_days: null
+            }, false]);
             const req = {
                 user: { tenant_org_id: '5318290' },
                 body: {}
             };
             const res = { json: sandbox.stub() };
 
-            await controller.patch(req, res);
+            await controller.putOverrides(req, res);
 
             sinon.assert.calledWithExactly(db.org_config.upsert, {
                 org_id: '5318290',
                 plan_retention_days: null,
                 plan_warning_days: null
             });
-            sinon.assert.calledWithExactly(res.json, expectedConfigData(null));
+            sinon.assert.calledWithExactly(res.json, {});
         });
 
-        test('when body omits both fields and org row exists, upserts same values and returns them', async () => {
-            db.org_config.findByPk.resolves({
-                plan_retention_days: 88,
-                plan_warning_days: 9
-            });
-            db.org_config.upsert.resolves();
+        test('returns persisted values rather than request body when they differ', async () => {
+            db.org_config.upsert.resolves([{
+                plan_retention_days: 51,
+                plan_warning_days: 14
+            }, false]);
             const req = {
                 user: { tenant_org_id: '5318290' },
-                body: {}
+                body: {
+                    plan_retention_days: 50,
+                    plan_warning_days: 14
+                }
             };
             const res = { json: sandbox.stub() };
 
-            await controller.patch(req, res);
+            await controller.putOverrides(req, res);
 
-            sinon.assert.calledWithExactly(db.org_config.upsert, {
-                org_id: '5318290',
-                plan_retention_days: 88,
-                plan_warning_days: 9
-            });
-            sinon.assert.calledWithExactly(res.json, expectedConfigData({ plan_retention_days: 88, plan_warning_days: 9 }));
+            sinon.assert.calledWithExactly(res.json, { plan_retention_days: 51, plan_warning_days: 14 });
         });
 
         test('rejects when warning >= retention', async () => {
-            db.org_config.findByPk.resolves(null);
             const validationError = new ValidationError('Validation error', [
                 { message: 'Warning period (30 days) must be less than retention period (30 days)' }
             ]);
@@ -200,8 +244,7 @@ describe('config controller unit tests', function () {
             const res = { json: sandbox.stub() };
             const next = sandbox.stub();
 
-            // Don't await - let errors.async catch and call next
-            await controller.patch(req, res, next).catch(() => {});
+            await controller.putOverrides(req, res, next).catch(() => {});
 
             sinon.assert.calledOnce(next);
             const err = next.firstCall.args[0];
@@ -210,32 +253,7 @@ describe('config controller unit tests', function () {
             err.error.title.should.equal('Data validation error');
         });
 
-        test('rejects when warning > retention', async () => {
-            db.org_config.findByPk.resolves(null);
-            const validationError = new ValidationError('Validation error', [
-                { message: 'Warning period (20 days) must be less than retention period (10 days)' }
-            ]);
-            db.org_config.upsert.rejects(validationError);
-
-            const req = {
-                user: { tenant_org_id: '5318290' },
-                body: {
-                    plan_retention_days: 10,
-                    plan_warning_days: 20
-                }
-            };
-            const res = { json: sandbox.stub() };
-            const next = sandbox.stub();
-
-            await controller.patch(req, res, next).catch(() => {});
-
-            sinon.assert.calledOnce(next);
-            const err = next.firstCall.args[0];
-            err.error.code.should.equal('INVALID_CONFIG');
-        });
-
         test('rejects when retention too low for default warning (30 days)', async () => {
-            db.org_config.findByPk.resolves(null);
             const validationError = new ValidationError('Validation error', [
                 { message: 'Warning period (30 days) must be less than retention period (20 days)' }
             ]);
@@ -244,14 +262,13 @@ describe('config controller unit tests', function () {
             const req = {
                 user: { tenant_org_id: '5318290' },
                 body: {
-                    plan_retention_days: 20,
-                    plan_warning_days: null
+                    plan_retention_days: 20
                 }
             };
             const res = { json: sandbox.stub() };
             const next = sandbox.stub();
 
-            await controller.patch(req, res, next).catch(() => {});
+            await controller.putOverrides(req, res, next).catch(() => {});
 
             sinon.assert.calledOnce(next);
             const err = next.firstCall.args[0];
@@ -259,9 +276,30 @@ describe('config controller unit tests', function () {
             err.error.details.message.should.match(/30 days.*20 days/);
         });
 
+        test('returns persisted override values', async () => {
+            db.org_config.upsert.resolves([{
+                plan_retention_days: 90,
+                plan_warning_days: 21
+            }, false]);
+            const req = {
+                user: { tenant_org_id: '5318290' },
+                body: {
+                    plan_retention_days: 90,
+                    plan_warning_days: 21
+                }
+            };
+            const res = { json: sandbox.stub() };
+
+            await controller.putOverrides(req, res);
+
+            sinon.assert.calledWithExactly(res.json, { plan_retention_days: 90, plan_warning_days: 21 });
+        });
+
         test('accepts when warning < retention', async () => {
-            db.org_config.findByPk.resolves(null);
-            db.org_config.upsert.resolves();
+            db.org_config.upsert.resolves([{
+                plan_retention_days: 90,
+                plan_warning_days: 14
+            }, false]);
             const req = {
                 user: { tenant_org_id: '5318290' },
                 body: {
@@ -271,133 +309,10 @@ describe('config controller unit tests', function () {
             };
             const res = { json: sandbox.stub() };
 
-            await controller.patch(req, res);
+            await controller.putOverrides(req, res);
 
             sinon.assert.calledOnce(db.org_config.upsert);
-            sinon.assert.calledWithExactly(res.json, expectedConfigData({ plan_retention_days: 90, plan_warning_days: 14 }));
-        });
-    });
-
-    describe('deleteConfig', function () {
-        test('returns null overrides when org has no config row', async () => {
-            db.org_config.findByPk.resolves(null);
-            const req = {
-                user: { tenant_org_id: '5318290' },
-                params: { field: 'plan_retention_days' }
-            };
-            const res = { json: sandbox.stub() };
-
-            await controller.deleteConfig(req, res, sandbox.stub());
-
-            sinon.assert.calledWithExactly(res.json, expectedConfigData(null));
-        });
-
-        test('resets one field to null and updates row when other stays customized', async () => {
-            const fakeRow = {
-                plan_retention_days: 90,
-                plan_warning_days: 14
-            };
-            fakeRow.update = sandbox.stub().callsFake(function(updates) {
-                Object.assign(fakeRow, updates);
-                return Promise.resolve();
-            });
-            fakeRow.destroy = sandbox.stub().resolves();
-            db.org_config.findByPk.resolves(fakeRow);
-
-            const req = {
-                user: { tenant_org_id: '5318290' },
-                params: { field: 'plan_retention_days' }
-            };
-            const res = { json: sandbox.stub() };
-
-            await controller.deleteConfig(req, res, sandbox.stub());
-
-            sinon.assert.calledOnce(fakeRow.update);
-            sinon.assert.calledWithExactly(fakeRow.update, { plan_retention_days: null });
-            sinon.assert.notCalled(fakeRow.destroy);
-            sinon.assert.calledWithExactly(res.json, expectedConfigData({ plan_retention_days: null, plan_warning_days: 14 }));
-        });
-
-        test('updates row setting both fields to null after reset', async () => {
-            const fakeRow = {
-                plan_retention_days: 120,
-                plan_warning_days: 10
-            };
-            fakeRow.update = sandbox.stub().callsFake(function(updates) {
-                Object.assign(fakeRow, updates);
-                return Promise.resolve();
-            });
-            fakeRow.destroy = sandbox.stub().resolves();
-            db.org_config.findByPk.resolves(fakeRow);
-
-            const req = {
-                user: { tenant_org_id: '5318290' },
-                params: { field: 'plan_warning_days' }
-            };
-            const res = { json: sandbox.stub() };
-
-            await controller.deleteConfig(req, res, sandbox.stub());
-
-            sinon.assert.calledOnce(fakeRow.update);
-            sinon.assert.calledWithExactly(fakeRow.update, { plan_warning_days: null });
-            sinon.assert.notCalled(fakeRow.destroy);
-            sinon.assert.calledWithExactly(res.json, expectedConfigData({ plan_retention_days: 120, plan_warning_days: null }));
-        });
-
-        test('rejects when resetting warning to default would violate rule', async () => {
-            // retention=25, warning=20 -> delete warning -> warning becomes 30
-            // 30 >= 25, so should fail
-            const validationError = new ValidationError('Validation error', [
-                { message: 'Warning period (30 days) must be less than retention period (25 days)' }
-            ]);
-
-            const fakeRow = {
-                plan_retention_days: 25,
-                plan_warning_days: 20
-            };
-            fakeRow.update = sandbox.stub().rejects(validationError);
-            fakeRow.destroy = sandbox.stub().resolves();
-            db.org_config.findByPk.resolves(fakeRow);
-
-            const req = {
-                user: { tenant_org_id: '5318290' },
-                params: { field: 'plan_warning_days' }
-            };
-            const res = { json: sandbox.stub() };
-            const next = sandbox.stub();
-
-            await controller.deleteConfig(req, res, next).catch(() => {});
-
-            sinon.assert.calledOnce(next);
-            const err = next.firstCall.args[0];
-            err.error.code.should.equal('INVALID_CONFIG');
-            err.error.details.message.should.match(/30 days.*25 days/);
-        });
-
-        test('accepts when resetting to default still satisfies rule', async () => {
-            // retention=150, warning=50 -> delete warning -> warning becomes 30
-            // 30 < 150, valid
-            const fakeRow = {
-                plan_retention_days: 150,
-                plan_warning_days: 50
-            };
-            fakeRow.update = sandbox.stub().callsFake(function(updates) {
-                Object.assign(fakeRow, updates);
-                return Promise.resolve();
-            });
-            fakeRow.destroy = sandbox.stub().resolves();
-            db.org_config.findByPk.resolves(fakeRow);
-
-            const req = {
-                user: { tenant_org_id: '5318290' },
-                params: { field: 'plan_warning_days' }
-            };
-            const res = { json: sandbox.stub() };
-
-            await controller.deleteConfig(req, res, sandbox.stub());
-
-            sinon.assert.calledOnce(fakeRow.update);
-            sinon.assert.calledWithExactly(res.json, expectedConfigData({ plan_retention_days: 150, plan_warning_days: null }));
+            sinon.assert.calledWithExactly(res.json, { plan_retention_days: 90, plan_warning_days: 14 });
         });
     });
 });

--- a/src/config/config.integration.js
+++ b/src/config/config.integration.js
@@ -9,21 +9,20 @@ const { MOCK_USERS } = require('../connectors/users/mock');
 const TEST_USER = MOCK_USERS.testWriteUser;
 const TEST_ORG_ID = TEST_USER.tenant_org_id;
 
-function expectedConfigData(orgConfig) {
-    const plan_retention_days = orgConfig?.plan_retention_days ?? null;
-    const plan_warning_days = orgConfig?.plan_warning_days ?? null;
-
+function expectedEffective(orgConfig) {
     return {
-        plan_retention_days: {
-            override: plan_retention_days,
-            default: config.plan_retention.retentionDays
-        },
-        plan_warning_days: {
-            override: plan_warning_days,
-            default: config.plan_retention.warningDays
-        }
+        plan_retention_days: orgConfig?.plan_retention_days ?? config.plan_retention.retentionDays,
+        plan_warning_days: orgConfig?.plan_warning_days ?? config.plan_retention.warningDays
     };
 }
+
+function expectedDefaults() {
+    return {
+        plan_retention_days: config.plan_retention.retentionDays,
+        plan_warning_days: config.plan_retention.warningDays
+    };
+}
+
 const ADMIN_AUTH = {
     [identityUtils.IDENTITY_HEADER]: identityUtils.createIdentityHeader(
         TEST_USER.username,
@@ -46,16 +45,16 @@ describe('config endpoints', () => {
         });
     });
 
-    test('GET /config returns null overrides when no org config exists', async () => {
+    test('GET /config returns defaults when no org config exists', async () => {
         const { body } = await request
             .get('/v1/config')
             .set(auth.testWrite)
             .expect(200);
 
-        body.should.eql(expectedConfigData(null));
+        body.should.eql(expectedEffective(null));
     });
 
-    test('GET /config returns saved organization values', async () => {
+    test('GET /config returns effective values with overrides applied', async () => {
         await db.org_config.upsert({
             org_id: TEST_ORG_ID,
             plan_retention_days: 90,
@@ -67,12 +66,45 @@ describe('config endpoints', () => {
             .set(auth.testWrite)
             .expect(200);
 
-        body.should.eql(expectedConfigData({ plan_retention_days: 90, plan_warning_days: 14 }));
+        body.should.eql(expectedEffective({ plan_retention_days: 90, plan_warning_days: 14 }));
     });
 
-    test('PATCH /config returns 403 for non-admin users', async () => {
+    test('GET /config/defaults returns system defaults', async () => {
         const { body } = await request
-            .patch('/v1/config')
+            .get('/v1/config/defaults')
+            .set(auth.testWrite)
+            .expect(200);
+
+        body.should.eql(expectedDefaults());
+    });
+
+    test('GET /config/overrides returns empty object when no org config exists', async () => {
+        const { body } = await request
+            .get('/v1/config/overrides')
+            .set(auth.testWrite)
+            .expect(200);
+
+        body.should.eql({});
+    });
+
+    test('GET /config/overrides returns only customized fields', async () => {
+        await db.org_config.upsert({
+            org_id: TEST_ORG_ID,
+            plan_retention_days: null,
+            plan_warning_days: 14
+        });
+
+        const { body } = await request
+            .get('/v1/config/overrides')
+            .set(auth.testWrite)
+            .expect(200);
+
+        body.should.eql({ plan_warning_days: 14 });
+    });
+
+    test('PUT /config/overrides returns 403 for non-admin users', async () => {
+        const { body } = await request
+            .put('/v1/config/overrides')
             .set(auth.testWrite)
             .send({
                 plan_retention_days: 90,
@@ -86,9 +118,9 @@ describe('config endpoints', () => {
         body.errors[0].details.message.should.equal('Organization admin access required');
     });
 
-    test('PATCH /config creates org config for admins', async () => {
+    test('PUT /config/overrides creates org config for admins', async () => {
         const { body } = await request
-            .patch('/v1/config')
+            .put('/v1/config/overrides')
             .set(ADMIN_AUTH)
             .send({
                 plan_retention_days: 90,
@@ -96,14 +128,14 @@ describe('config endpoints', () => {
             })
             .expect(200);
 
-        body.should.eql(expectedConfigData({ plan_retention_days: 90, plan_warning_days: 14 }));
+        body.should.eql({ plan_retention_days: 90, plan_warning_days: 14 });
 
         const saved = await db.org_config.findByPk(TEST_ORG_ID);
         saved.plan_retention_days.should.equal(90);
         saved.plan_warning_days.should.equal(14);
     });
 
-    test('PATCH /config updates existing org config for admins', async () => {
+    test('PUT /config/overrides updates existing org config for admins', async () => {
         await db.org_config.upsert({
             org_id: TEST_ORG_ID,
             plan_retention_days: 120,
@@ -111,7 +143,7 @@ describe('config endpoints', () => {
         });
 
         await request
-            .patch('/v1/config')
+            .put('/v1/config/overrides')
             .set(ADMIN_AUTH)
             .send({
                 plan_retention_days: 45,
@@ -124,12 +156,12 @@ describe('config endpoints', () => {
             .set(auth.testWrite)
             .expect(200);
 
-        body.should.eql(expectedConfigData({ plan_retention_days: 45, plan_warning_days: 7 }));
+        body.should.eql(expectedEffective({ plan_retention_days: 45, plan_warning_days: 7 }));
     });
 
-    test('PATCH /config validates retention range', async () => {
+    test('PUT /config/overrides validates retention range', async () => {
         const { body } = await request
-            .patch('/v1/config')
+            .put('/v1/config/overrides')
             .set(ADMIN_AUTH)
             .send({
                 plan_retention_days: 0,
@@ -141,31 +173,41 @@ describe('config endpoints', () => {
         body.errors[0].code.should.equal('minimum.openapi.requestValidation');
     });
 
-    test('PATCH /config can send only plan_retention_days; warning stays null when no row', async () => {
+    test('PUT /config/overrides with one field clears the other override', async () => {
         const { body } = await request
-            .patch('/v1/config')
+            .put('/v1/config/overrides')
             .set(ADMIN_AUTH)
             .send({ plan_retention_days: 55 })
             .expect(200);
 
-        body.should.eql(expectedConfigData({ plan_retention_days: 55, plan_warning_days: null }));
+        body.should.eql({ plan_retention_days: 55 });
+
+        const saved = await db.org_config.findByPk(TEST_ORG_ID);
+        saved.plan_retention_days.should.equal(55);
+        should(saved.plan_warning_days).equal(null);
     });
 
-    test('PATCH /config with empty body persists nulls and creates org row', async () => {
+    test('PUT /config/overrides with empty body clears all overrides', async () => {
+        await db.org_config.upsert({
+            org_id: TEST_ORG_ID,
+            plan_retention_days: 90,
+            plan_warning_days: 14
+        });
+
         const { body } = await request
-            .patch('/v1/config')
+            .put('/v1/config/overrides')
             .set(ADMIN_AUTH)
             .send({})
             .expect(200);
 
-        body.should.eql(expectedConfigData(null));
+        body.should.eql({});
 
         const saved = await db.org_config.findByPk(TEST_ORG_ID);
         should(saved.plan_retention_days).equal(null);
         should(saved.plan_warning_days).equal(null);
     });
 
-    test('PATCH /config can send only one field; other keeps existing org value', async () => {
+    test('PUT /config/overrides accepts null to clear a field override', async () => {
         await db.org_config.upsert({
             org_id: TEST_ORG_ID,
             plan_retention_days: 90,
@@ -173,72 +215,68 @@ describe('config endpoints', () => {
         });
 
         const { body } = await request
-            .patch('/v1/config')
+            .put('/v1/config/overrides')
             .set(ADMIN_AUTH)
-            .send({ plan_warning_days: 21 })
+            .send({
+                plan_retention_days: null,
+                plan_warning_days: 14
+            })
             .expect(200);
 
-        body.should.eql(expectedConfigData({ plan_retention_days: 90, plan_warning_days: 21 }));
-    });
-
-    test('DELETE /config/:field returns 403 for non-admin users', async () => {
-        await request
-            .delete('/v1/config/plan_retention_days')
-            .set(auth.testWrite)
-            .expect(403);
-    });
-
-    test('DELETE /config/:field resets plan_retention_days to null; warning unchanged', async () => {
-        await db.org_config.upsert({
-            org_id: TEST_ORG_ID,
-            plan_retention_days: 90,
-            plan_warning_days: 14
-        });
-
-        const { body } = await request
-            .delete('/v1/config/plan_retention_days')
-            .set(ADMIN_AUTH)
-            .expect(200);
-
-        body.should.eql(expectedConfigData({ plan_retention_days: null, plan_warning_days: 14 }));
+        body.should.eql({ plan_warning_days: 14 });
 
         const saved = await db.org_config.findByPk(TEST_ORG_ID);
         should(saved.plan_retention_days).equal(null);
         saved.plan_warning_days.should.equal(14);
     });
 
-    test('DELETE /config/:field updates row setting field to null', async () => {
+    test('PUT /config/overrides replaces prior overrides when sending one field', async () => {
         await db.org_config.upsert({
             org_id: TEST_ORG_ID,
-            plan_retention_days: 120,
-            plan_warning_days: 10
+            plan_retention_days: 90,
+            plan_warning_days: 14
         });
 
         const { body } = await request
-            .delete('/v1/config/plan_warning_days')
+            .put('/v1/config/overrides')
             .set(ADMIN_AUTH)
+            .send({ plan_warning_days: 21 })
             .expect(200);
 
-        body.should.eql(expectedConfigData({ plan_retention_days: 120, plan_warning_days: null }));
+        body.should.eql({ plan_warning_days: 21 });
 
         const saved = await db.org_config.findByPk(TEST_ORG_ID);
-        saved.plan_retention_days.should.equal(120);
-        should(saved.plan_warning_days).equal(null);
+        should(saved.plan_retention_days).equal(null);
+        saved.plan_warning_days.should.equal(21);
     });
 
-    test('DELETE /config/:field when no org row returns null overrides', async () => {
+    test('PUT /config/overrides returns all fields included in the request body', async () => {
+        await db.org_config.upsert({
+            org_id: TEST_ORG_ID,
+            plan_retention_days: 90,
+            plan_warning_days: 14
+        });
+
         const { body } = await request
-            .delete('/v1/config/plan_retention_days')
+            .put('/v1/config/overrides')
             .set(ADMIN_AUTH)
+            .send({
+                plan_retention_days: 90,
+                plan_warning_days: 21
+            })
             .expect(200);
 
-        body.should.eql(expectedConfigData(null));
+        body.should.eql({ plan_retention_days: 90, plan_warning_days: 21 });
+
+        const saved = await db.org_config.findByPk(TEST_ORG_ID);
+        saved.plan_retention_days.should.equal(90);
+        saved.plan_warning_days.should.equal(21);
     });
 
     describe('validation: plan_warning_days must be less than plan_retention_days', () => {
-        test('PATCH /config rejects when warning >= retention (both explicit)', async () => {
+        test('PUT /config/overrides rejects when warning >= retention (both explicit)', async () => {
             const { body } = await request
-                .patch('/v1/config')
+                .put('/v1/config/overrides')
                 .set(ADMIN_AUTH)
                 .send({
                     plan_retention_days: 30,
@@ -251,9 +289,9 @@ describe('config endpoints', () => {
             body.errors[0].title.should.equal('Data validation error');
         });
 
-        test('PATCH /config rejects when warning > retention', async () => {
+        test('PUT /config/overrides rejects when warning > retention', async () => {
             const { body } = await request
-                .patch('/v1/config')
+                .put('/v1/config/overrides')
                 .set(ADMIN_AUTH)
                 .send({
                     plan_retention_days: 10,
@@ -264,14 +302,12 @@ describe('config endpoints', () => {
             body.errors[0].code.should.equal('INVALID_CONFIG');
         });
 
-        test('PATCH /config rejects when retention too low for default warning', async () => {
-            // Default warning is 30 days
+        test('PUT /config/overrides rejects when retention too low for default warning', async () => {
             const { body } = await request
-                .patch('/v1/config')
+                .put('/v1/config/overrides')
                 .set(ADMIN_AUTH)
                 .send({
-                    plan_retention_days: 20,
-                    plan_warning_days: null
+                    plan_retention_days: 20
                 })
                 .expect(400);
 
@@ -279,13 +315,11 @@ describe('config endpoints', () => {
             body.errors[0].details.message.should.match(/30 days.*20 days/);
         });
 
-        test('PATCH /config rejects when warning too high for default retention', async () => {
-            // Default retention is 120 days
+        test('PUT /config/overrides rejects when warning too high for default retention', async () => {
             const { body } = await request
-                .patch('/v1/config')
+                .put('/v1/config/overrides')
                 .set(ADMIN_AUTH)
                 .send({
-                    plan_retention_days: null,
                     plan_warning_days: 120
                 })
                 .expect(400);
@@ -294,7 +328,7 @@ describe('config endpoints', () => {
             body.errors[0].details.message.should.match(/120 days.*120 days/);
         });
 
-        test('PATCH /config rejects when updating one field violates rule with existing value', async () => {
+        test('PUT /config/overrides rejects when updating one field violates rule with cleared field using default', async () => {
             await db.org_config.upsert({
                 org_id: TEST_ORG_ID,
                 plan_retention_days: 60,
@@ -302,7 +336,7 @@ describe('config endpoints', () => {
             });
 
             const { body } = await request
-                .patch('/v1/config')
+                .put('/v1/config/overrides')
                 .set(ADMIN_AUTH)
                 .send({ plan_retention_days: 5 })
                 .expect(400);
@@ -310,10 +344,7 @@ describe('config endpoints', () => {
             body.errors[0].code.should.equal('INVALID_CONFIG');
         });
 
-        test('DELETE /config/:field rejects when reset would violate rule', async () => {
-            // Set up: retention=25, warning=20 (valid state)
-            // Delete warning -> warning becomes 30 (default), retention stays 25
-            // 30 >= 25, invalid!
+        test('PUT /config/overrides rejects when clearing warning would violate rule with retention override', async () => {
             await db.org_config.upsert({
                 org_id: TEST_ORG_ID,
                 plan_retention_days: 25,
@@ -321,17 +352,18 @@ describe('config endpoints', () => {
             });
 
             const { body } = await request
-                .delete('/v1/config/plan_warning_days')
+                .put('/v1/config/overrides')
                 .set(ADMIN_AUTH)
+                .send({ plan_retention_days: 25 })
                 .expect(400);
 
             body.errors[0].code.should.equal('INVALID_CONFIG');
             body.errors[0].details.message.should.match(/30 days.*25 days/);
         });
 
-        test('PATCH /config accepts when warning < retention', async () => {
+        test('PUT /config/overrides accepts when warning < retention', async () => {
             const { body } = await request
-                .patch('/v1/config')
+                .put('/v1/config/overrides')
                 .set(ADMIN_AUTH)
                 .send({
                     plan_retention_days: 90,
@@ -339,21 +371,17 @@ describe('config endpoints', () => {
                 })
                 .expect(200);
 
-            body.should.eql(expectedConfigData({ plan_retention_days: 90, plan_warning_days: 14 }));
+            body.should.eql({ plan_retention_days: 90, plan_warning_days: 14 });
         });
 
-        test('PATCH /config accepts when both null (uses defaults)', async () => {
-            // Default: retention=120, warning=30, which satisfies 30 < 120
+        test('PUT /config/overrides accepts when all overrides cleared', async () => {
             const { body } = await request
-                .patch('/v1/config')
+                .put('/v1/config/overrides')
                 .set(ADMIN_AUTH)
-                .send({
-                    plan_retention_days: null,
-                    plan_warning_days: null
-                })
+                .send({})
                 .expect(200);
 
-            body.should.eql(expectedConfigData(null));
+            body.should.eql({});
         });
     });
 });

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -6,6 +6,7 @@ const orgAdmin = require('../middleware/identity/orgAdmin');
 
 module.exports = function (router) {
     router.get('/config', openapi('getConfig'), controller.get);
-    router.patch('/config', orgAdmin, openapi('updateConfig'), controller.patch);
-    router.delete('/config/:field', orgAdmin, openapi('deleteConfigField'), controller.deleteConfig);
+    router.get('/config/defaults', openapi('getConfigDefaults'), controller.getDefaults);
+    router.get('/config/overrides', openapi('getConfigOverrides'), controller.getOverrides);
+    router.put('/config/overrides', orgAdmin, openapi('putConfigOverrides'), controller.putOverrides);
 };


### PR DESCRIPTION
## Summary by Sourcery

Revise configuration APIs to separate effective values, system defaults, and organization-specific overrides, simplifying response shapes and replacing patch/delete operations with a single override-focused endpoint.

New Features:
- Introduce endpoints to retrieve system default configuration values and organization-specific override values separately from effective values.

Enhancements:
- Change GET /config to return effective configuration values directly instead of nested override/default objects.
- Replace PATCH /config and DELETE /config/{field} with PUT /config/overrides, which clears omitted fields to defaults and returns only non-default overrides.
- Update OpenAPI specifications, schemas, and examples to reflect the new configuration model and validation behavior.

Tests:
- Update and expand unit and integration tests to cover the new configuration endpoints, override semantics, validation scenarios, and response formats.

Made the updates needed for this new design:

method & resource | request | response
-- | -- | --
GET /config | n/a | {"a": 30, "b": 120}
GET /config/defaults | n/a | {"a": 30, "b": 60}
GET /config/overrides | n/a | {"b": 120}
PUT /config/overrides | {"b": 90} | {"b": 90}

## Summary by Sourcery

Revise configuration API to return effective values directly and introduce separate endpoints for system defaults and organization-specific overrides, replacing patch/delete operations with a single override-focused update endpoint.

New Features:
- Add GET /config/defaults endpoint to return system default configuration values.
- Add GET /config/overrides endpoint to return only organization-specific override values.
- Add PUT /config/overrides endpoint to replace configuration overrides for an organization.

Enhancements:
- Change GET /config to return effective configuration values without nested override/default objects.
- Adjust override semantics so omitted fields are cleared back to defaults and responses only include non-default overrides.
- Update OpenAPI schemas, descriptions, and examples to reflect the new configuration model and validation behavior.

Tests:
- Update unit and integration tests to cover the new endpoints, override-clearing semantics, and validation rules while removing delete/patch-specific tests.