### PR TITLE
RHINENG-21568: Handle HBI 404s and use local systems table for playbooks

### DIFF
--- a/db/seeders/20180101000000-systems.js
+++ b/db/seeders/20180101000000-systems.js
@@ -14,7 +14,8 @@ const SPECIAL_SYSTEMS = {
     '35f36364-6007-4ecc-9666-c4f8d354be9f': { hostname: '35e9b452-e405-499c-9c6e-120010b7b465.example.com' },
     '1040856f-b772-44c7-83a9-eea4813c4be8': { 
         hostname: '1040856f-b772-44c7-83a9-eea4813c4be8.example.com',
-        display_name: 'test-system-1'
+        display_name: 'test-system-1',
+        ansible_hostname: '1040856f-b772-44c7-83a9-eea4813c4be8.ansible.example.com'
     }
 };
 
@@ -108,7 +109,7 @@ function generateSystemData(id) {
             id,
             hostname: SPECIAL_SYSTEMS[id].hostname || null,
             display_name: SPECIAL_SYSTEMS[id].display_name || null,
-            ansible_hostname: SPECIAL_SYSTEMS[id].ansible_host || null
+            ansible_hostname: SPECIAL_SYSTEMS[id].ansible_hostname || null
         };
     }
 

--- a/src/generator/generator.controller.js
+++ b/src/generator/generator.controller.js
@@ -5,7 +5,9 @@ const P = require('bluebird');
 const etag = require('etag');
 
 const errors = require('../errors');
+const queries = require('../remediations/remediations.queries');
 const inventory = require('../connectors/inventory');
+const { storeSystemDetails } = require('../remediations/controller.write');
 const templates = require('../templates/static');
 const SpecialPlay = require('./plays/SpecialPlay');
 const format = require('./format');
@@ -126,17 +128,17 @@ exports.systemToHost = function (system) {
 };
 
 /**
- * Resolves system IDs to hostnames by fetching system details from Inventory.
+ * Resolves system IDs to hostnames by first checking the local systems table,
+ * then falling back to Inventory for any missing systems.
  * Adds a `hosts` property to each issue containing the resolved hostnames.
  *
  * @param {Array} issues - Array of issue objects, each containing a `systems` array of system IDs
  * @param {boolean} strict - Controls error handling for missing systems:
- *   - true (default): Throws UNKNOWN_SYSTEM error if any system ID is not found in Inventory
- *   - false: Gracefully handles missing systems by filtering them out and removing empty issues
+ *   - true (default): Throws UNKNOWN_SYSTEM error if any system ID is not found
+ *   - false: Filters out missing systems from hosts and removes issues with no valid systems/hosts
  *
- * Returns the issues array with `hosts` added to each issue
- * Or throws UNKNOWN_SYSTEM error if strict=true and some systems weren't found in Inventory.
- * When strict=false, missing systems are filtered out and issues with no remaining systems are removed.
+ * Returns the issues array with `hosts` added. Issues with no valid hosts are removed (strict=false only).
+ * Systems fetched from Inventory are stored locally for future lookups.
  */
 exports.resolveSystems = async function (issues, strict = true) {
     trace.enter('generator.controller.resolveSystems');
@@ -146,40 +148,42 @@ exports.resolveSystems = async function (issues, strict = true) {
         trace.event(`System IDs: ${JSON.stringify(systemIds)}`);
     }
 
-    trace.event('Get system details...');
-    // Fetch system details from Inventory:
-    // - refresh=true: bypass cache as ansible_host may change
-    // - strict=true: throw UNKNOWN_SYSTEM error if any systems are missing
-    // - strict=false: return partial results with only known systems
-    const systems = await inventory.getSystemDetailsBatch(systemIds, true, 2, strict)
+    trace.event('Get system details from local DB...');
+    let systems = await queries.getSystemDetailsForPlaybook(systemIds);
+
+    // Fallback: if any systems missing from local table, fetch from Inventory and store
+    const missingIds = systemIds.filter(id => !(id in systems));
+    if (missingIds.length > 0) {
+        trace.event(`Fetching ${missingIds.length} missing systems from Inventory...`);
+
+        // Fetch system details from Inventory:
+        // - refresh=true: bypass cache as ansible_host may change
+        // - strict=true: throw UNKNOWN_SYSTEM error if any systems are missing
+        // - strict=false: return partial results with only known systems
+        const inventoryData = await inventory.getSystemDetailsBatch(missingIds, true, 2, strict)
         .catch(e => {
             probes.failedGeneration('unknown system(s)');
             throw e;
         });
 
-    // When strict=false, filter out missing systems from issues
-    if (!strict) {
-        trace.event('Remove systems for which we have no inventory entry...');
-        _.forEach(issues, issue => issue.systems = issue.systems.filter((id) => {
-            // eslint-disable-next-line security/detect-object-injection
-            return (systems.hasOwnProperty(id));
-        }));
+        // Store Inventory systems in our local systems table so we don't have to fetch from Inventory next time
+        storeSystemDetails(inventoryData).catch(err => log.warn({ err }, 'Failed to store system details'));
+        systems = { ...systems, ...inventoryData };
     }
 
-    // Map system IDs to hostnames
-    trace.event('Map system IDs to hosts...');
-    _.forEach(issues, issue => issue.hosts = issue.systems.map(id => {
+    // Map system IDs to Ansible hostnames and filters out any systems not found in local systems table or Inventory
+    // For strict=true this is a no-op since getSystemDetailsBatch throws if any systems are missing
+    trace.event('Filter systems and map to hosts...');
+    _.forEach(issues, issue => {
         // eslint-disable-next-line security/detect-object-injection
-        const system = systems[id];
-        return exports.systemToHost(system);
-    }));
-    trace.event('All systems mapped!');
+        issue.hosts = issue.systems
+            .filter(id => id in systems)
+            .map(id => exports.systemToHost(systems[id]));
+    });
 
-    // If strict=false, filter out issues with no systems (systems that were removed because they don't exist in Inventory)
-    if (!strict) {
-        trace.event('Remove issues with no systems...')
-        issues = _.filter(issues, (issue) => (issue.systems.length > 0));
-    }
+    // Remove issues that have no hosts after filtering
+    // For strict=true this is a no-op since no systems should have been filtered out
+    issues = _.filter(issues, issue => issue.hosts.length > 0);
 
     trace.leave();
     return issues;

--- a/src/generator/generator.controller.js
+++ b/src/generator/generator.controller.js
@@ -6,8 +6,6 @@ const etag = require('etag');
 
 const errors = require('../errors');
 const queries = require('../remediations/remediations.queries');
-const inventory = require('../connectors/inventory');
-const { storeSystemDetails } = require('../remediations/controller.write');
 const templates = require('../templates/static');
 const SpecialPlay = require('./plays/SpecialPlay');
 const format = require('./format');
@@ -124,7 +122,7 @@ exports.generate = errors.async(async function (req, res) {
 });
 
 exports.systemToHost = function (system) {
-    return system.ansible_host || system.hostname || system.id;
+    return system.ansible_hostname || system.ansible_host || system.hostname || system.id;
 };
 
 /**
@@ -148,31 +146,17 @@ exports.resolveSystems = async function (issues, strict = true) {
         trace.event(`System IDs: ${JSON.stringify(systemIds)}`);
     }
 
-    trace.event('Get system details from local DB...');
-    let systems = await queries.getSystemDetailsForPlaybook(systemIds);
-
-    // Fallback: if any systems missing from local table, fetch from Inventory and store
-    const missingIds = systemIds.filter(id => !(id in systems));
-    if (missingIds.length > 0) {
-        trace.event(`Fetching ${missingIds.length} missing systems from Inventory...`);
-
-        // Fetch system details from Inventory:
-        // - refresh=true: bypass cache as ansible_host may change
-        // - strict=true: throw UNKNOWN_SYSTEM error if any systems are missing
-        // - strict=false: return partial results with only known systems
-        const inventoryData = await inventory.getSystemDetailsBatch(missingIds, true, 2, strict)
-        .catch(e => {
-            probes.failedGeneration('unknown system(s)');
-            throw e;
-        });
-
-        // Store Inventory systems in our local systems table so we don't have to fetch from Inventory next time
-        storeSystemDetails(inventoryData).catch(err => log.warn({ err }, 'Failed to store system details'));
-        systems = { ...systems, ...inventoryData };
+    trace.event('Get system details...');
+    let systems;
+    try {
+        systems = await queries.getPlanSystemsDetails(systemIds, 50, true, strict);
+    } catch (e) {
+        probes.failedGeneration('unknown system(s)');
+        throw e;
     }
 
-    // Map system IDs to Ansible hostnames and filters out any systems not found in local systems table or Inventory
-    // For strict=true this is a no-op since getSystemDetailsBatch throws if any systems are missing
+    // Build issue.hosts from resolved system ids
+    // Skip system ids that weren't found in the local systems table or Inventory
     trace.event('Filter systems and map to hosts...');
     _.forEach(issues, issue => {
         // eslint-disable-next-line security/detect-object-injection
@@ -181,7 +165,7 @@ exports.resolveSystems = async function (issues, strict = true) {
             .map(id => exports.systemToHost(systems[id]));
     });
 
-    // Remove issues that have no hosts after filtering
+    // Remove issues that have no issue.hosts after filtering
     // For strict=true this is a no-op since no systems should have been filtered out
     issues = _.filter(issues, issue => issue.hosts.length > 0);
 

--- a/src/generator/generator.controller.js
+++ b/src/generator/generator.controller.js
@@ -121,10 +121,6 @@ exports.generate = errors.async(async function (req, res) {
     return exports.send(req, res, playbook);
 });
 
-exports.systemToHost = function (system) {
-    return system.ansible_hostname || system.ansible_host || system.hostname || system.id;
-};
-
 /**
  * Resolves system IDs to hostnames by first checking the local systems table,
  * then falling back to Inventory for any missing systems.
@@ -149,20 +145,22 @@ exports.resolveSystems = async function (issues, strict = true) {
     trace.event('Get system details...');
     let systems;
     try {
-        systems = await queries.getPlanSystemsDetails(systemIds, 50, true, strict);
+        systems = await queries.getPlanSystemsDetails(systemIds, strict, true);
     } catch (e) {
-        probes.failedGeneration('unknown system(s)');
+        if (e.error?.code === 'UNKNOWN_SYSTEM') {
+            probes.failedGeneration('unknown system(s)');
+        }
         throw e;
     }
 
-    // Build issue.hosts from resolved system ids
+    // Build issue.hosts from resolved system ids: ansible_host → hostname → system id
     // Skip system ids that weren't found in the local systems table or Inventory
     trace.event('Filter systems and map to hosts...');
     _.forEach(issues, issue => {
         // eslint-disable-next-line security/detect-object-injection
         issue.hosts = issue.systems
             .filter(id => id in systems)
-            .map(id => exports.systemToHost(systems[id]));
+            .map(id => systems[id].ansible_host || systems[id].hostname || id);
     });
 
     // Remove issues that have no issue.hosts after filtering

--- a/src/generator/generator.unit.js
+++ b/src/generator/generator.unit.js
@@ -749,3 +749,142 @@ describe('host sanitation', function () {
         expect(text).toMatchSnapshot();
     });
 });
+
+describe('resolveSystems', function () {
+    const controller = require('./generator.controller');
+    const queries = require('../remediations/remediations.queries');
+    const inventory = require('../connectors/inventory');
+    const errors = require('../errors');
+
+    const system1Id = '68799a02-8be9-11e8-9eb6-529269fb1459';
+    const system2Id = '936ef48c-8f05-11e8-9eb6-529269fb1459';
+    const missingSystemId = '00000000-0000-0000-0000-000000000000';
+
+    let queriesStub;
+    let inventoryStub;
+
+    beforeEach(() => {
+        queriesStub = getSandbox().stub(queries, 'getSystemDetailsForPlaybook');
+        inventoryStub = getSandbox().stub(inventory, 'getSystemDetailsBatch');
+        // Note: storeSystemDetails is imported via destructuring, so we can't stub it easily
+        // The call happens but we test it indirectly by verifying Inventory data is used
+    });
+
+    test('uses systems from local DB when all found (Inventory not called)', async () => {
+        const issues = [{ id: 'test:ping', systems: [system1Id, system2Id] }];
+        
+        // All systems found in local DB
+        queriesStub.resolves({
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' },
+            [system2Id]: { id: system2Id, hostname: 'host2.example.com', ansible_host: null, display_name: 'Host 2' }
+        });
+
+        const result = await controller.resolveSystems(issues, true);
+
+        // Should have hosts mapped
+        result[0].hosts.should.deepEqual(['host1.example.com', 'host2.example.com']);
+        
+        // Inventory should NOT be called since all systems were in local DB
+        inventoryStub.should.not.have.been.called;
+    });
+
+    test('falls back to Inventory for systems missing from local DB', async () => {
+        const issues = [{ id: 'test:ping', systems: [system1Id, system2Id] }];
+        
+        // Only system1 found in local DB
+        queriesStub.resolves({
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' }
+        });
+        
+        // system2 fetched from Inventory
+        inventoryStub.resolves({
+            [system2Id]: { id: system2Id, hostname: 'host2.example.com', ansible_host: null, display_name: 'Host 2' }
+        });
+
+        const result = await controller.resolveSystems(issues, true);
+
+        // Should have both hosts mapped
+        result[0].hosts.should.deepEqual(['host1.example.com', 'host2.example.com']);
+        
+        // Inventory should be called only for missing system
+        inventoryStub.should.have.been.calledOnce;
+        inventoryStub.firstCall.args[0].should.deepEqual([system2Id]);
+    });
+
+    test('fetches from Inventory when systems missing from local DB', async () => {
+        const issues = [{ id: 'test:ping', systems: [system1Id] }];
+        
+        // No systems in local DB
+        queriesStub.resolves({});
+        
+        // System fetched from Inventory
+        const inventoryData = {
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' }
+        };
+        inventoryStub.resolves(inventoryData);
+
+        const result = await controller.resolveSystems(issues, true);
+
+        // Inventory should be called for the missing system
+        inventoryStub.should.have.been.calledOnce;
+        inventoryStub.firstCall.args[0].should.deepEqual([system1Id]);
+        
+        // Result should have the host mapped
+        result[0].hosts.should.deepEqual(['host1.example.com']);
+    });
+
+    test('throws UNKNOWN_SYSTEM error when strict=true and system not found', async () => {
+        const issues = [{ id: 'test:ping', systems: [missingSystemId] }];
+        
+        // No systems in local DB
+        queriesStub.resolves({});
+        
+        // Inventory throws UNKNOWN_SYSTEM error
+        const unknownSystemError = new errors.BadRequest('UNKNOWN_SYSTEM', `Unknown system identifier "${missingSystemId}"`);
+        unknownSystemError.notFoundIds = [missingSystemId];
+        inventoryStub.rejects(unknownSystemError);
+
+        await expect(controller.resolveSystems(issues, true))
+            .rejects.toThrow('Unknown system identifier');
+    });
+
+    test('filters out missing systems when strict=false', async () => {
+        const issues = [{ id: 'test:ping', systems: [system1Id, missingSystemId] }];
+        
+        // Only system1 in local DB
+        queriesStub.resolves({
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' }
+        });
+        
+        // Inventory returns empty (strict=false filters out missing)
+        inventoryStub.resolves({});
+
+        const result = await controller.resolveSystems(issues, false);
+
+        // Should only have host for system1, missingSystemId filtered out
+        result[0].hosts.should.deepEqual(['host1.example.com']);
+        // systems array is NOT modified - only hosts is filtered
+        result[0].systems.should.deepEqual([system1Id, missingSystemId]);
+    });
+
+    test('removes issues with no systems when strict=false', async () => {
+        const issues = [
+            { id: 'test:ping', systems: [missingSystemId] },
+            { id: 'test:reboot', systems: [system1Id] }
+        ];
+        
+        // Only system1 in local DB
+        queriesStub.resolves({
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' }
+        });
+        
+        // Inventory returns empty for missing system
+        inventoryStub.resolves({});
+
+        const result = await controller.resolveSystems(issues, false);
+
+        // First issue should be removed (no valid hosts)
+        result.should.have.length(1);
+        result[0].id.should.equal('test:reboot');
+    });
+});

--- a/src/generator/generator.unit.js
+++ b/src/generator/generator.unit.js
@@ -753,7 +753,6 @@ describe('host sanitation', function () {
 describe('resolveSystems', function () {
     const controller = require('./generator.controller');
     const queries = require('../remediations/remediations.queries');
-    const inventory = require('../connectors/inventory');
     const errors = require('../errors');
 
     const system1Id = '68799a02-8be9-11e8-9eb6-529269fb1459';
@@ -761,88 +760,58 @@ describe('resolveSystems', function () {
     const missingSystemId = '00000000-0000-0000-0000-000000000000';
 
     let queriesStub;
-    let inventoryStub;
 
     beforeEach(() => {
-        queriesStub = getSandbox().stub(queries, 'getSystemDetailsForPlaybook');
-        inventoryStub = getSandbox().stub(inventory, 'getSystemDetailsBatch');
-        // Note: storeSystemDetails is imported via destructuring, so we can't stub it easily
-        // The call happens but we test it indirectly by verifying Inventory data is used
+        queriesStub = getSandbox().stub(queries, 'getPlanSystemsDetails');
     });
 
     test('uses systems from local DB when all found (Inventory not called)', async () => {
         const issues = [{ id: 'test:ping', systems: [system1Id, system2Id] }];
         
-        // All systems found in local DB
         queriesStub.resolves({
-            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' },
-            [system2Id]: { id: system2Id, hostname: 'host2.example.com', ansible_host: null, display_name: 'Host 2' }
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_hostname: null, display_name: 'Host 1' },
+            [system2Id]: { id: system2Id, hostname: 'host2.example.com', ansible_hostname: null, display_name: 'Host 2' }
         });
 
         const result = await controller.resolveSystems(issues, true);
 
-        // Should have hosts mapped
         result[0].hosts.should.deepEqual(['host1.example.com', 'host2.example.com']);
-        
-        // Inventory should NOT be called since all systems were in local DB
-        inventoryStub.should.not.have.been.called;
+        queriesStub.calledOnceWith([system1Id, system2Id], 50, true, true).should.equal(true);
     });
 
     test('falls back to Inventory for systems missing from local DB', async () => {
         const issues = [{ id: 'test:ping', systems: [system1Id, system2Id] }];
         
-        // Only system1 found in local DB
         queriesStub.resolves({
-            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' }
-        });
-        
-        // system2 fetched from Inventory
-        inventoryStub.resolves({
-            [system2Id]: { id: system2Id, hostname: 'host2.example.com', ansible_host: null, display_name: 'Host 2' }
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_hostname: null, display_name: 'Host 1' },
+            [system2Id]: { id: system2Id, hostname: 'host2.example.com', ansible_hostname: null, display_name: 'Host 2' }
         });
 
         const result = await controller.resolveSystems(issues, true);
 
-        // Should have both hosts mapped
         result[0].hosts.should.deepEqual(['host1.example.com', 'host2.example.com']);
-        
-        // Inventory should be called only for missing system
-        inventoryStub.should.have.been.calledOnce;
-        inventoryStub.firstCall.args[0].should.deepEqual([system2Id]);
+        queriesStub.calledOnceWith([system1Id, system2Id], 50, true, true).should.equal(true);
     });
 
     test('fetches from Inventory when systems missing from local DB', async () => {
         const issues = [{ id: 'test:ping', systems: [system1Id] }];
         
-        // No systems in local DB
-        queriesStub.resolves({});
-        
-        // System fetched from Inventory
-        const inventoryData = {
-            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' }
-        };
-        inventoryStub.resolves(inventoryData);
+        queriesStub.resolves({
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_hostname: null, display_name: 'Host 1' }
+        });
 
         const result = await controller.resolveSystems(issues, true);
 
-        // Inventory should be called for the missing system
-        inventoryStub.should.have.been.calledOnce;
-        inventoryStub.firstCall.args[0].should.deepEqual([system1Id]);
-        
-        // Result should have the host mapped
+        queriesStub.calledOnceWith([system1Id], 50, true, true).should.equal(true);
         result[0].hosts.should.deepEqual(['host1.example.com']);
     });
 
     test('throws UNKNOWN_SYSTEM error when strict=true and system not found', async () => {
         const issues = [{ id: 'test:ping', systems: [missingSystemId] }];
         
-        // No systems in local DB
-        queriesStub.resolves({});
-        
-        // Inventory throws UNKNOWN_SYSTEM error
         const unknownSystemError = new errors.BadRequest('UNKNOWN_SYSTEM', `Unknown system identifier "${missingSystemId}"`);
         unknownSystemError.notFoundIds = [missingSystemId];
-        inventoryStub.rejects(unknownSystemError);
+        queriesStub.rejects(unknownSystemError);
 
         await expect(controller.resolveSystems(issues, true))
             .rejects.toThrow('Unknown system identifier');
@@ -851,20 +820,15 @@ describe('resolveSystems', function () {
     test('filters out missing systems when strict=false', async () => {
         const issues = [{ id: 'test:ping', systems: [system1Id, missingSystemId] }];
         
-        // Only system1 in local DB
         queriesStub.resolves({
-            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' }
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_hostname: null, display_name: 'Host 1' }
         });
-        
-        // Inventory returns empty (strict=false filters out missing)
-        inventoryStub.resolves({});
 
         const result = await controller.resolveSystems(issues, false);
 
-        // Should only have host for system1, missingSystemId filtered out
         result[0].hosts.should.deepEqual(['host1.example.com']);
-        // systems array is NOT modified - only hosts is filtered
         result[0].systems.should.deepEqual([system1Id, missingSystemId]);
+        queriesStub.calledOnceWith([system1Id, missingSystemId], 50, true, false).should.equal(true);
     });
 
     test('removes issues with no systems when strict=false', async () => {
@@ -873,18 +837,30 @@ describe('resolveSystems', function () {
             { id: 'test:reboot', systems: [system1Id] }
         ];
         
-        // Only system1 in local DB
         queriesStub.resolves({
-            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' }
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_hostname: null, display_name: 'Host 1' }
         });
-        
-        // Inventory returns empty for missing system
-        inventoryStub.resolves({});
 
         const result = await controller.resolveSystems(issues, false);
 
-        // First issue should be removed (no valid hosts)
         result.should.have.length(1);
         result[0].id.should.equal('test:reboot');
+    });
+
+    test('prefers ansible_hostname over hostname for playbook hosts', async () => {
+        const issues = [{ id: 'test:ping', systems: [system1Id] }];
+
+        queriesStub.resolves({
+            [system1Id]: {
+                id: system1Id,
+                hostname: 'host1.example.com',
+                ansible_hostname: 'ansible1.example.com',
+                display_name: 'Host 1'
+            }
+        });
+
+        const result = await controller.resolveSystems(issues, true);
+
+        result[0].hosts.should.deepEqual(['ansible1.example.com']);
     });
 });

--- a/src/generator/generator.unit.js
+++ b/src/generator/generator.unit.js
@@ -769,40 +769,40 @@ describe('resolveSystems', function () {
         const issues = [{ id: 'test:ping', systems: [system1Id, system2Id] }];
         
         queriesStub.resolves({
-            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_hostname: null, display_name: 'Host 1' },
-            [system2Id]: { id: system2Id, hostname: 'host2.example.com', ansible_hostname: null, display_name: 'Host 2' }
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' },
+            [system2Id]: { id: system2Id, hostname: 'host2.example.com', ansible_host: null, display_name: 'Host 2' }
         });
 
         const result = await controller.resolveSystems(issues, true);
 
         result[0].hosts.should.deepEqual(['host1.example.com', 'host2.example.com']);
-        queriesStub.calledOnceWith([system1Id, system2Id], 50, true, true).should.equal(true);
+        queriesStub.calledOnceWith([system1Id, system2Id], true, true).should.equal(true);
     });
 
     test('falls back to Inventory for systems missing from local DB', async () => {
         const issues = [{ id: 'test:ping', systems: [system1Id, system2Id] }];
         
         queriesStub.resolves({
-            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_hostname: null, display_name: 'Host 1' },
-            [system2Id]: { id: system2Id, hostname: 'host2.example.com', ansible_hostname: null, display_name: 'Host 2' }
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' },
+            [system2Id]: { id: system2Id, hostname: 'host2.example.com', ansible_host: null, display_name: 'Host 2' }
         });
 
         const result = await controller.resolveSystems(issues, true);
 
         result[0].hosts.should.deepEqual(['host1.example.com', 'host2.example.com']);
-        queriesStub.calledOnceWith([system1Id, system2Id], 50, true, true).should.equal(true);
+        queriesStub.calledOnceWith([system1Id, system2Id], true, true).should.equal(true);
     });
 
     test('fetches from Inventory when systems missing from local DB', async () => {
         const issues = [{ id: 'test:ping', systems: [system1Id] }];
         
         queriesStub.resolves({
-            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_hostname: null, display_name: 'Host 1' }
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' }
         });
 
         const result = await controller.resolveSystems(issues, true);
 
-        queriesStub.calledOnceWith([system1Id], 50, true, true).should.equal(true);
+        queriesStub.calledOnceWith([system1Id], true, true).should.equal(true);
         result[0].hosts.should.deepEqual(['host1.example.com']);
     });
 
@@ -821,14 +821,14 @@ describe('resolveSystems', function () {
         const issues = [{ id: 'test:ping', systems: [system1Id, missingSystemId] }];
         
         queriesStub.resolves({
-            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_hostname: null, display_name: 'Host 1' }
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' }
         });
 
         const result = await controller.resolveSystems(issues, false);
 
         result[0].hosts.should.deepEqual(['host1.example.com']);
         result[0].systems.should.deepEqual([system1Id, missingSystemId]);
-        queriesStub.calledOnceWith([system1Id, missingSystemId], 50, true, false).should.equal(true);
+        queriesStub.calledOnceWith([system1Id, missingSystemId], false, true).should.equal(true);
     });
 
     test('removes issues with no systems when strict=false', async () => {
@@ -838,7 +838,7 @@ describe('resolveSystems', function () {
         ];
         
         queriesStub.resolves({
-            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_hostname: null, display_name: 'Host 1' }
+            [system1Id]: { id: system1Id, hostname: 'host1.example.com', ansible_host: null, display_name: 'Host 1' }
         });
 
         const result = await controller.resolveSystems(issues, false);
@@ -847,14 +847,14 @@ describe('resolveSystems', function () {
         result[0].id.should.equal('test:reboot');
     });
 
-    test('prefers ansible_hostname over hostname for playbook hosts', async () => {
+    test('prefers ansible_host over hostname for playbook hosts', async () => {
         const issues = [{ id: 'test:ping', systems: [system1Id] }];
 
         queriesStub.resolves({
             [system1Id]: {
                 id: system1Id,
                 hostname: 'host1.example.com',
-                ansible_hostname: 'ansible1.example.com',
+                ansible_host: 'ansible1.example.com',
                 display_name: 'Host 1'
             }
         });

--- a/src/remediations/controller.write.js
+++ b/src/remediations/controller.write.js
@@ -511,3 +511,6 @@ exports.removeSystem = errors.async(async function (req, res) {
 
     return res.status(404).end();
 });
+
+// Export for reuse in generator.controller.js (backfill systems not in local DB)
+exports.storeSystemDetails = storeSystemDetails;

--- a/src/remediations/controller.write.js
+++ b/src/remediations/controller.write.js
@@ -52,7 +52,7 @@ async function storeSystemDetails(systemsById) {
 
     if (remediationSystems.length > 0) {
         await db.systems.bulkCreate(remediationSystems, {
-            ignoreDuplicates: true
+            updateOnDuplicate: ['hostname', 'display_name', 'ansible_hostname', 'updated_at']
         });
     }
 }

--- a/src/remediations/fifi.unit.js
+++ b/src/remediations/fifi.unit.js
@@ -289,12 +289,12 @@ describe('formatRunHosts and formatRHCHostDetails', function () {
             getPlanSystemsDetailsStub.resolves({
                 [system1Id]: {
                     hostname: 'server1.example.com',
-                    ansible_hostname: 'ansible1',
+                    ansible_host: 'ansible1',
                     display_name: 'Production Server 1'
                 },
                 [system2Id]: {
                     hostname: 'server2.example.com', 
-                    ansible_hostname: 'ansible2',
+                    ansible_host: 'ansible2',
                     display_name: 'Production Server 2'
                 }
             });
@@ -339,7 +339,7 @@ describe('formatRunHosts and formatRHCHostDetails', function () {
             getPlanSystemsDetailsStub.resolves({
                 [system1Id]: {
                     hostname: 'server1.example.com',
-                    ansible_hostname: 'ansible1',
+                    ansible_host: 'ansible1',
                     display_name: null
                 }
             });
@@ -473,7 +473,7 @@ describe('formatRunHosts and formatRHCHostDetails', function () {
             getPlanSystemsDetailsStub.resolves({
                 [system1Id]: {
                     hostname: 'server1.example.com',
-                    ansible_hostname: 'ansible1', 
+                    ansible_host: 'ansible1', 
                     display_name: 'Production Server 1'
                 }
             });
@@ -504,7 +504,7 @@ describe('formatRunHosts and formatRHCHostDetails', function () {
             getPlanSystemsDetailsStub.resolves({
                 [system1Id]: {
                     hostname: 'server1.example.com',
-                    ansible_hostname: 'ansible1',
+                    ansible_host: 'ansible1',
                     display_name: null
                 }
             });
@@ -558,7 +558,7 @@ describe('formatRunHosts and formatRHCHostDetails', function () {
             getPlanSystemsDetailsStub.resolves({
                 [system1Id]: {
                     hostname: 'server1.example.com',
-                    ansible_hostname: 'ansible1',
+                    ansible_host: 'ansible1',
                     display_name: 'Production Server 1'
                 }
             });

--- a/src/remediations/remediations.format.js
+++ b/src/remediations/remediations.format.js
@@ -9,7 +9,6 @@ const USER = ['username', 'first_name', 'last_name'];
 const PLAYBOOK_SUFFIX = 'yml';
 const config = require('../config');
 const {filterIssuesPerExecutor} = require("./fifi");
-const {systemToHost} = require("../generator/generator.controller");
 
 const listLinkBuilder = (path, sort, system) => (limit, page) => {
     const uri = new URI(config.path.base);

--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -888,12 +888,12 @@ exports.getPlanSystems = async function (
 /**
  * Fetch system details for a list of inventory UUIDs from the systems table.
  * For any systems not found in the local systems table, fetches details from the inventory service
- * and stores them locally. Returns hostname, ansible_hostname, and display_name for each system.
+ * and stores them locally. Returns hostname, ansible_host, and display_name for each system.
  * 
  * @param {string[]} inventoryIds - Array of inventory/system UUIDs to fetch details for
- * @param {number} [chunkSize=50] - Number of systems to process in each database chunk
- * @param {boolean} [refresh=false] - Bypass Inventory cache when fetching missing systems
  * @param {boolean} [strict=false] - Throw UNKNOWN_SYSTEM when Inventory cannot resolve a system
+ * @param {boolean} [refresh=false] - Bypass Inventory cache when fetching missing systems
+ * @param {number} [chunkSize=50] - Number of systems to process in each database chunk
  * @returns {Object} Object with inventory UUIDs as keys and system details as values
  * 
  * @example
@@ -905,12 +905,12 @@ exports.getPlanSystems = async function (
  * // Returns: {
  * //   'f6b7a1c2-3d4e-5f6a-7b8c-9d0e1f2a3b4c': { 
  * //     hostname: 'server1.example.com', 
- * //     ansible_hostname: 'ansible1', 
+ * //     ansible_host: 'ansible1',
  * //     display_name: 'Server 1'
  * //   },
  * //   'a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d': { 
  * //     hostname: 'server2.example.com', 
- * //     ansible_hostname: 'ansible2', 
+ * //     ansible_host: 'ansible2',
  * //     display_name: 'Server 2'
  * //   }
  * // }
@@ -919,28 +919,35 @@ exports.getPlanSystems = async function (
  * // Custom chunk size for performance tuning
  * const systemDetails = await getPlanSystemsDetails([
  *   'f6b7a1c2-3d4e-5f6a-7b8c-9d0e1f2a3b4c'
- * ], 25);
+ * ], false, false, 25);
  */
-exports.getPlanSystemsDetails = async function (inventoryIds, chunkSize = 50, refresh = false, strict = false) {
+exports.getPlanSystemsDetails = async function (inventoryIds, strict = false, refresh = false, chunkSize = 50) {
     if (!inventoryIds || inventoryIds.length === 0) {
         return {};
     }
 
+    // Process inventoryIds in chunks because a very large WHERE id IN (...) clause
+    // can potentially hit SQL query/message size limits
+
     // Check which systems already exist in the systems table
-    const existingSystems = await db.systems.findAll({
-        attributes: ['id'],
-        where: { id: inventoryIds },
-        raw: true
-    });
-    const existingIds = existingSystems.map(s => s.id);
-    const missingIds = _.difference(inventoryIds, existingIds);
+    const existingIds = new Set();
+    for (const chunk of _.chunk(inventoryIds, chunkSize)) {
+        const rows = await db.systems.findAll({
+            attributes: ['id'],
+            where: { id: chunk },
+            raw: true
+        });
+        rows.forEach(row => existingIds.add(row.id));
+    }
+
+    const missingIds = inventoryIds.filter(id => !existingIds.has(id));
 
     // Fetch missing system details from inventory service and store them
     await fetch_missing_system_data(missingIds, { refresh, strict });
 
     const result = {};
 
-    // Process in configurable chunks
+    // Read system details from the systems table
     for (const chunk of _.chunk(inventoryIds, chunkSize)) {
         const systems = await db.systems.findAll({
             attributes: ['id', 'hostname', 'ansible_hostname', 'display_name'],
@@ -953,7 +960,7 @@ exports.getPlanSystemsDetails = async function (inventoryIds, chunkSize = 50, re
             result[system.id] = {
                 id: system.id,
                 hostname: system.hostname,
-                ansible_hostname: system.ansible_hostname,
+                ansible_host: system.ansible_hostname,
                 display_name: system.display_name
             };
         });

--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -1212,3 +1212,25 @@ exports.clearOrgConfigCache = async function (tenant_org_id) {
         }
     }
 };
+
+exports.getSystemDetailsForPlaybook = async function (systemIds) {
+    if (!systemIds || systemIds.length === 0) {
+        return {};
+    }
+
+    const systems = await db.systems.findAll({
+        attributes: ['id', 'hostname', 'ansible_hostname', 'display_name'],
+        where: { id: systemIds },
+        raw: true
+    });
+
+    return _(systems)
+        .keyBy('id')
+        .mapValues(system => ({
+            id: system.id,
+            hostname: system.hostname,
+            ansible_host: system.ansible_hostname,
+            display_name: system.display_name
+        }))
+        .value();
+};

--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -6,6 +6,7 @@ const config = require('../config');
 const cache = require('../cache');
 const db = require('../db');
 const inventory = require('../connectors/inventory');
+const { storeSystemDetails } = require('./controller.write');
 const {NULL_NAME_VALUE} = require('./models/remediation');
 const _ = require('lodash');
 const log = require('../util/log');
@@ -757,26 +758,13 @@ exports.getIssueSystems = function (id, tenant_org_id, created_by, issueId) {
     });
 };
 
-// Fetch missing system details from inventory service and store in systems table
-async function fetch_missing_system_data(missingIds) {
-    // just being diligent and validating our input parameters...
+async function fetch_missing_system_data(missingIds, { refresh = false, strict = false } = {}) {
     if (missingIds.length === 0) {
         return;
     }
 
-    const systemDetails = await inventory.getSystemDetailsBatch(missingIds);
-    const remediationSystems = Object.values(systemDetails).map(system => ({
-        id: system.id,
-        hostname: system.hostname || null,
-        display_name: system.display_name || null,
-        ansible_hostname: system.ansible_host || null
-    }));
-
-    if (remediationSystems.length > 0) {
-        await db.systems.bulkCreate(remediationSystems, {
-            updateOnDuplicate: ['hostname', 'display_name', 'ansible_hostname', 'updated_at']
-        });
-    }
+    const inventoryData = await inventory.getSystemDetailsBatch(missingIds, refresh, 2, strict);
+    await storeSystemDetails(inventoryData);
 }
 
 /**
@@ -903,7 +891,9 @@ exports.getPlanSystems = async function (
  * and stores them locally. Returns hostname, ansible_hostname, and display_name for each system.
  * 
  * @param {string[]} inventoryIds - Array of inventory/system UUIDs to fetch details for
- * @param {number} [chunkSize=50] - Number of systems to process in each database chunk (default: 50)
+ * @param {number} [chunkSize=50] - Number of systems to process in each database chunk
+ * @param {boolean} [refresh=false] - Bypass Inventory cache when fetching missing systems
+ * @param {boolean} [strict=false] - Throw UNKNOWN_SYSTEM when Inventory cannot resolve a system
  * @returns {Object} Object with inventory UUIDs as keys and system details as values
  * 
  * @example
@@ -930,27 +920,8 @@ exports.getPlanSystems = async function (
  * const systemDetails = await getPlanSystemsDetails([
  *   'f6b7a1c2-3d4e-5f6a-7b8c-9d0e1f2a3b4c'
  * ], 25);
- * 
- * @example
- * // Handling systems not found in inventory (fallback to UUID as hostname)
- * const systemDetails = await getPlanSystemsDetails([
- *   'f6b7a1c2-3d4e-5f6a-7b8c-9d0e1f2a3b4c',
- *   '00000000-0000-0000-0000-000000000000'
- * ]);
- * // Returns: {
- * //   'f6b7a1c2-3d4e-5f6a-7b8c-9d0e1f2a3b4c': { 
- * //     hostname: 'server1.example.com', 
- * //     ansible_hostname: 'ansible1', 
- * //     display_name: 'Server 1'
- * //   },
- * //   '00000000-0000-0000-0000-000000000000': { 
- * //     hostname: '00000000-0000-0000-0000-000000000000', 
- * //     ansible_hostname: null, 
- * //     display_name: null
- * //   }
- * // }
  */
-exports.getPlanSystemsDetails = async function (inventoryIds, chunkSize = 50) {
+exports.getPlanSystemsDetails = async function (inventoryIds, chunkSize = 50, refresh = false, strict = false) {
     if (!inventoryIds || inventoryIds.length === 0) {
         return {};
     }
@@ -965,42 +936,28 @@ exports.getPlanSystemsDetails = async function (inventoryIds, chunkSize = 50) {
     const missingIds = _.difference(inventoryIds, existingIds);
 
     // Fetch missing system details from inventory service and store them
-    await fetch_missing_system_data(missingIds);
+    await fetch_missing_system_data(missingIds, { refresh, strict });
 
     const result = {};
 
     // Process in configurable chunks
-    const chunks = _.chunk(inventoryIds, chunkSize);
-
-    for (const chunk of chunks) {
+    for (const chunk of _.chunk(inventoryIds, chunkSize)) {
         const systems = await db.systems.findAll({
             attributes: ['id', 'hostname', 'ansible_hostname', 'display_name'],
-            where: {
-                id: chunk
-            },
+            where: { id: chunk },
             raw: true
         });
 
         // Add systems to result object
         systems.forEach(system => {
             result[system.id] = {
+                id: system.id,
                 hostname: system.hostname,
                 ansible_hostname: system.ansible_hostname,
                 display_name: system.display_name
             };
         });
     }
-
-    // For any systems we still couldn't find details for, set default values
-    inventoryIds.forEach(inventoryId => {
-        if (!result[inventoryId]) {
-            result[inventoryId] = {
-                hostname: null,
-                ansible_hostname: null,
-                display_name: null
-            };
-        }
-    });
 
     return result;
 };
@@ -1211,26 +1168,4 @@ exports.clearOrgConfigCache = async function (tenant_org_id) {
             log.warn(err, 'failed to clear org config retention cache');
         }
     }
-};
-
-exports.getSystemDetailsForPlaybook = async function (systemIds) {
-    if (!systemIds || systemIds.length === 0) {
-        return {};
-    }
-
-    const systems = await db.systems.findAll({
-        attributes: ['id', 'hostname', 'ansible_hostname', 'display_name'],
-        where: { id: systemIds },
-        raw: true
-    });
-
-    return _(systems)
-        .keyBy('id')
-        .mapValues(system => ({
-            id: system.id,
-            hostname: system.hostname,
-            ansible_host: system.ansible_hostname,
-            display_name: system.display_name
-        }))
-        .value();
 };

--- a/src/remediations/remediations.queries.unit.js
+++ b/src/remediations/remediations.queries.unit.js
@@ -437,3 +437,111 @@ describe('list filter expires_within', function () {
         findAndCountAllStub.should.have.been.calledOnce;
     });
 });
+
+describe('getSystemDetailsForPlaybook', function () {
+    const system1Id = 'f6b7a1c2-3d4e-5f6a-7b8c-9d0e1f2a3b4c';
+    const system2Id = 'a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d';
+    const missingSystemId = '00000000-0000-0000-0000-000000000000';
+
+    let dbSystemsFindAllStub;
+
+    beforeEach(() => {
+        dbSystemsFindAllStub = base.sandbox.stub(db.systems, 'findAll');
+    });
+
+    test('should return empty object for empty input', async () => {
+        const result = await queries.getSystemDetailsForPlaybook([]);
+        result.should.deepEqual({});
+        
+        dbSystemsFindAllStub.should.not.have.been.called;
+    });
+
+    test('should return empty object for null input', async () => {
+        const result = await queries.getSystemDetailsForPlaybook(null);
+        result.should.deepEqual({});
+        
+        dbSystemsFindAllStub.should.not.have.been.called;
+    });
+
+    test('should fetch system details from database and map to playbook format', async () => {
+        const systemIds = [system1Id, system2Id];
+        
+        dbSystemsFindAllStub.resolves([
+            {
+                id: system1Id,
+                hostname: 'server1.example.com',
+                ansible_hostname: 'ansible1.example.com',
+                display_name: 'Server 1'
+            },
+            {
+                id: system2Id,
+                hostname: 'server2.example.com', 
+                ansible_hostname: null,
+                display_name: 'Server 2'
+            }
+        ]);
+
+        const result = await queries.getSystemDetailsForPlaybook(systemIds);
+
+        // Should map ansible_hostname to ansible_host for playbook compatibility
+        result.should.deepEqual({
+            [system1Id]: {
+                id: system1Id,
+                hostname: 'server1.example.com',
+                ansible_host: 'ansible1.example.com',
+                display_name: 'Server 1'
+            },
+            [system2Id]: {
+                id: system2Id,
+                hostname: 'server2.example.com',
+                ansible_host: null,
+                display_name: 'Server 2'
+            }
+        });
+
+        dbSystemsFindAllStub.should.have.been.calledOnce;
+    });
+
+    test('should only return systems found in database (no fallback for missing)', async () => {
+        const systemIds = [system1Id, missingSystemId];
+        
+        // Only system1 found in database
+        dbSystemsFindAllStub.resolves([
+            {
+                id: system1Id,
+                hostname: 'server1.example.com',
+                ansible_hostname: 'ansible1.example.com',
+                display_name: 'Server 1'
+            }
+        ]);
+
+        const result = await queries.getSystemDetailsForPlaybook(systemIds);
+
+        // Should NOT include missingSystemId - only returns what's in DB
+        result.should.deepEqual({
+            [system1Id]: {
+                id: system1Id,
+                hostname: 'server1.example.com',
+                ansible_host: 'ansible1.example.com',
+                display_name: 'Server 1'
+            }
+        });
+
+        // missingSystemId should not be in result
+        result.should.not.have.property(missingSystemId);
+        
+        dbSystemsFindAllStub.should.have.been.calledOnce;
+    });
+
+    test('should return empty object when no systems found in database', async () => {
+        const systemIds = [missingSystemId];
+        
+        dbSystemsFindAllStub.resolves([]);
+
+        const result = await queries.getSystemDetailsForPlaybook(systemIds);
+
+        result.should.deepEqual({});
+        
+        dbSystemsFindAllStub.should.have.been.calledOnce;
+    });
+});

--- a/src/remediations/remediations.queries.unit.js
+++ b/src/remediations/remediations.queries.unit.js
@@ -44,13 +44,11 @@ describe('getPlanSystemsDetails', function () {
     test('should fetch system details from database when all systems exist', async () => {
         const inventoryIds = [system1Id, system2Id];
 
-        // Mock existing systems check - all systems exist
         dbSystemsFindAllStub.onFirstCall().resolves([
             { id: system1Id },
             { id: system2Id }
         ]);
 
-        // Mock system details fetch from database
         dbSystemsFindAllStub.onSecondCall().resolves([
             {
                 id: system1Id,
@@ -70,18 +68,20 @@ describe('getPlanSystemsDetails', function () {
 
         result.should.deepEqual({
             [system1Id]: {
+                id: system1Id,
                 hostname: 'server1.example.com',
                 ansible_hostname: 'ansible1',
                 display_name: 'Server 1'
             },
             [system2Id]: {
+                id: system2Id,
                 hostname: 'server2.example.com',
                 ansible_hostname: 'ansible2',
                 display_name: 'Server 2'
             }
         });
 
-        // Should not call inventory service since all systems exist
+        dbSystemsFindAllStub.should.have.been.calledTwice;
         inventoryGetSystemDetailsBatchStub.should.not.have.been.called;
         dbSystemsBulkCreateStub.should.not.have.been.called;
     });
@@ -89,12 +89,10 @@ describe('getPlanSystemsDetails', function () {
     test('should fetch missing systems from inventory service', async () => {
         const inventoryIds = [system1Id, missingSystemId];
 
-        // Mock existing systems check - only system1 exists
         dbSystemsFindAllStub.onFirstCall().resolves([
             { id: system1Id }
         ]);
 
-        // Mock inventory service response for missing system
         inventoryGetSystemDetailsBatchStub.resolves({
             [missingSystemId]: {
                 id: missingSystemId,
@@ -104,7 +102,6 @@ describe('getPlanSystemsDetails', function () {
             }
         });
 
-        // Mock system details fetch after inventory call
         dbSystemsFindAllStub.onSecondCall().resolves([
             {
                 id: system1Id,
@@ -124,11 +121,13 @@ describe('getPlanSystemsDetails', function () {
 
         result.should.deepEqual({
             [system1Id]: {
+                id: system1Id,
                 hostname: 'server1.example.com',
                 ansible_hostname: 'ansible1',
                 display_name: 'Server 1'
             },
             [missingSystemId]: {
+                id: missingSystemId,
                 hostname: 'missing-server.example.com',
                 ansible_hostname: 'missing-ansible',
                 display_name: 'Missing Server'
@@ -136,31 +135,29 @@ describe('getPlanSystemsDetails', function () {
         });
 
         // Should call inventory service for missing system
-        inventoryGetSystemDetailsBatchStub.calledOnceWith([missingSystemId]).should.equal(true);
+        inventoryGetSystemDetailsBatchStub.calledOnceWith([missingSystemId], false, 2, false).should.equal(true);
+        dbSystemsFindAllStub.should.have.been.calledTwice;
 
-        // Should bulk create missing system in database
+        // Should store missing system in database
         dbSystemsBulkCreateStub.calledOnceWith([{
             id: missingSystemId,
             hostname: 'missing-server.example.com',
             display_name: 'Missing Server',
             ansible_hostname: 'missing-ansible'
         }], {
-            updateOnDuplicate: ['hostname', 'display_name', 'ansible_hostname', 'updated_at']
+            ignoreDuplicates: true
         }).should.equal(true);
     });
 
-    test('should handle systems not found anywhere with fallback values', async () => {
+    test('should omit systems not found anywhere', async () => {
         const inventoryIds = [system1Id, missingSystemId];
 
-        // Mock existing systems check - only system1 exists
         dbSystemsFindAllStub.onFirstCall().resolves([
             { id: system1Id }
         ]);
 
-        // Mock inventory service returns empty (system not found)
         inventoryGetSystemDetailsBatchStub.resolves({});
 
-        // Mock system details fetch - still only system1 found
         dbSystemsFindAllStub.onSecondCall().resolves([
             {
                 id: system1Id,
@@ -174,19 +171,18 @@ describe('getPlanSystemsDetails', function () {
 
         result.should.deepEqual({
             [system1Id]: {
+                id: system1Id,
                 hostname: 'server1.example.com',
                 ansible_hostname: 'ansible1',
                 display_name: 'Server 1'
-            },
-            [missingSystemId]: {
-                hostname: null,
-                ansible_hostname: null,
-                display_name: null
             }
         });
 
+        result.should.not.have.property(missingSystemId);
+
         // Should try inventory service but system wasn't found
-        inventoryGetSystemDetailsBatchStub.calledOnceWith([missingSystemId]).should.equal(true);
+        inventoryGetSystemDetailsBatchStub.calledOnceWith([missingSystemId], false, 2, false).should.equal(true);
+        dbSystemsFindAllStub.should.have.been.calledTwice;
 
         // Should not bulk create since no systems returned from inventory
         dbSystemsBulkCreateStub.called.should.equal(false);
@@ -194,9 +190,8 @@ describe('getPlanSystemsDetails', function () {
 
     test('should handle chunking with custom chunk size', async () => {
         const inventoryIds = [system1Id, system2Id, system3Id, system4Id];
-        const chunkSize = 2; // Force chunking
+        const chunkSize = 2;
 
-        // Mock existing systems check - all systems exist
         dbSystemsFindAllStub.onFirstCall().resolves([
             { id: system1Id },
             { id: system2Id },
@@ -204,7 +199,6 @@ describe('getPlanSystemsDetails', function () {
             { id: system4Id }
         ]);
 
-        // Mock system details fetch for first chunk
         dbSystemsFindAllStub.onSecondCall().resolves([
             {
                 id: system1Id,
@@ -220,7 +214,6 @@ describe('getPlanSystemsDetails', function () {
             }
         ]);
 
-        // Mock system details fetch for second chunk
         dbSystemsFindAllStub.onThirdCall().resolves([
             {
                 id: system3Id,
@@ -240,49 +233,50 @@ describe('getPlanSystemsDetails', function () {
 
         result.should.deepEqual({
             [system1Id]: {
+                id: system1Id,
                 hostname: 'server1.example.com',
                 ansible_hostname: 'ansible1',
                 display_name: 'Server 1'
             },
             [system2Id]: {
+                id: system2Id,
                 hostname: 'server2.example.com',
                 ansible_hostname: 'ansible2',
                 display_name: 'Server 2'
             },
             [system3Id]: {
+                id: system3Id,
                 hostname: 'server3.example.com',
                 ansible_hostname: 'ansible3',
                 display_name: 'Server 3'
             },
             [system4Id]: {
+                id: system4Id,
                 hostname: 'server4.example.com',
                 ansible_hostname: 'ansible4',
                 display_name: 'Server 4'
             }
         });
 
-        // Should make 3 database calls total (1 for existing check + 2 chunks)
         dbSystemsFindAllStub.should.have.been.calledThrice;
 
-        // Verify chunk sizes
         const secondCall = dbSystemsFindAllStub.getCall(1);
         const thirdCall = dbSystemsFindAllStub.getCall(2);
 
-        secondCall.args[0].where.id.should.have.length(2); // First chunk
-        thirdCall.args[0].where.id.should.have.length(2);  // Second chunk
+        secondCall.args[0].where.id.should.have.length(2);
+        thirdCall.args[0].where.id.should.have.length(2);
+        inventoryGetSystemDetailsBatchStub.should.not.have.been.called;
     });
 
     test('should handle mixed scenario with chunking and missing systems', async () => {
         const inventoryIds = [system1Id, missingSystemId, system3Id];
         const chunkSize = 2;
 
-        // Mock existing systems check - system1 and system3 exist, missingSystemId doesn't
         dbSystemsFindAllStub.onFirstCall().resolves([
             { id: system1Id },
             { id: system3Id }
         ]);
 
-        // Mock inventory service response for missing system
         inventoryGetSystemDetailsBatchStub.resolves({
             [missingSystemId]: {
                 id: missingSystemId,
@@ -292,7 +286,6 @@ describe('getPlanSystemsDetails', function () {
             }
         });
 
-        // Mock system details fetch for first chunk
         dbSystemsFindAllStub.onSecondCall().resolves([
             {
                 id: system1Id,
@@ -308,7 +301,6 @@ describe('getPlanSystemsDetails', function () {
             }
         ]);
 
-        // Mock system details fetch for second chunk
         dbSystemsFindAllStub.onThirdCall().resolves([
             {
                 id: system3Id,
@@ -322,16 +314,19 @@ describe('getPlanSystemsDetails', function () {
 
         result.should.deepEqual({
             [system1Id]: {
+                id: system1Id,
                 hostname: 'server1.example.com',
                 ansible_hostname: 'ansible1',
                 display_name: 'Server 1'
             },
             [missingSystemId]: {
+                id: missingSystemId,
                 hostname: 'fetched-missing.example.com',
                 ansible_hostname: 'fetched-ansible',
                 display_name: 'Fetched Missing System'
             },
             [system3Id]: {
+                id: system3Id,
                 hostname: 'server3.example.com',
                 ansible_hostname: 'ansible3',
                 display_name: 'Server 3'
@@ -339,7 +334,8 @@ describe('getPlanSystemsDetails', function () {
         });
 
         // Should call inventory service for missing system
-        inventoryGetSystemDetailsBatchStub.calledOnceWith([missingSystemId]).should.equal(true);
+        inventoryGetSystemDetailsBatchStub.calledOnceWith([missingSystemId], false, 2, false).should.equal(true);
+        dbSystemsFindAllStub.should.have.been.calledThrice;
 
         // Should bulk create the fetched system
         dbSystemsBulkCreateStub.calledOnceWith([{
@@ -348,17 +344,43 @@ describe('getPlanSystemsDetails', function () {
             display_name: 'Fetched Missing System',
             ansible_hostname: 'fetched-ansible'
         }], {
-            updateOnDuplicate: ['hostname', 'display_name', 'ansible_hostname', 'updated_at']
+            ignoreDuplicates: true
         }).should.equal(true);
+    });
+
+    test('should pass refresh and strict options to inventory service', async () => {
+        const inventoryIds = [missingSystemId];
+
+        dbSystemsFindAllStub.onFirstCall().resolves([]);
+        inventoryGetSystemDetailsBatchStub.resolves({
+            [missingSystemId]: {
+                id: missingSystemId,
+                hostname: 'missing-server.example.com',
+                display_name: 'Missing Server',
+                ansible_host: 'missing-ansible'
+            }
+        });
+        dbSystemsFindAllStub.onSecondCall().resolves([
+            {
+                id: missingSystemId,
+                hostname: 'missing-server.example.com',
+                ansible_hostname: 'missing-ansible',
+                display_name: 'Missing Server'
+            }
+        ]);
+
+        const result = await queries.getPlanSystemsDetails(inventoryIds, 50, true, true);
+
+        inventoryGetSystemDetailsBatchStub.calledOnceWith([missingSystemId], true, 2, true).should.equal(true);
+        dbSystemsFindAllStub.should.have.been.calledTwice;
+        result.should.have.property(missingSystemId);
     });
 
     test('should handle inventory service returning partial results', async () => {
         const inventoryIds = [missingSystemId, 'another-missing-uuid'];
 
-        // Mock existing systems check - no systems exist
         dbSystemsFindAllStub.onFirstCall().resolves([]);
 
-        // Mock inventory service returns only one of the missing systems
         inventoryGetSystemDetailsBatchStub.resolves({
             [missingSystemId]: {
                 id: missingSystemId,
@@ -366,10 +388,8 @@ describe('getPlanSystemsDetails', function () {
                 display_name: 'Partially Found System',
                 ansible_host: 'partially-found-ansible'
             }
-            // 'another-missing-uuid' not returned by inventory
         });
 
-        // Mock system details fetch - only the one found in inventory
         dbSystemsFindAllStub.onSecondCall().resolves([
             {
                 id: missingSystemId,
@@ -383,16 +403,15 @@ describe('getPlanSystemsDetails', function () {
 
         result.should.deepEqual({
             [missingSystemId]: {
+                id: missingSystemId,
                 hostname: 'partially-found.example.com',
                 ansible_hostname: 'partially-found-ansible',
                 display_name: 'Partially Found System'
-            },
-            'another-missing-uuid': {
-                hostname: null,
-                ansible_hostname: null,
-                display_name: null
             }
         });
+
+        result.should.not.have.property('another-missing-uuid');
+        dbSystemsFindAllStub.should.have.been.calledTwice;
     });
 });
 
@@ -435,113 +454,5 @@ describe('list filter expires_within', function () {
     test('accepts whole number and queries', async () => {
         await listWithFilter(30);
         findAndCountAllStub.should.have.been.calledOnce;
-    });
-});
-
-describe('getSystemDetailsForPlaybook', function () {
-    const system1Id = 'f6b7a1c2-3d4e-5f6a-7b8c-9d0e1f2a3b4c';
-    const system2Id = 'a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d';
-    const missingSystemId = '00000000-0000-0000-0000-000000000000';
-
-    let dbSystemsFindAllStub;
-
-    beforeEach(() => {
-        dbSystemsFindAllStub = base.sandbox.stub(db.systems, 'findAll');
-    });
-
-    test('should return empty object for empty input', async () => {
-        const result = await queries.getSystemDetailsForPlaybook([]);
-        result.should.deepEqual({});
-        
-        dbSystemsFindAllStub.should.not.have.been.called;
-    });
-
-    test('should return empty object for null input', async () => {
-        const result = await queries.getSystemDetailsForPlaybook(null);
-        result.should.deepEqual({});
-        
-        dbSystemsFindAllStub.should.not.have.been.called;
-    });
-
-    test('should fetch system details from database and map to playbook format', async () => {
-        const systemIds = [system1Id, system2Id];
-        
-        dbSystemsFindAllStub.resolves([
-            {
-                id: system1Id,
-                hostname: 'server1.example.com',
-                ansible_hostname: 'ansible1.example.com',
-                display_name: 'Server 1'
-            },
-            {
-                id: system2Id,
-                hostname: 'server2.example.com', 
-                ansible_hostname: null,
-                display_name: 'Server 2'
-            }
-        ]);
-
-        const result = await queries.getSystemDetailsForPlaybook(systemIds);
-
-        // Should map ansible_hostname to ansible_host for playbook compatibility
-        result.should.deepEqual({
-            [system1Id]: {
-                id: system1Id,
-                hostname: 'server1.example.com',
-                ansible_host: 'ansible1.example.com',
-                display_name: 'Server 1'
-            },
-            [system2Id]: {
-                id: system2Id,
-                hostname: 'server2.example.com',
-                ansible_host: null,
-                display_name: 'Server 2'
-            }
-        });
-
-        dbSystemsFindAllStub.should.have.been.calledOnce;
-    });
-
-    test('should only return systems found in database (no fallback for missing)', async () => {
-        const systemIds = [system1Id, missingSystemId];
-        
-        // Only system1 found in database
-        dbSystemsFindAllStub.resolves([
-            {
-                id: system1Id,
-                hostname: 'server1.example.com',
-                ansible_hostname: 'ansible1.example.com',
-                display_name: 'Server 1'
-            }
-        ]);
-
-        const result = await queries.getSystemDetailsForPlaybook(systemIds);
-
-        // Should NOT include missingSystemId - only returns what's in DB
-        result.should.deepEqual({
-            [system1Id]: {
-                id: system1Id,
-                hostname: 'server1.example.com',
-                ansible_host: 'ansible1.example.com',
-                display_name: 'Server 1'
-            }
-        });
-
-        // missingSystemId should not be in result
-        result.should.not.have.property(missingSystemId);
-        
-        dbSystemsFindAllStub.should.have.been.calledOnce;
-    });
-
-    test('should return empty object when no systems found in database', async () => {
-        const systemIds = [missingSystemId];
-        
-        dbSystemsFindAllStub.resolves([]);
-
-        const result = await queries.getSystemDetailsForPlaybook(systemIds);
-
-        result.should.deepEqual({});
-        
-        dbSystemsFindAllStub.should.have.been.calledOnce;
     });
 });

--- a/src/remediations/remediations.queries.unit.js
+++ b/src/remediations/remediations.queries.unit.js
@@ -70,13 +70,13 @@ describe('getPlanSystemsDetails', function () {
             [system1Id]: {
                 id: system1Id,
                 hostname: 'server1.example.com',
-                ansible_hostname: 'ansible1',
+                ansible_host: 'ansible1',
                 display_name: 'Server 1'
             },
             [system2Id]: {
                 id: system2Id,
                 hostname: 'server2.example.com',
-                ansible_hostname: 'ansible2',
+                ansible_host: 'ansible2',
                 display_name: 'Server 2'
             }
         });
@@ -123,13 +123,13 @@ describe('getPlanSystemsDetails', function () {
             [system1Id]: {
                 id: system1Id,
                 hostname: 'server1.example.com',
-                ansible_hostname: 'ansible1',
+                ansible_host: 'ansible1',
                 display_name: 'Server 1'
             },
             [missingSystemId]: {
                 id: missingSystemId,
                 hostname: 'missing-server.example.com',
-                ansible_hostname: 'missing-ansible',
+                ansible_host: 'missing-ansible',
                 display_name: 'Missing Server'
             }
         });
@@ -145,7 +145,7 @@ describe('getPlanSystemsDetails', function () {
             display_name: 'Missing Server',
             ansible_hostname: 'missing-ansible'
         }], {
-            ignoreDuplicates: true
+            updateOnDuplicate: ['hostname', 'display_name', 'ansible_hostname', 'updated_at']
         }).should.equal(true);
     });
 
@@ -173,7 +173,7 @@ describe('getPlanSystemsDetails', function () {
             [system1Id]: {
                 id: system1Id,
                 hostname: 'server1.example.com',
-                ansible_hostname: 'ansible1',
+                ansible_host: 'ansible1',
                 display_name: 'Server 1'
             }
         });
@@ -194,12 +194,15 @@ describe('getPlanSystemsDetails', function () {
 
         dbSystemsFindAllStub.onFirstCall().resolves([
             { id: system1Id },
-            { id: system2Id },
+            { id: system2Id }
+        ]);
+
+        dbSystemsFindAllStub.onSecondCall().resolves([
             { id: system3Id },
             { id: system4Id }
         ]);
 
-        dbSystemsFindAllStub.onSecondCall().resolves([
+        dbSystemsFindAllStub.onThirdCall().resolves([
             {
                 id: system1Id,
                 hostname: 'server1.example.com',
@@ -214,7 +217,7 @@ describe('getPlanSystemsDetails', function () {
             }
         ]);
 
-        dbSystemsFindAllStub.onThirdCall().resolves([
+        dbSystemsFindAllStub.onCall(3).resolves([
             {
                 id: system3Id,
                 hostname: 'server3.example.com',
@@ -229,42 +232,42 @@ describe('getPlanSystemsDetails', function () {
             }
         ]);
 
-        const result = await queries.getPlanSystemsDetails(inventoryIds, chunkSize);
+        const result = await queries.getPlanSystemsDetails(inventoryIds, false, false, chunkSize);
 
         result.should.deepEqual({
             [system1Id]: {
                 id: system1Id,
                 hostname: 'server1.example.com',
-                ansible_hostname: 'ansible1',
+                ansible_host: 'ansible1',
                 display_name: 'Server 1'
             },
             [system2Id]: {
                 id: system2Id,
                 hostname: 'server2.example.com',
-                ansible_hostname: 'ansible2',
+                ansible_host: 'ansible2',
                 display_name: 'Server 2'
             },
             [system3Id]: {
                 id: system3Id,
                 hostname: 'server3.example.com',
-                ansible_hostname: 'ansible3',
+                ansible_host: 'ansible3',
                 display_name: 'Server 3'
             },
             [system4Id]: {
                 id: system4Id,
                 hostname: 'server4.example.com',
-                ansible_hostname: 'ansible4',
+                ansible_host: 'ansible4',
                 display_name: 'Server 4'
             }
         });
 
-        dbSystemsFindAllStub.should.have.been.calledThrice;
+        dbSystemsFindAllStub.callCount.should.equal(4);
 
-        const secondCall = dbSystemsFindAllStub.getCall(1);
         const thirdCall = dbSystemsFindAllStub.getCall(2);
+        const fourthCall = dbSystemsFindAllStub.getCall(3);
 
-        secondCall.args[0].where.id.should.have.length(2);
         thirdCall.args[0].where.id.should.have.length(2);
+        fourthCall.args[0].where.id.should.have.length(2);
         inventoryGetSystemDetailsBatchStub.should.not.have.been.called;
     });
 
@@ -273,7 +276,10 @@ describe('getPlanSystemsDetails', function () {
         const chunkSize = 2;
 
         dbSystemsFindAllStub.onFirstCall().resolves([
-            { id: system1Id },
+            { id: system1Id }
+        ]);
+
+        dbSystemsFindAllStub.onSecondCall().resolves([
             { id: system3Id }
         ]);
 
@@ -286,7 +292,7 @@ describe('getPlanSystemsDetails', function () {
             }
         });
 
-        dbSystemsFindAllStub.onSecondCall().resolves([
+        dbSystemsFindAllStub.onThirdCall().resolves([
             {
                 id: system1Id,
                 hostname: 'server1.example.com',
@@ -301,7 +307,7 @@ describe('getPlanSystemsDetails', function () {
             }
         ]);
 
-        dbSystemsFindAllStub.onThirdCall().resolves([
+        dbSystemsFindAllStub.onCall(3).resolves([
             {
                 id: system3Id,
                 hostname: 'server3.example.com',
@@ -310,32 +316,32 @@ describe('getPlanSystemsDetails', function () {
             }
         ]);
 
-        const result = await queries.getPlanSystemsDetails(inventoryIds, chunkSize);
+        const result = await queries.getPlanSystemsDetails(inventoryIds, false, false, chunkSize);
 
         result.should.deepEqual({
             [system1Id]: {
                 id: system1Id,
                 hostname: 'server1.example.com',
-                ansible_hostname: 'ansible1',
+                ansible_host: 'ansible1',
                 display_name: 'Server 1'
             },
             [missingSystemId]: {
                 id: missingSystemId,
                 hostname: 'fetched-missing.example.com',
-                ansible_hostname: 'fetched-ansible',
+                ansible_host: 'fetched-ansible',
                 display_name: 'Fetched Missing System'
             },
             [system3Id]: {
                 id: system3Id,
                 hostname: 'server3.example.com',
-                ansible_hostname: 'ansible3',
+                ansible_host: 'ansible3',
                 display_name: 'Server 3'
             }
         });
 
         // Should call inventory service for missing system
         inventoryGetSystemDetailsBatchStub.calledOnceWith([missingSystemId], false, 2, false).should.equal(true);
-        dbSystemsFindAllStub.should.have.been.calledThrice;
+        dbSystemsFindAllStub.callCount.should.equal(4);
 
         // Should bulk create the fetched system
         dbSystemsBulkCreateStub.calledOnceWith([{
@@ -344,7 +350,7 @@ describe('getPlanSystemsDetails', function () {
             display_name: 'Fetched Missing System',
             ansible_hostname: 'fetched-ansible'
         }], {
-            ignoreDuplicates: true
+            updateOnDuplicate: ['hostname', 'display_name', 'ansible_hostname', 'updated_at']
         }).should.equal(true);
     });
 
@@ -369,7 +375,7 @@ describe('getPlanSystemsDetails', function () {
             }
         ]);
 
-        const result = await queries.getPlanSystemsDetails(inventoryIds, 50, true, true);
+        const result = await queries.getPlanSystemsDetails(inventoryIds, true, true);
 
         inventoryGetSystemDetailsBatchStub.calledOnceWith([missingSystemId], true, 2, true).should.equal(true);
         dbSystemsFindAllStub.should.have.been.calledTwice;
@@ -405,7 +411,7 @@ describe('getPlanSystemsDetails', function () {
             [missingSystemId]: {
                 id: missingSystemId,
                 hostname: 'partially-found.example.com',
-                ansible_hostname: 'partially-found-ansible',
+                ansible_host: 'partially-found-ansible',
                 display_name: 'Partially Found System'
             }
         });

--- a/src/remediations/write.integration.js
+++ b/src/remediations/write.integration.js
@@ -2313,7 +2313,7 @@ describe('remediations', function () {
             newCachedSystem.should.have.property('ansible_hostname');
         });
 
-        test('handles duplicate systems gracefully with ignoreDuplicates', async () => {
+        test('handles duplicate systems gracefully with updateOnDuplicate', async () => {
             const systemId = '56db4b54-6273-48dc-b0be-41eb4dc87c7f';
             
             // Create first remediation with system


### PR DESCRIPTION
## Summary by Sourcery

Resolve systems for playbook generation using a local systems table with fallback to Inventory and persist fetched system details for future use.

New Features:
- Add a query helper to retrieve system details for playbooks from the local systems table.
- Populate ansible_host for a seeded test system to support playbook host resolution.

Bug Fixes:
- Ensure missing systems are filtered from playbook issues and hosts when strict mode is disabled, and UNKNOWN_SYSTEM errors propagate correctly when enabled.

Enhancements:
- Update system resolution in the generator controller to prefer locally stored system details, only calling Inventory for missing systems and backfilling them into the database.
- Refine host mapping logic to base hosts on successfully resolved systems and drop issues with no valid hosts in non-strict mode.

Tests:
- Add unit tests for resolveSystems to cover local DB usage, Inventory fallback, strict vs non-strict handling, and issue filtering behavior.
- Add unit tests for getSystemDetailsForPlaybook to verify DB lookups, ansible_host mapping, and handling of missing or empty inputs.