### PR TITLE
RHINENG-25797: Add upper limit for expires_within filter

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -1055,7 +1055,7 @@ components:
         - updated_after: modified on or after date-time, `filter[updated_after]=2025-03-31T08:19:36.641Z`
         - last_run_after: executed on or after date-time or 'never', `filter[last_run_after]=never` 
         - status: status matching one of [running, success, failure], `filter[status]=failure`
-        - expires_within: plans that expire within N days (expires_at date is on or before now + N days), `filter[expires_within]=30`
+        - expires_within: plans that expire within N days (expires_at date is on or before now + N days where N is an integer 1–366), `filter[expires_within]=30`
       required: false
       schema:
         anyOf:
@@ -1098,10 +1098,9 @@ components:
                   Example: '2024-09-11T12:00:00Z' or '2024-09-11T12:00:00.123Z'
               expires_within:
                 type: string
-                pattern: '^[1-9][0-9]*$'
                 description: >
                   Filter remediation plans that expire within N days (expires_at date is on or before now + N days).
-                  Must be an integer >= 1 (e.g. 30).
+                  Must be an integer from 1 to 366 (e.g. 30).
       style: deepObject
       explode: true
 

--- a/src/remediations/controller.read.js
+++ b/src/remediations/controller.read.js
@@ -124,6 +124,15 @@ exports.list = errors.async(async function (req, res) {
         filter = {name: filter};
     }
 
+    // OpenAPI request validator does not coerce or validate integer min/max on nested
+    // deepObject filter fields when the filter parameter uses anyOf so we validate filter.expires_within here
+    if (filter?.expires_within != null) {
+        const days = Number(filter.expires_within);
+        if (!Number.isInteger(days) || days < 1 || days > 366) {
+            throw new errors.BadRequest('INVALID_REQUEST', 'filter.expires_within must be an integer from 1 to 366');
+        }
+    }
+
     // NOTE: OpenAPI request validator is not enforcing enumerated string restrictions for array elements,
     // so we're validating fields[data] parameter here to prevent partial matches and enforce allowed values
     const fieldsData = _.get(req, 'query.fields.data', []);

--- a/src/remediations/read.integration.js
+++ b/src/remediations/read.integration.js
@@ -741,12 +741,12 @@ describe('remediations', function () {
                     testList('last_run_after=never query with match', '/v1/remediations?filter[last_run_after]=never', r256, r178, re80, rcbc, r66e);
                     testList('name and last_run_after query no match', '/v1/remediations?filter[last_run_after]=2018-12-04T08:19:36.641Z&filter[name]=REBootNoMatch');
 
-                    test('filter[expires_within] with a large window returns the same plans as an unfiltered list', async () => {
+                    test('filter[expires_within] with maximum window returns the same plans as an unfiltered list', async () => {
                         const {body: baseline} = await request
                             .get('/v1/remediations?pretty')
                             .expect(200);
                         const {body} = await request
-                            .get('/v1/remediations?pretty&filter[expires_within]=99999')
+                            .get('/v1/remediations?pretty&filter[expires_within]=366')
                             .expect(200);
 
                         _.map(body.data, 'id').should.eql(_.map(baseline.data, 'id'));
@@ -778,18 +778,18 @@ describe('remediations', function () {
                         'enum.openapi.requestValidation',
                         'must be equal to one of the allowed values (location: query, path: filter.status)'
                     );
-                    test400(
-                        'expires_within rejects zero',
-                        '/v1/remediations?filter[expires_within]=0',
-                        'pattern.openapi.requestValidation',
-                        'must match pattern "^[1-9][0-9]*$" (location: query, path: filter.expires_within)'
-                    );
-                    test400(
-                        'expires_within rejects non-numeric value',
-                        '/v1/remediations?filter[expires_within]=notanumber',
-                        'pattern.openapi.requestValidation',
-                        'must match pattern "^[1-9][0-9]*$" (location: query, path: filter.expires_within)'
-                    );
+                    test('expires_within rejects invalid values', async () => {
+                        for (const value of ['0', 'notanumber', '367']) {
+                            const {body} = await request
+                                .get(`/v1/remediations?filter[expires_within]=${value}`)
+                                .expect(400);
+
+                            body.errors[0].code.should.equal('INVALID_REQUEST');
+                            body.errors[0].title.should.equal(
+                                'filter.expires_within must be an integer from 1 to 366'
+                            );
+                        }
+                    });
                 });
             });
         });


### PR DESCRIPTION
## Summary by Sourcery

Enforce and document an upper bound on the expires_within remediation filter and update validation tests accordingly.

Bug Fixes:
- Validate filter.expires_within server-side to ensure it is an integer within the allowed range.

Enhancements:
- Clarify OpenAPI documentation for the expires_within filter to specify the valid numeric range and behavior.

Tests:
- Adjust and expand integration tests for the expires_within filter to cover the new maximum and invalid values.