### PR TITLE
RHINENG-25798: Add expires_at to example in api spec

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -1238,6 +1238,7 @@ components:
             "first_name": "Jozef",
             "last_name": "Hartinger"
           },
+          "expires_at": "2019-04-04T08:19:36.641Z",
           "issue_count": 8,
           "issue_count_details": {
             "advisor": 1,


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Document the expires_at field in the sample payload for this API endpoint in the OpenAPI spec.