### PR TITLE
RHINENG-26252: Improve performance for GET /remediations/:id/connection_status

### DIFF
--- a/src/remediations/controller.fifi.js
+++ b/src/remediations/controller.fifi.js
@@ -16,7 +16,7 @@ const notMatching = res => res.sendStatus(412);
 const notFound = res => res.sendStatus(404);
 
 exports.checkExecutable = errors.async(async function (req, res) {
-    const exists = await queries.checkExecutable(
+    const exists = await queries.checkPlanExistence(
         req.params.id,
         req.user.tenant_org_id,
         req.user.username

--- a/src/remediations/controller.fifi_2.js
+++ b/src/remediations/controller.fifi_2.js
@@ -21,29 +21,21 @@ exports.connection_status = errors.async(async function (req, res) {
     const remediationId = req.params.id;
     const tenantOrgId = req.user.tenant_org_id;
     const username = req.user.username;
-    const exclude = req.body.exclude || [];
 
     //----------------------------------------------------------------
-    // fetch remediation
+    // verify remediation exists
     //----------------------------------------------------------------
-    const remediation = await queries.get(remediationId, tenantOrgId, username);
+    const remediation = await queries.checkPlanExistence(remediationId, tenantOrgId, username);
 
     if (!remediation) {
         // 404 if remediation not found
         return notFound(res);
     }
 
-    //--------------------------------------------------------------
-    // Extract unique, sorted list of system_ids from remediation
-    //--------------------------------------------------------------
-    const systemIds = [
-        ... new Set(
-            _(remediation.issues)
-                .flatMap('systems')
-                .map('system_id')
-                .value()
-        )
-    ].sort();
+    //----------------------------------------------------------------
+    // fetch distinct system ids for the plan
+    //----------------------------------------------------------------
+    const systemIds = await queries.getPlanSystemIds(remediationId, tenantOrgId, username);
 
     // If no systems, return empty result without calling dispatcher
     if (systemIds.length === 0) {

--- a/src/remediations/remediations.queries.js
+++ b/src/remediations/remediations.queries.js
@@ -675,7 +675,7 @@ exports.getSummary = async function (id, tenant_org_id, created_by = null) {
 
 // Return `{ id }` when id, tenant_org_id, and created_by match (remediation exists).
 // Return null if no remediation matches (does not exist or wrong scope).
-exports.checkExecutable = async function (id, tenant_org_id, created_by) {
+exports.checkPlanExistence = async function (id, tenant_org_id, created_by) {
     return db.remediation.findOne({
         attributes: ['id'],
         where: {
@@ -778,21 +778,14 @@ async function fetch_missing_system_data(missingIds) {
     }
 }
 
-// Return a paginated, sorted list of distinct systems for a remediation plan
-exports.getPlanSystems = async function (
-    remediation_plan_id,
-    tenant_org_id,
-    created_by,
-    column = 'display_name',
-    asc = true,
-    filter = null,
-    limit = 50,
-    offset = 0
-) {
-    const { Op, s: { literal, col, cast }, fn: { DISTINCT, COUNT }, issue, issue_system, remediation } = db;
+/**
+ * Returns a sorted list of distinct system IDs for a remediation plan scoped by org and creator,
+ * or an empty array when the plan has no systems or is out of scope.
+ */
+exports.getPlanSystemIds = async function (remediation_plan_id, tenant_org_id, created_by) {
+    const { s: { col }, fn: { DISTINCT }, issue, issue_system, remediation } = db;
 
-    // Fetch distinct system ids for the plan scoped by tenant/user
-    const distinctSystemIds = (await issue_system.findAll({
+    const rows = await issue_system.findAll({
         attributes: [[DISTINCT(col('issue_system.system_id')), 'system_id']],
         include: [{
             attributes: [],
@@ -808,7 +801,26 @@ exports.getPlanSystems = async function (
             }]
         }],
         raw: true
-    })).map(r => r.system_id);
+    });
+
+    return rows.map(r => r.system_id).sort();
+};
+
+// Return a paginated, sorted list of distinct systems for a remediation plan
+exports.getPlanSystems = async function (
+    remediation_plan_id,
+    tenant_org_id,
+    created_by,
+    column = 'display_name',
+    asc = true,
+    filter = null,
+    limit = 50,
+    offset = 0
+) {
+    const { Op, s: { col, cast }, fn: { COUNT } } = db;
+
+    // Fetch distinct system ids for the plan scoped by tenant/user
+    const distinctSystemIds = await exports.getPlanSystemIds(remediation_plan_id, tenant_org_id, created_by);
 
     // If no systems found for the remediation plan, return empty results
     if (distinctSystemIds.length === 0) {


### PR DESCRIPTION
## Summary by Sourcery

Optimize remediation connection status retrieval by reusing a shared query for distinct system IDs and lightweight plan existence checks.

Enhancements:
- Introduce a dedicated query to fetch distinct system IDs for a remediation plan and reuse it in both query and controller layers.
- Rename and repurpose the remediation existence check to a lighter-weight plan existence query used by multiple endpoints.