### PR TITLE
RHINENG-25798 RHINENG-25799: Adjust formatting for expires_at in list and get

### DIFF
--- a/src/remediations/remediations.format.js
+++ b/src/remediations/remediations.format.js
@@ -85,7 +85,7 @@ exports.list = function (remediations, total, limit, offset, sort, system) {
             resolved_count: (resolved_count === null) ? 0 : resolved_count,
             archived,
             last_run_at: last_run_at ? last_run_at.toISOString() : null,
-            expires_at: expires_at ? expires_at.toISOString() : null,
+            expires_at: _.isDate(expires_at) ? expires_at.toISOString() : expires_at,
             playbook_runs: (playbook_runs === null) ? [] : playbook_runs
         })
     );
@@ -111,7 +111,7 @@ exports.get = function ({id, name, needs_reboot, auto_reboot, created_by, create
         created_at: created_at.toISOString(),
         updated_by: _.pick(updated_by, USER),
         updated_at: updated_at.toISOString(),
-        expires_at: expires_at instanceof Date ? expires_at.toISOString() : String(expires_at)
+        expires_at: _.isDate(expires_at) ? expires_at.toISOString() : expires_at
     };
 
     // handle format='detail' items


### PR DESCRIPTION
The `null` fallback on `list` was removed so list and get now use the same `expires_at` logic in the format functions. The `_.isDate()` pass-through is intentional because the query functions **should** return Date objects (`get` responses might return ISO strings after `JSON.parse` but that should still work fine too). `expires_at` is always computed in SQL by using the plan `updated_at` time and `last_run_at` time and is required/non-nullable in the OpenAPI spec. Explicit handling for null/undefined isn't needed here because that would basically be an internal bug that we need to fix on our end. 

## Summary by Sourcery

Bug Fixes:
- Prevent improper conversion of non-Date expires_at values when formatting remediation list and detail responses.