### PR TITLE
RHINENG-26902: add subscriptionRefresh play for patch remediations

### DIFF
--- a/src/connectors/patchman/impl.js
+++ b/src/connectors/patchman/impl.js
@@ -12,6 +12,7 @@ module.exports = new class extends Connector {
     constructor () {
         super(module);
         this.metrics = metrics.createConnectorMetric(this.getName());
+        this.templateMetrics = metrics.createConnectorMetric(this.getName(), 'getTemplateSystemIds');
     }
 
     async getErratum (id, refresh = false) {
@@ -40,6 +41,26 @@ module.exports = new class extends Connector {
 
             throw e;
         }
+    }
+
+    async getTemplateSystemIds (systemIds) {
+        const uri = new URI(host);
+        uri.path('/api/patch/v3/systems');
+        uri.search({
+            'filter[id]': `in:${systemIds.join(',')}`,
+            'filter[template_uuid]': 'neq:null',
+            limit: -1
+        });
+
+        const res = await this.doHttp({
+            uri: uri.toString(),
+            method: 'GET',
+            json: true,
+            headers: this.getForwardedHeaders()
+        }, false, this.templateMetrics);
+
+        const ids = _.get(res, ['data'], []).map(system => system.id);
+        return new Set(ids);
     }
 
     async ping () {

--- a/src/connectors/patchman/impl.unit.js
+++ b/src/connectors/patchman/impl.unit.js
@@ -56,6 +56,45 @@ describe('patchman impl', function () {
         cache.setex.callCount.should.equal(1);
     });
 
+    test('returns template-managed system IDs', async function () {
+        base.getSandbox().stub(request, 'run').resolves({
+            statusCode: 200,
+            body: {
+                data: [
+                    { id: '68799a02-8be9-11e8-9eb6-529269fb1459', type: 'system' },
+                    { id: '53fbcd90-9c8f-11e8-98d0-529269fb1459', type: 'system' }
+                ]
+            },
+            headers: {}
+        });
+
+        const result = await impl.getTemplateSystemIds([
+            '68799a02-8be9-11e8-9eb6-529269fb1459',
+            '53fbcd90-9c8f-11e8-98d0-529269fb1459',
+            'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+        ]);
+
+        result.should.be.an.instanceOf(Set);
+        result.size.should.equal(2);
+        result.has('68799a02-8be9-11e8-9eb6-529269fb1459').should.be.true();
+        result.has('53fbcd90-9c8f-11e8-98d0-529269fb1459').should.be.true();
+    });
+
+    test('returns empty Set when no systems are template-managed', async function () {
+        base.getSandbox().stub(request, 'run').resolves({
+            statusCode: 200,
+            body: {
+                data: []
+            },
+            headers: {}
+        });
+
+        const result = await impl.getTemplateSystemIds(['68799a02-8be9-11e8-9eb6-529269fb1459']);
+
+        result.should.be.an.instanceOf(Set);
+        result.size.should.equal(0);
+    });
+
     test('returns null on unknown CVE', async function () {
         const cache = mockCache();
 

--- a/src/connectors/patchman/mock.js
+++ b/src/connectors/patchman/mock.js
@@ -5,6 +5,10 @@ const Connector = require('../Connector');
 
 /* eslint-disable security/detect-object-injection, max-len */
 
+const TEMPLATE_MANAGED_SYSTEMS = new Set([
+    '32801e58-5765-4a0e-b1a0-1ab226aafeaa'
+]);
+
 const ERRATA = {
     'RHBA-2019:4105': {
         attributes: {
@@ -69,6 +73,11 @@ module.exports = new class extends Connector {
 
     getErratum (id) {
         return P.resolve(ERRATA[id]);
+    }
+
+    getTemplateSystemIds (systemIds) {
+        const result = new Set(systemIds.filter(id => TEMPLATE_MANAGED_SYSTEMS.has(id)));
+        return P.resolve(result);
     }
 
     ping () {

--- a/src/generator/__snapshots__/patchman.integration.js.snap
+++ b/src/generator/__snapshots__/patchman.integration.js.snap
@@ -1,5 +1,105 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`patchman adds subscription refresh play for template-managed systems 1`] = `
+"---
+# Red Hat Insights has recommended one or more actions for you, a system administrator, to review and if you
+# deem appropriate, deploy on your systems running Red Hat software. Based on the analysis, we have automatically
+# generated an Ansible Playbook for you. Please review and test the recommended actions and the Playbook as
+# they may contain configuration changes, updates, reboots and/or other changes to your systems. Red Hat is not
+# responsible for any adverse outcomes related to these recommendations or Playbooks.
+
+- name: refresh subscription-manager
+  hosts: "68799a02-8be9-11e8-9eb6-529269fb1459.example.com"
+  become: true
+  gather_facts: false
+  vars:
+    insights_signature_exclude: /hosts,/vars/insights_signature
+    insights_signature: ""
+  tasks:
+    - name: refresh subscription-manager
+      command: subscription-manager refresh
+      changed_when: false
+
+# Apply RHBA-2019:4105
+# Identifier: (patch-advisory:RHBA-2019:4105,fix)
+# Version: test
+- name: update packages
+  hosts: "68799a02-8be9-11e8-9eb6-529269fb1459.example.com"
+  vars:
+    insights_issues: "--advisory RHBA-2019:4105"
+    requires_reboot: "false"
+    insights_signature_exclude: "/hosts,/vars/insights_signature,/vars/insights_issues,/vars/requires_reboot"
+    insights_signature: !!binary |
+      TFMwdExTMUNSVWRKVGlCUVIxQWdVMGxIVGtGVVZWSkZMUzB0TFMwS1ZtVnljMmx2YmpvZ1IyNTFV
+      RWNnZGpFS0NtbFJTV05DUVVGQ1EwRkJSMEpSU20xWU5VdDBRVUZ2U2tWTmRuYzFPRVFyYWpWd1Ru
+      VTNZMUF2TVZGeGFuVkNUR1p4Y0ZFNVVpOVdkblYxWVVaVk1YSUtaa2x1Y3pSMFNWZHBSM3BGZEUx
+      c1ZEZGtZMHRhZG5wM2MzY3lOMEZwV1ZKVlVGSXdURk5ITlVKb2NXdEdaMmwxVUUxSlkwNXZlbmRI
+      TUVScU5IWjRkd3BQZVZWbU5XSmFaWGw2TDNnMlpsTk1hMVIwZWpOMk1VSjFVWFYxTlhWRlMxWnBX
+      bE5GWXpVeGFWUnphVGgyU2tGRFFreFRWbTk2V2toUVN6aEJURkZJQ2tabk9VTlZhVk5pVTJKYWRq
+      TmtlUzl4VUdkS1FUaHVVVEZQUkVwblYyWm1lRXBsVFZSWlpFNW5VVWRpT0VOMWVHOW5WMWRLYWtW
+      V09YUXdSMXBDTm04S2VXNDBiSFpsTUhZdmNGQTVSWFl2ZUVwUGFHUXljMWxvWjFWbWNteG9XRTQ1
+      V0ZweGJuaExlaTlsTUU0eE9FdG5RbWRYTURGNmRGVlhRVkl2TVhscWNBcGFlamdyVWt0NVdEQnBW
+      SEZLZWpWVGNWSjBiMlZZV1U4eloyNXViV2R0ZG1jM1dqbFRjMHR6ZVdzd1UzaExhRkF3WmtnM1Yy
+      MHljbmRoTWpsNFFpODRDbUp0YVRoNWR6TktTRUZvYzI5WmNGcDZUMGxuT1hGYVJYZGFZV1p3VVVS
+      UVJFMWpVakJaUmtkWk4xZHpVMkpETVRKNVVuRkpNbTgzY0dSUEt6WlViMUVLUkdweE5qbE5hR1Vy
+      TUZsUE9HOURUMWxQUWtKa1R6Sm5jaTkwYjFKaUwxWnBMeTl6VDNkMVdHdHZWeXQzYjFaMFdXczFU
+      R28wVlRWUFQzbENjMlZMV2dwU1RUWjVORnBCY2tWdlpTODJhMUZNV1hsaVEwbFFPRGM0UkVOT1Rq
+      bGpOMmd5UTFoRWNXNTZlWFJFT0ZNMWRXRnZkMlpoUnpoV09FVXhWR3AwWjFseENtZFpaVXhITVV3
+      MVExTTNkbFJ4UzFSUWRIbE9VREkwZVRKeFExZDFhVzlDVGt0NmJFdzJSVXBQTDJwaGEybExhbTFH
+      Wm05T1RTdFViRlY1VjJKUWQxRUtlbXRRVVdkUWRWcDBSbTFCVm01Qk9IVXJjVlJ1ZFdWeFVHWk9i
+      MVJ6TWxSV1ZXeE9UbEI0UlZOSGJFUkpNSHBDWVhCbmNHTkhVUzlzWlRGUVR5OXpZZ3BWZW10SmMy
+      WkxWMnhuUzJJemJYaFBZMmgzTndvOVpYRTFUQW90TFMwdExVVk9SQ0JRUjFBZ1UwbEhUa0ZVVlZK
+      RkxTMHRMUzBL
+  become: true
+  tasks:
+    - name: check for update
+      shell: "{{ ansible_facts['pkg_mgr'] }} check-update -q {{ insights_issues | regex_search('(--advisory ((FEDORA-EPEL-[\\\\w-]+)|(RH[SBE]A-20[\\\\d]{2}:[\\\\d]{4,6}))\\\\s*)+') }}"
+      check_mode: no
+      register: check_out
+      failed_when: check_out.rc != 0 and check_out.rc != 100
+
+    - when: check_out.rc == 100
+      name: upgrade package
+      shell: "{{ ansible_facts['pkg_mgr'] }} update-minimal -d 2 -y {{ insights_issues | regex_search('(--advisory ((FEDORA-EPEL-[\\\\w-]+)|(RH[SBE]A-20[\\\\d]{2}:[\\\\d]{4,6}))\\\\s*)+') }}"
+
+    - when: check_out.rc == 100
+      name: set reboot fact
+      set_fact:
+        insights_needs_reboot: "{{requires_reboot}}"
+
+- name: run insights
+  hosts: "68799a02-8be9-11e8-9eb6-529269fb1459.example.com"
+  become: true
+  gather_facts: false
+  vars:
+    insights_signature_exclude: /hosts,/vars/insights_signature
+    insights_signature: !!binary |
+      TFMwdExTMUNSVWRKVGlCUVIxQWdVMGxIVGtGVVZWSkZMUzB0TFMwS1ZtVnljMmx2YmpvZ1IyNTFV
+      RWNnZGpFS0NtbFJTVlpCZDFWQldVaHBRaXR6ZG5jMU9FUXJhalZ3VGtGUmFXdDRaeTh2WmtaRFoz
+      QXlTblIxVEd0UU5qQnNTa3BZYm1GU1JGTjVjVVYwU0ZSNlRGY0tOVlZSVlc5MWEyUmpVRFJVUlZn
+      d01EaDFhRkJHUzFaSmVrdFVTR2RsYTFOaU1UUXlkMjlQYm5sR2VUUnpRbEJrZEZoaGREVlliWEp0
+      VGxsR1EwaEVWZ28xYVhSdlNrcDBPVzg1UWtkQlJVaDVZMFJ3SzBoNVNqWXphM0paZVRGUk1rOXVU
+      azF3VjJaSmNtYzJUakJXVTJoa1JtVk1lR0ppTjBaMlpFaEpjbFo2Q2pJNGFrdHhOemx1Tm13eUx6
+      aDZZVkJSTDFkWVZIWkNaMDVhUkVWTFJ6TmhSSFl3WVRkbWIyUnlPRWhEZGxseE5tNUhNRkZOY1RO
+      U1ZFOXBkbFZtTTFnS1JuQnlhVTh2TDNKSlRDOVlSelE1TTA1NGFWSjBRakVyZEhSUk0wZHNhM1ZE
+      ZFVwck1EQkdaREp0ZDNZNFprRnZaR2xUUW5aelQydEpZekZyV25adFN3cEJjR3BEY1ZKMWVHaExU
+      MDgzYWxZM1FYSnRTV0p6TkhobVJrUkJVMkZaV2t4R01VMHZhME42ZWs1d1MwTjFhbE5hVUUxRlVt
+      WlhhV2RHVGpGMWRqRjNDalpQSzB0b1pTdFJVRU5hUm5CV1kwVndSbTFSTVdwcWFrOVFPV2haSzNW
+      alZWSnhSVEkyTlhGTWRuWnFSWE4wUW5WQk4xQkZNRVZ3UkRsaU5VaFZSM1lLTkZKemJXc3pNbFpC
+      Vnl0WE5IWk1VRWQwZG1sQ00wSXpUbE0wZUhCdVIzSmlObGs1Y1cwNFZuVTJSRUZIV2xOYWRsbFlk
+      bWQwTm1WR2N6RTVTVFZZUWdvMGVtcFVSRUlyTW1sT2NrcE9jM2d5YURoU1VGVnJMMmhZUzFKMGEy
+      WnZZMlpKZVRkcGNWY3hiMGRsTlZSMmFqTTFSbXRqUld0YU9VRnpSMjl6WXpWMENuUlZkVlZJWWpS
+      ME5EVTFSSE5EWlZWc1ZEZFNOakJDTTB4d1Z6TmlTRTF0YzFCMEx6RktNRFEwYm1KS2RFTkhUM1Jy
+      UVVWWVRsVTJlbGxUTDNBMFFqSUtaSFYxY2tZdlNHUnFWWFJNVDNSdlNFTnlZVWd2WkZwaFRVNTZk
+      MVZpZUc1VFZXUkdZU3R6TTBaNFJHczFVVkU0VVRaMVVucFpRbWw0WkcxeWREZGpUQXBKYTA1NlEy
+      aHBRMDlrY3owS1BVMVZOMk1LTFMwdExTMUZUa1FnVUVkUUlGTkpSMDVCVkZWU1JTMHRMUzB0Q2c9
+      PQ==
+  tasks:
+    - name: run insights
+      command: insights-client
+      changed_when: false"
+`;
+
 exports[`patchman aggregates multiple advisories into a single play 1`] = `
 "---
 # Red Hat Insights has recommended one or more actions for you, a system administrator, to review and if you
@@ -463,6 +563,153 @@ exports[`patchman generates a simple playbook with single patchman advisory reme
 
 - name: run insights
   hosts: "68799a02-8be9-11e8-9eb6-529269fb1459.example.com"
+  become: true
+  gather_facts: false
+  vars:
+    insights_signature_exclude: /hosts,/vars/insights_signature
+    insights_signature: !!binary |
+      TFMwdExTMUNSVWRKVGlCUVIxQWdVMGxIVGtGVVZWSkZMUzB0TFMwS1ZtVnljMmx2YmpvZ1IyNTFV
+      RWNnZGpFS0NtbFJTVlpCZDFWQldVaHBRaXR6ZG5jMU9FUXJhalZ3VGtGUmFXdDRaeTh2WmtaRFoz
+      QXlTblIxVEd0UU5qQnNTa3BZYm1GU1JGTjVjVVYwU0ZSNlRGY0tOVlZSVlc5MWEyUmpVRFJVUlZn
+      d01EaDFhRkJHUzFaSmVrdFVTR2RsYTFOaU1UUXlkMjlQYm5sR2VUUnpRbEJrZEZoaGREVlliWEp0
+      VGxsR1EwaEVWZ28xYVhSdlNrcDBPVzg1UWtkQlJVaDVZMFJ3SzBoNVNqWXphM0paZVRGUk1rOXVU
+      azF3VjJaSmNtYzJUakJXVTJoa1JtVk1lR0ppTjBaMlpFaEpjbFo2Q2pJNGFrdHhOemx1Tm13eUx6
+      aDZZVkJSTDFkWVZIWkNaMDVhUkVWTFJ6TmhSSFl3WVRkbWIyUnlPRWhEZGxseE5tNUhNRkZOY1RO
+      U1ZFOXBkbFZtTTFnS1JuQnlhVTh2TDNKSlRDOVlSelE1TTA1NGFWSjBRakVyZEhSUk0wZHNhM1ZE
+      ZFVwck1EQkdaREp0ZDNZNFprRnZaR2xUUW5aelQydEpZekZyV25adFN3cEJjR3BEY1ZKMWVHaExU
+      MDgzYWxZM1FYSnRTV0p6TkhobVJrUkJVMkZaV2t4R01VMHZhME42ZWs1d1MwTjFhbE5hVUUxRlVt
+      WlhhV2RHVGpGMWRqRjNDalpQSzB0b1pTdFJVRU5hUm5CV1kwVndSbTFSTVdwcWFrOVFPV2haSzNW
+      alZWSnhSVEkyTlhGTWRuWnFSWE4wUW5WQk4xQkZNRVZ3UkRsaU5VaFZSM1lLTkZKemJXc3pNbFpC
+      Vnl0WE5IWk1VRWQwZG1sQ00wSXpUbE0wZUhCdVIzSmlObGs1Y1cwNFZuVTJSRUZIV2xOYWRsbFlk
+      bWQwTm1WR2N6RTVTVFZZUWdvMGVtcFVSRUlyTW1sT2NrcE9jM2d5YURoU1VGVnJMMmhZUzFKMGEy
+      WnZZMlpKZVRkcGNWY3hiMGRsTlZSMmFqTTFSbXRqUld0YU9VRnpSMjl6WXpWMENuUlZkVlZJWWpS
+      ME5EVTFSSE5EWlZWc1ZEZFNOakJDTTB4d1Z6TmlTRTF0YzFCMEx6RktNRFEwYm1KS2RFTkhUM1Jy
+      UVVWWVRsVTJlbGxUTDNBMFFqSUtaSFYxY2tZdlNHUnFWWFJNVDNSdlNFTnlZVWd2WkZwaFRVNTZk
+      MVZpZUc1VFZXUkdZU3R6TTBaNFJHczFVVkU0VVRaMVVucFpRbWw0WkcxeWREZGpUQXBKYTA1NlEy
+      aHBRMDlrY3owS1BVMVZOMk1LTFMwdExTMUZUa1FnVUVkUUlGTkpSMDVCVkZWU1JTMHRMUzB0Q2c9
+      PQ==
+  tasks:
+    - name: run insights
+      command: insights-client
+      changed_when: false"
+`;
+
+exports[`patchman subscription refresh targets only template-managed hosts 1`] = `
+"---
+# Red Hat Insights has recommended one or more actions for you, a system administrator, to review and if you
+# deem appropriate, deploy on your systems running Red Hat software. Based on the analysis, we have automatically
+# generated an Ansible Playbook for you. Please review and test the recommended actions and the Playbook as
+# they may contain configuration changes, updates, reboots and/or other changes to your systems. Red Hat is not
+# responsible for any adverse outcomes related to these recommendations or Playbooks.
+
+- name: refresh subscription-manager
+  hosts: "68799a02-8be9-11e8-9eb6-529269fb1459.example.com"
+  become: true
+  gather_facts: false
+  vars:
+    insights_signature_exclude: /hosts,/vars/insights_signature
+    insights_signature: ""
+  tasks:
+    - name: refresh subscription-manager
+      command: subscription-manager refresh
+      changed_when: false
+
+# Apply RHBA-2019:4105
+# Identifier: (patch-advisory:RHBA-2019:4105,fix)
+# Version: test
+- name: update packages
+  hosts: "68799a02-8be9-11e8-9eb6-529269fb1459.example.com"
+  vars:
+    insights_issues: "--advisory RHBA-2019:4105"
+    requires_reboot: "false"
+    insights_signature_exclude: "/hosts,/vars/insights_signature,/vars/insights_issues,/vars/requires_reboot"
+    insights_signature: !!binary |
+      TFMwdExTMUNSVWRKVGlCUVIxQWdVMGxIVGtGVVZWSkZMUzB0TFMwS1ZtVnljMmx2YmpvZ1IyNTFV
+      RWNnZGpFS0NtbFJTV05DUVVGQ1EwRkJSMEpSU20xWU5VdDBRVUZ2U2tWTmRuYzFPRVFyYWpWd1Ru
+      VTNZMUF2TVZGeGFuVkNUR1p4Y0ZFNVVpOVdkblYxWVVaVk1YSUtaa2x1Y3pSMFNWZHBSM3BGZEUx
+      c1ZEZGtZMHRhZG5wM2MzY3lOMEZwV1ZKVlVGSXdURk5ITlVKb2NXdEdaMmwxVUUxSlkwNXZlbmRI
+      TUVScU5IWjRkd3BQZVZWbU5XSmFaWGw2TDNnMlpsTk1hMVIwZWpOMk1VSjFVWFYxTlhWRlMxWnBX
+      bE5GWXpVeGFWUnphVGgyU2tGRFFreFRWbTk2V2toUVN6aEJURkZJQ2tabk9VTlZhVk5pVTJKYWRq
+      TmtlUzl4VUdkS1FUaHVVVEZQUkVwblYyWm1lRXBsVFZSWlpFNW5VVWRpT0VOMWVHOW5WMWRLYWtW
+      V09YUXdSMXBDTm04S2VXNDBiSFpsTUhZdmNGQTVSWFl2ZUVwUGFHUXljMWxvWjFWbWNteG9XRTQ1
+      V0ZweGJuaExlaTlsTUU0eE9FdG5RbWRYTURGNmRGVlhRVkl2TVhscWNBcGFlamdyVWt0NVdEQnBW
+      SEZLZWpWVGNWSjBiMlZZV1U4eloyNXViV2R0ZG1jM1dqbFRjMHR6ZVdzd1UzaExhRkF3WmtnM1Yy
+      MHljbmRoTWpsNFFpODRDbUp0YVRoNWR6TktTRUZvYzI5WmNGcDZUMGxuT1hGYVJYZGFZV1p3VVVS
+      UVJFMWpVakJaUmtkWk4xZHpVMkpETVRKNVVuRkpNbTgzY0dSUEt6WlViMUVLUkdweE5qbE5hR1Vy
+      TUZsUE9HOURUMWxQUWtKa1R6Sm5jaTkwYjFKaUwxWnBMeTl6VDNkMVdHdHZWeXQzYjFaMFdXczFU
+      R28wVlRWUFQzbENjMlZMV2dwU1RUWjVORnBCY2tWdlpTODJhMUZNV1hsaVEwbFFPRGM0UkVOT1Rq
+      bGpOMmd5UTFoRWNXNTZlWFJFT0ZNMWRXRnZkMlpoUnpoV09FVXhWR3AwWjFseENtZFpaVXhITVV3
+      MVExTTNkbFJ4UzFSUWRIbE9VREkwZVRKeFExZDFhVzlDVGt0NmJFdzJSVXBQTDJwaGEybExhbTFH
+      Wm05T1RTdFViRlY1VjJKUWQxRUtlbXRRVVdkUWRWcDBSbTFCVm01Qk9IVXJjVlJ1ZFdWeFVHWk9i
+      MVJ6TWxSV1ZXeE9UbEI0UlZOSGJFUkpNSHBDWVhCbmNHTkhVUzlzWlRGUVR5OXpZZ3BWZW10SmMy
+      WkxWMnhuUzJJemJYaFBZMmgzTndvOVpYRTFUQW90TFMwdExVVk9SQ0JRUjFBZ1UwbEhUa0ZVVlZK
+      RkxTMHRMUzBL
+  become: true
+  tasks:
+    - name: check for update
+      shell: "{{ ansible_facts['pkg_mgr'] }} check-update -q {{ insights_issues | regex_search('(--advisory ((FEDORA-EPEL-[\\\\w-]+)|(RH[SBE]A-20[\\\\d]{2}:[\\\\d]{4,6}))\\\\s*)+') }}"
+      check_mode: no
+      register: check_out
+      failed_when: check_out.rc != 0 and check_out.rc != 100
+
+    - when: check_out.rc == 100
+      name: upgrade package
+      shell: "{{ ansible_facts['pkg_mgr'] }} update-minimal -d 2 -y {{ insights_issues | regex_search('(--advisory ((FEDORA-EPEL-[\\\\w-]+)|(RH[SBE]A-20[\\\\d]{2}:[\\\\d]{4,6}))\\\\s*)+') }}"
+
+    - when: check_out.rc == 100
+      name: set reboot fact
+      set_fact:
+        insights_needs_reboot: "{{requires_reboot}}"
+
+# Apply RHBA-2019:0689
+# Identifier: (patch-advisory:RHBA-2019:0689,fix)
+# Version: test
+- name: update packages
+  hosts: "53fbcd90-9c8f-11e8-98d0-529269fb1459.example.com"
+  vars:
+    insights_issues: "--advisory RHBA-2019:0689"
+    requires_reboot: "false"
+    insights_signature_exclude: "/hosts,/vars/insights_signature,/vars/insights_issues,/vars/requires_reboot"
+    insights_signature: !!binary |
+      TFMwdExTMUNSVWRKVGlCUVIxQWdVMGxIVGtGVVZWSkZMUzB0TFMwS1ZtVnljMmx2YmpvZ1IyNTFV
+      RWNnZGpFS0NtbFJTV05DUVVGQ1EwRkJSMEpSU20xWU5VdDBRVUZ2U2tWTmRuYzFPRVFyYWpWd1Ru
+      VTNZMUF2TVZGeGFuVkNUR1p4Y0ZFNVVpOVdkblYxWVVaVk1YSUtaa2x1Y3pSMFNWZHBSM3BGZEUx
+      c1ZEZGtZMHRhZG5wM2MzY3lOMEZwV1ZKVlVGSXdURk5ITlVKb2NXdEdaMmwxVUUxSlkwNXZlbmRI
+      TUVScU5IWjRkd3BQZVZWbU5XSmFaWGw2TDNnMlpsTk1hMVIwZWpOMk1VSjFVWFYxTlhWRlMxWnBX
+      bE5GWXpVeGFWUnphVGgyU2tGRFFreFRWbTk2V2toUVN6aEJURkZJQ2tabk9VTlZhVk5pVTJKYWRq
+      TmtlUzl4VUdkS1FUaHVVVEZQUkVwblYyWm1lRXBsVFZSWlpFNW5VVWRpT0VOMWVHOW5WMWRLYWtW
+      V09YUXdSMXBDTm04S2VXNDBiSFpsTUhZdmNGQTVSWFl2ZUVwUGFHUXljMWxvWjFWbWNteG9XRTQ1
+      V0ZweGJuaExlaTlsTUU0eE9FdG5RbWRYTURGNmRGVlhRVkl2TVhscWNBcGFlamdyVWt0NVdEQnBW
+      SEZLZWpWVGNWSjBiMlZZV1U4eloyNXViV2R0ZG1jM1dqbFRjMHR6ZVdzd1UzaExhRkF3WmtnM1Yy
+      MHljbmRoTWpsNFFpODRDbUp0YVRoNWR6TktTRUZvYzI5WmNGcDZUMGxuT1hGYVJYZGFZV1p3VVVS
+      UVJFMWpVakJaUmtkWk4xZHpVMkpETVRKNVVuRkpNbTgzY0dSUEt6WlViMUVLUkdweE5qbE5hR1Vy
+      TUZsUE9HOURUMWxQUWtKa1R6Sm5jaTkwYjFKaUwxWnBMeTl6VDNkMVdHdHZWeXQzYjFaMFdXczFU
+      R28wVlRWUFQzbENjMlZMV2dwU1RUWjVORnBCY2tWdlpTODJhMUZNV1hsaVEwbFFPRGM0UkVOT1Rq
+      bGpOMmd5UTFoRWNXNTZlWFJFT0ZNMWRXRnZkMlpoUnpoV09FVXhWR3AwWjFseENtZFpaVXhITVV3
+      MVExTTNkbFJ4UzFSUWRIbE9VREkwZVRKeFExZDFhVzlDVGt0NmJFdzJSVXBQTDJwaGEybExhbTFH
+      Wm05T1RTdFViRlY1VjJKUWQxRUtlbXRRVVdkUWRWcDBSbTFCVm01Qk9IVXJjVlJ1ZFdWeFVHWk9i
+      MVJ6TWxSV1ZXeE9UbEI0UlZOSGJFUkpNSHBDWVhCbmNHTkhVUzlzWlRGUVR5OXpZZ3BWZW10SmMy
+      WkxWMnhuUzJJemJYaFBZMmgzTndvOVpYRTFUQW90TFMwdExVVk9SQ0JRUjFBZ1UwbEhUa0ZVVlZK
+      RkxTMHRMUzBL
+  become: true
+  tasks:
+    - name: check for update
+      shell: "{{ ansible_facts['pkg_mgr'] }} check-update -q {{ insights_issues | regex_search('(--advisory ((FEDORA-EPEL-[\\\\w-]+)|(RH[SBE]A-20[\\\\d]{2}:[\\\\d]{4,6}))\\\\s*)+') }}"
+      check_mode: no
+      register: check_out
+      failed_when: check_out.rc != 0 and check_out.rc != 100
+
+    - when: check_out.rc == 100
+      name: upgrade package
+      shell: "{{ ansible_facts['pkg_mgr'] }} update-minimal -d 2 -y {{ insights_issues | regex_search('(--advisory ((FEDORA-EPEL-[\\\\w-]+)|(RH[SBE]A-20[\\\\d]{2}:[\\\\d]{4,6}))\\\\s*)+') }}"
+
+    - when: check_out.rc == 100
+      name: set reboot fact
+      set_fact:
+        insights_needs_reboot: "{{requires_reboot}}"
+
+- name: run insights
+  hosts: "53fbcd90-9c8f-11e8-98d0-529269fb1459.example.com,68799a02-8be9-11e8-9eb6-529269fb1459.example.com"
   become: true
   gather_facts: false
   vars:

--- a/src/generator/generator.controller.js
+++ b/src/generator/generator.controller.js
@@ -11,6 +11,7 @@ const SpecialPlay = require('./plays/SpecialPlay');
 const format = require('./format');
 const identifiers = require('../util/identifiers');
 const erratumPlayAggregator = require('./erratumPlayAggregator');
+const patchman = require('../connectors/patchman');
 const issueManager = require('../issues');
 const log = require('../util/log');
 const trace = require('../util/trace');
@@ -38,6 +39,26 @@ exports.playbookPipeline = async function ({issues, auto_reboot = true}, remedia
     _.forEach(issues, issue => {
         issue.id = identifiers.parse(issue.id);
         trace.event(`issue.id = ${issue.id}`);
+    });
+
+    const patchmanSystemIds = _(issues)
+        .filter(i => i.id.app === 'patch-advisory')
+        .flatMap('systems')
+        .uniq()
+        .value();
+
+    const templateSystemIdsPromise = patchmanSystemIds.length > 0
+        ? patchman.getTemplateSystemIds(patchmanSystemIds).catch(e => {
+            log.warn(e, 'failed to query patchman for template systems, skipping subscription refresh play');
+            return new Set();
+        })
+        : Promise.resolve(new Set());
+
+    const systemIdToHostMap = new Map();
+    issues.forEach(issue => {
+        issue.systems.forEach((systemId, index) => {
+            systemIdToHostMap.set(systemId, issue.hosts[index]);
+        });
     });
 
     trace.event('Get play snippets for each issue...');
@@ -77,7 +98,12 @@ exports.playbookPipeline = async function ({issues, auto_reboot = true}, remedia
     trace.event('Aggregate erratum plays...');
     issues = erratumPlayAggregator.process(issues);
 
-    // Add play that generates a new Compliance report when there are Compliance(ssg) issues  
+    if (patchmanSystemIds.length > 0) {
+        trace.event('Add subscription-manager refresh play...');
+        issues = await addSubscriptionRefreshPlay(issues, templateSystemIdsPromise, systemIdToHostMap);
+    }
+
+    // Add play that generates a new Compliance report when there are Compliance(ssg) issues
     const complianceIssue = _.some(issues, issue => issue.id.app === 'ssg');
     if (complianceIssue) {
         trace.event('Generate new Compliance report...');
@@ -226,6 +252,27 @@ function addDiagnosisPlay (plays, remediation = false) {
 
     const hosts = _(diagnosisPlays).flatMap('hosts').uniq().sort().value();
     return [new SpecialPlay('special:diagnosis', hosts, templates.special.diagnosis), ...plays];
+}
+
+async function addSubscriptionRefreshPlay (plays, templateSystemIdsPromise, systemIdToHostMap) {
+    const templateSystemIds = await templateSystemIdsPromise;
+
+    if (templateSystemIds.size === 0) {
+        return plays;
+    }
+
+    const hosts = _(Array.from(templateSystemIds))
+        .map(id => systemIdToHostMap.get(id))
+        .filter()
+        .uniq()
+        .sort()
+        .value();
+
+    if (hosts.length === 0) {
+        return plays;
+    }
+
+    return [new SpecialPlay('special:subscription-refresh', hosts, templates.special.subscriptionRefresh), ...plays];
 }
 
 exports.send = async function (req, res, {yaml, definition}, attachment = false) {

--- a/src/generator/patchman.integration.js
+++ b/src/generator/patchman.integration.js
@@ -2,6 +2,7 @@
 
 const base = require('../test');
 const { request } = base;
+const patchman = require('../connectors/patchman');
 
 describe('patchman', function () {
     test('generates a simple playbook with single patchman advisory remediation', async () => {
@@ -97,6 +98,92 @@ describe('patchman', function () {
         .expect(200);
 
         expect(res.text).toMatchSnapshot();
+    });
+
+    test('adds subscription refresh play for template-managed systems', async () => {
+        base.getSandbox().stub(patchman, 'getTemplateSystemIds').resolves(
+            new Set(['68799a02-8be9-11e8-9eb6-529269fb1459'])
+        );
+
+        const data = {
+            issues: [{
+                id: 'patch-advisory:RHBA-2019:4105',
+                systems: ['68799a02-8be9-11e8-9eb6-529269fb1459']
+            }]
+        };
+
+        const res = await request
+        .post('/v1/playbook')
+        .send(data)
+        .expect(200);
+
+        expect(res.text).toMatchSnapshot();
+        expect(res.text.indexOf('refresh subscription-manager')).toBeLessThan(
+            res.text.indexOf('update packages')
+        );
+    });
+
+    test('subscription refresh targets only template-managed hosts', async () => {
+        base.getSandbox().stub(patchman, 'getTemplateSystemIds').resolves(
+            new Set(['68799a02-8be9-11e8-9eb6-529269fb1459'])
+        );
+
+        const data = {
+            issues: [{
+                id: 'patch-advisory:RHBA-2019:4105',
+                systems: ['68799a02-8be9-11e8-9eb6-529269fb1459']
+            }, {
+                id: 'patch-advisory:RHBA-2019:0689',
+                systems: ['53fbcd90-9c8f-11e8-98d0-529269fb1459']
+            }]
+        };
+
+        const res = await request
+        .post('/v1/playbook')
+        .send(data)
+        .expect(200);
+
+        expect(res.text).toMatchSnapshot();
+        expect(res.text.indexOf('refresh subscription-manager')).toBeLessThan(
+            res.text.indexOf('update packages')
+        );
+    });
+
+    test('skips subscription refresh when no systems are template-managed', async () => {
+        const data = {
+            issues: [{
+                id: 'patch-advisory:RHBA-2019:4105',
+                systems: ['68799a02-8be9-11e8-9eb6-529269fb1459']
+            }]
+        };
+
+        const res = await request
+        .post('/v1/playbook')
+        .send(data)
+        .expect(200);
+
+        expect(res.text).not.toContain('subscription-manager refresh');
+    });
+
+    test('generates playbook without subscription refresh on patchman API failure', async () => {
+        base.getSandbox().stub(patchman, 'getTemplateSystemIds').rejects(
+            new Error('patchman API error')
+        );
+
+        const data = {
+            issues: [{
+                id: 'patch-advisory:RHBA-2019:4105',
+                systems: ['68799a02-8be9-11e8-9eb6-529269fb1459']
+            }]
+        };
+
+        const res = await request
+        .post('/v1/playbook')
+        .send(data)
+        .expect(200);
+
+        expect(res.text).not.toContain('subscription-manager refresh');
+        expect(res.text).toContain('update packages');
     });
 
     test('400s on unknown issue', async () => {

--- a/src/templates/static/special/subscriptionRefresh.yml
+++ b/src/templates/static/special/subscriptionRefresh.yml
@@ -1,0 +1,11 @@
+- name: refresh subscription-manager
+  hosts: "@@HOSTS@@"
+  become: true
+  gather_facts: false
+  vars:
+    insights_signature_exclude: /hosts,/vars/insights_signature
+    insights_signature: ""
+  tasks:
+    - name: refresh subscription-manager
+      command: subscription-manager refresh
+      changed_when: false


### PR DESCRIPTION
This supports a feature of Patch that will pre-calculate template advisory installability. This means that Patch may know that an advisory is installable before a system does. In the case where a user switches a system from one template to another, this could break a patch remediation if the advisory is installable according to patch, but the system has not been refreshed recently and therefore is not actually installable on the system.

I added a special play that does a subscription-manager refresh before dnf update. It only adds the refresh on template-managed systems. I also added a mock template managed system, so it can be verified locally with:

```
curl -s -X POST "$BASE_URL" \
  -H 'Content-Type: application/json' \
  -H "x-rh-identity: $IDENTITY" \
  -d '{"issues":[{"id":"patch-advisory:RHBA-2019:4105","systems":["32801e58-5765-4a0e-b1a0-1ab226aafeaa"]}]}'
```

Happy to answer any questions. Also happy to change anything or everything. I did my best to follow existing precedence, but this seemed like a weird case, and I've never worked on this project before :)

## Summary by Sourcery

Add a subscription-manager refresh play to patch remediation playbooks for template-managed systems and wire it through the Patchman connector.

New Features:
- Generate a dedicated subscription refresh play in remediation playbooks for template-managed systems before package updates.
- Expose a Patchman connector API to fetch template-managed system IDs and use it when building playbooks.
- Provide a static Ansible template for the subscription-manager refresh play.

Enhancements:
- Integrate template-managed system detection into the playbook generation pipeline while gracefully degrading on Patchman API failures.

Tests:
- Add integration tests verifying subscription refresh plays are added only for template-managed systems and skipped on failures or non-template systems.
- Add unit tests for the Patchman connector method that retrieves template-managed system IDs.