### PR TITLE
RHINENG-27057: Fix pagination bugs

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -1197,7 +1197,7 @@ components:
       name: fields[data]
       description: |
         Include specified items
-        - name: list all remediation plan names and IDs in organization (cannot be combined with other fields)
+        - name: list all remediation plan names and IDs in organization (cannot be combined with other fields; limit and offset are ignored)
         - playbook_runs: include playbook run data in the response (cannot be combined with other fields)
         - last_playbook_run: include latest playbook run summary in the response (cannot be combined with other fields)
       required: false
@@ -2492,7 +2492,7 @@ components:
     RemediationNameList:
       type: object
       additionalProperties: false
-      required: [data, meta, links]
+      required: [data, meta]
       properties:
         data:
           type: array
@@ -2500,8 +2500,6 @@ components:
             $ref: '#/components/schemas/RemediationNameListItem'
         meta:
           $ref: '#/components/schemas/Meta'
-        links:
-          $ref: '#/components/schemas/Links'
 
     RemediationNameListItem:
       type: object

--- a/src/remediations/__snapshots__/read.integration.js.snap
+++ b/src/remediations/__snapshots__/read.integration.js.snap
@@ -2020,8 +2020,8 @@ exports[`remediations issues get filtered plan issues 1`] = `
     },
   ],
   "links": {
-    "first": "/api/remediations/v1/remediations/66eec356-dd06-4c72-a3b6-ef27d1508a02/issues?limit=10&offset=0",
-    "last": "/api/remediations/v1/remediations/66eec356-dd06-4c72-a3b6-ef27d1508a02/issues?limit=10&offset=0",
+    "first": "/api/remediations/v1/remediations/66eec356-dd06-4c72-a3b6-ef27d1508a02/issues?sort=id&limit=10&offset=0",
+    "last": "/api/remediations/v1/remediations/66eec356-dd06-4c72-a3b6-ef27d1508a02/issues?sort=id&limit=10&offset=0",
     "next": null,
     "previous": null,
   },
@@ -2049,8 +2049,8 @@ exports[`remediations issues get remediation plan issues 1`] = `
     },
   ],
   "links": {
-    "first": "/api/remediations/v1/remediations/e809526c-56f5-4cd8-a809-93328436ea23/issues?limit=4&offset=0",
-    "last": "/api/remediations/v1/remediations/e809526c-56f5-4cd8-a809-93328436ea23/issues?limit=4&offset=0",
+    "first": "/api/remediations/v1/remediations/e809526c-56f5-4cd8-a809-93328436ea23/issues?sort=id&limit=4&offset=0",
+    "last": "/api/remediations/v1/remediations/e809526c-56f5-4cd8-a809-93328436ea23/issues?sort=id&limit=4&offset=0",
     "next": null,
     "previous": null,
   },

--- a/src/remediations/__snapshots__/read.integration.js.snap
+++ b/src/remediations/__snapshots__/read.integration.js.snap
@@ -2020,8 +2020,8 @@ exports[`remediations issues get filtered plan issues 1`] = `
     },
   ],
   "links": {
-    "first": "/api/remediations/v1/remediations?limit=10&offset=0",
-    "last": "/api/remediations/v1/remediations?limit=10&offset=0",
+    "first": "/api/remediations/v1/remediations/66eec356-dd06-4c72-a3b6-ef27d1508a02/issues?limit=10&offset=0",
+    "last": "/api/remediations/v1/remediations/66eec356-dd06-4c72-a3b6-ef27d1508a02/issues?limit=10&offset=0",
     "next": null,
     "previous": null,
   },
@@ -2049,8 +2049,8 @@ exports[`remediations issues get remediation plan issues 1`] = `
     },
   ],
   "links": {
-    "first": "/api/remediations/v1/remediations?limit=4&offset=0",
-    "last": "/api/remediations/v1/remediations?limit=4&offset=0",
+    "first": "/api/remediations/v1/remediations/e809526c-56f5-4cd8-a809-93328436ea23/issues?limit=4&offset=0",
+    "last": "/api/remediations/v1/remediations/e809526c-56f5-4cd8-a809-93328436ea23/issues?limit=4&offset=0",
     "next": null,
     "previous": null,
   },
@@ -2078,8 +2078,8 @@ exports[`remediations issues get sorted plan issues 1`] = `
     },
   ],
   "links": {
-    "first": "/api/remediations/v1/remediations?limit=10&offset=0",
-    "last": "/api/remediations/v1/remediations?limit=10&offset=0",
+    "first": "/api/remediations/v1/remediations/e809526c-56f5-4cd8-a809-93328436ea23/issues?sort=-id&limit=10&offset=0",
+    "last": "/api/remediations/v1/remediations/e809526c-56f5-4cd8-a809-93328436ea23/issues?sort=-id&limit=10&offset=0",
     "next": null,
     "previous": null,
   },

--- a/src/remediations/controller.read.js
+++ b/src/remediations/controller.read.js
@@ -151,11 +151,8 @@ exports.list = errors.async(async function (req, res) {
 
         plan_names = _.map(plan_names, name => name.toJSON())
 
-        const total = fifi.getListSize(plan_names);
-        limit = limit || 1;
-
         trace.event('Format response');
-        const resp = format.planNames(plan_names, total, limit, offset, req.query.sort, req.query.system)
+        const resp = format.planNames(plan_names)
 
         trace.leave();
 

--- a/src/remediations/controller.read.js
+++ b/src/remediations/controller.read.js
@@ -640,7 +640,7 @@ exports.getIssues = errors.async(async function (req, res) {
     await Promise.all(promises);
 
     // return formatted results
-    const result = format.issues(plan_id, selected_issues, issue_count, limit, offset);
+    const result = format.issues(plan_id, selected_issues, issue_count, limit, offset, sort);
 
     res.json(result);
 });

--- a/src/remediations/read.integration.js
+++ b/src/remediations/read.integration.js
@@ -234,12 +234,31 @@ describe('remediations', function () {
             .set(auth.fifi)
             .expect(200);
 
+            expect(body.links).toBeUndefined();
+            expect(body.meta.count).toBe(body.meta.total);
+            expect(body.meta.count).toBe(body.data.length);
+
             // items in list should have 'id' and 'name' fields
             for (const item of body.data) {
                 expect(Object.keys(item)).toHaveLength(2);
                 expect(item).toHaveProperty('id');
                 expect(item).toHaveProperty('name');
             }
+        });
+
+        test('list remediation plan names ignores limit', async () => {
+            const {body: limited} = await request
+            .get('/v1/remediations?fields[data]=name&limit=3')
+            .set(auth.fifi)
+            .expect(200);
+
+            const {body: unlimited} = await request
+            .get('/v1/remediations?fields[data]=name')
+            .set(auth.fifi)
+            .expect(200);
+
+            expect(limited.links).toBeUndefined();
+            expect(limited.data.length).toBe(unlimited.data.length);
         });
 
         test('fields[data]=names cannot be combined', async () => {
@@ -956,6 +975,9 @@ describe('remediations', function () {
             body.data.map(i => i.id).should.eql(['test:reboot']);
             body.meta.count.should.equal(1);
             body.meta.total.should.equal(2);
+            expect(body.links.first).toContain(`/v1/remediations/${remId}/systems/${systemId}/issues`);
+            expect(body.links.previous).toContain('offset=0');
+            expect(body.links.next).toBeNull();
         });
 
         test('returns 404 when system does not exist in remediation', async () => {
@@ -1213,10 +1235,14 @@ describe('remediations', function () {
 
     describe('issues', function () {
         test('get remediation plan issues', async () => {
+            const planId = 'e809526c-56f5-4cd8-a809-93328436ea23';
             const {body} = await request
-            .get('/v1/remediations/e809526c-56f5-4cd8-a809-93328436ea23/issues?limit=4')
+            .get(`/v1/remediations/${planId}/issues?limit=4`)
             .expect(200);
 
+            expect(body.links.first).toContain(`/v1/remediations/${planId}/issues`);
+            expect(body.links.first).toContain('limit=4');
+            expect(body.links.first).toContain('offset=0');
             expect(body).toMatchSnapshot();
         });
 
@@ -1463,8 +1489,9 @@ describe('remediations', function () {
 
     describe('remediation plan systems', function () {
         test('gets list of distinct systems with limit=2', async () => {
+            const planId = '5e6d136e-ea32-46e4-a350-325ef41790f4';
             const { body } = await request
-            .get('/v1/remediations/5e6d136e-ea32-46e4-a350-325ef41790f4/systems?limit=2')
+            .get(`/v1/remediations/${planId}/systems?limit=2`)
             .set(auth.testReadSingle)
             .expect(200);
 
@@ -1474,6 +1501,13 @@ describe('remediations', function () {
             body.should.have.property('data');
             body.data.should.be.Array();
             body.data.length.should.equal(body.meta.count);
+            expect(body.links.first).toContain(`/v1/remediations/${planId}/systems`);
+            expect(body.links.first).toContain('limit=2');
+            expect(body.links.first).toContain('offset=0');
+            if (body.meta.total > 2) {
+                expect(body.links.next).toContain(`/v1/remediations/${planId}/systems`);
+                expect(body.links.next).toContain('offset=2');
+            }
             if (body.data.length > 0) {
                 body.data[0].should.have.property('id');
                 body.data[0].should.have.property('hostname');

--- a/src/remediations/remediations.format.js
+++ b/src/remediations/remediations.format.js
@@ -11,12 +11,11 @@ const config = require('../config');
 const {filterIssuesPerExecutor} = require("./fifi");
 const {systemToHost} = require("../generator/generator.controller");
 
-const listLinkBuilder = (path, sort, system) => (limit, page) =>
-    new URI(config.path.base)
-    .segment('v1')
-    .segment('remediations')
-    .query({system, sort, limit, offset: page * limit})
-    .toString();
+const listLinkBuilder = (path, sort, system) => (limit, page) => {
+    const uri = new URI(config.path.base);
+    path.split('/').forEach(segment => uri.segment(segment));
+    return uri.query({system, sort, limit, offset: page * limit}).toString();
+};
 
 function buildListLinks (path, total, limit, offset, sort, system) {
     const lastPage = Math.floor(Math.max(total - 1, 0) / limit);
@@ -377,8 +376,7 @@ exports.planSystems = function (plan_id, systems, total, limit, offset, sort) {
     };
 };
 
-exports.planNames = function (names, total, limit, offset, sort, system) {
-    // Format data to include both id and name
+exports.planNames = function (names) {
     const formatted_data = _.map(names, plan => ({
         id: plan.id,
         name: plan.name
@@ -387,10 +385,9 @@ exports.planNames = function (names, total, limit, offset, sort, system) {
     return {
         meta: {
             count: names.length,
-            total
+            total: names.length
         },
-        data: formatted_data,
-        links: buildListLinks(total, limit, offset, sort, system),
+        data: formatted_data
     };
 };
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust remediation list pagination behaviors and response formats for plan name and related endpoints.

Bug Fixes:
- Ensure remediation plan name listing ignores limit/offset while keeping meta count consistent with returned items.
- Correct pagination link construction to respect arbitrary remediation subpaths instead of hard-coded segments.
- Validate pagination links and offsets for remediation issues and systems endpoints in integration tests.

Enhancements:
- Simplify remediation plan name list responses by dropping pagination links and deriving total from the returned data.
- Update OpenAPI schema and parameter descriptions to reflect the new remediation name list response shape and ignored pagination parameters.

Documentation:
- Document that limit and offset are ignored when listing remediation plan names and update the remediation name list response schema.

Tests:
- Expand integration tests to assert correct pagination metadata and links for remediation plan names, issues, and systems listings.