### PR TITLE
RHINENG-22737: Block execution of overly large plans

### DIFF
--- a/src/config/__snapshots__/config.unit.js.snap
+++ b/src/config/__snapshots__/config.unit.js.snap
@@ -130,6 +130,11 @@ exports[`Configuration Verify app-common-js function 1`] = `
     "base": "/api/remediations",
     "prefix": "/api",
   },
+  "planLimits": {
+    "bypassFeatureFlag": "remediations.plan-limits-bypass",
+    "maxIssues": 20000,
+    "maxSystems": 20000,
+  },
   "plan_retention": {
     "retentionDays": 120,
     "warningDays": 30,

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -242,6 +242,12 @@ function Config() {
         plan_retention: {
             retentionDays: parseIntEnv('PLAN_RETENTION_DAYS', 120), // days of inactivity before plan expiration
             warningDays: parseIntEnv('PLAN_WARNING_DAYS', 30) // days before expiration to show warning
+        },
+
+        planLimits: {
+            maxSystems: parseIntEnv('PLAN_MAX_SYSTEMS', 20000),
+            maxIssues: parseIntEnv('PLAN_MAX_ISSUES', 20000),
+            bypassFeatureFlag: env.PLAN_LIMITS_BYPASS_FEATURE_FLAG || 'remediations.plan-limits-bypass'
         }
     };
 

--- a/src/remediations/controller.fifi_2.js
+++ b/src/remediations/controller.fifi_2.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const errors = require("../errors");
+const config = require('../config');
+const featureFlags = require('../connectors/featureFlags');
 const queries = require("./remediations.queries");
 const fifi = require("./fifi_2");
 const _ = require("lodash");
@@ -12,6 +14,36 @@ const format = require("./remediations.format_2");
 
 const notMatching = res => res.sendStatus(412);
 const notFound = res => res.sendStatus(404);
+
+
+function validatePlanSize(issueCount, systemCount, req) {
+    const { maxSystems, maxIssues, bypassFeatureFlag } = config.planLimits;
+
+    if (featureFlags.isEnabled(bypassFeatureFlag, {
+        userId: req.user.username,
+        properties: {
+            tenantOrgId: req.user.tenant_org_id,
+            accountNumber: req.user.account_number
+        }
+    })) {
+        return;
+    }
+
+    const messages = [];
+
+    if (systemCount > maxSystems) {
+        messages.push(`plan would contain ${systemCount} systems, exceeding the maximum of ${maxSystems}`);
+    }
+
+    if (issueCount > maxIssues) {
+        messages.push(`plan would contain ${issueCount} issues, exceeding the maximum of ${maxIssues}`);
+    }
+
+    if (messages.length) {
+        throw new errors.BadRequest('PLAN_SIZE_LIMIT_EXCEEDED',
+            `Remediation plan exceeds size limits: ${messages.join('; ')}`);
+    }
+}
 
 
 //-------------------------------------------------------------------------------------
@@ -111,6 +143,8 @@ exports.executePlaybookRuns = errors.async(async function (req, res) {
         // no systems
         throw errors.noSystems(remediation);
     }
+
+    validatePlanSize(remediation.issues.length, systemIds.length, req);
 
     //-----------------------------------------------
     // get connection status of referenced systems

--- a/src/remediations/fifi.integration.js
+++ b/src/remediations/fifi.integration.js
@@ -1246,6 +1246,53 @@ describe('FiFi', function () {
                     'Excluded Executor [722ec903-f4b5-4b1f-9c2f-23fc7b0ba380] not found in list of identified executors');
             });
 
+            describe('plan size limits', function () {
+                const largePlanId = 'dd6a0b1b-5331-4e7b-92ec-9a01806fb181';
+
+                beforeEach(function () {
+                    base.getSandbox().stub(config.planLimits, 'maxSystems').value(3);
+                    base.getSandbox().stub(config.planLimits, 'maxIssues').value(3);
+                });
+
+                test('rejects POST playbook_runs when plan exceeds max systems', async () => {
+                    const {body} = await request
+                        .post(`/v1/remediations/${largePlanId}/playbook_runs`)
+                        .set(auth.fifi)
+                        .expect(400);
+
+                    body.errors[0].code.should.equal('PLAN_SIZE_LIMIT_EXCEEDED');
+                });
+
+                test('rejects POST playbook_runs when plan exceeds max issues', async () => {
+                    base.getSandbox().restore();
+                    base.getSandbox().stub(config.planLimits, 'maxSystems').value(20000);
+                    base.getSandbox().stub(config.planLimits, 'maxIssues').value(0);
+
+                    const {body} = await request
+                        .post(`/v1/remediations/${largePlanId}/playbook_runs`)
+                        .set(auth.fifi)
+                        .expect(400);
+
+                    body.errors[0].code.should.equal('PLAN_SIZE_LIMIT_EXCEEDED');
+                });
+
+                test('allows execution when bypass feature flag is enabled', async () => {
+                    const featureFlags = require('../connectors/featureFlags');
+                    base.getSandbox().stub(featureFlags, 'isEnabled').callsFake(
+                        flag => flag === config.planLimits.bypassFeatureFlag
+                    );
+                    base.getSandbox().stub(fifi_2, 'generatePlaybookRunId').returns(randomUUID());
+                    base.getSandbox().stub(dispatcher, 'postV2PlaybookRunRequests').resolves([
+                        { code: 200, id: randomUUID() }
+                    ]);
+
+                    await request
+                        .post(`/v1/remediations/${largePlanId}/playbook_runs`)
+                        .set(auth.fifi)
+                        .expect(201);
+                });
+            });
+
             test('cancel playbook when there are Sat-RHC systems running', async () => {
                 const spy = base.getSandbox().spy(dispatcher, 'postPlaybookCancelRequest');
                 await request

--- a/src/remediations/write.integration.js
+++ b/src/remediations/write.integration.js
@@ -203,9 +203,9 @@ describe('remediations', function () {
             testIssue(r2.body, 'advisor:network_bond_opts_config_issue|NETWORK_BONDING_OPTS_DOUBLE_QUOTES_ISSUE', 'fix', systems);
         });
 
-        test('creates a new remediation with 20k systems in batches', async () => {
-            const name = `new remediation with 20k systems`;
-            const TOTAL_SYSTEMS = 20000;
+        test('creates a new remediation with 19k systems in batches', async () => {
+            const name = `new remediation with 19k systems ${randomUUID()}`;
+            const TOTAL_SYSTEMS = 19000;
             const BATCH_SIZE = 50;
             const allSystems = _.times(TOTAL_SYSTEMS, () => randomUUID());
 
@@ -251,7 +251,7 @@ describe('remediations', function () {
             const remediation = _.find(body.data, {id});
             (remediation !== undefined).should.be.true();
             remediation.system_count.should.equal(TOTAL_SYSTEMS);
-        });
+        }, 120000);
 
         test('does not create remediations with more than 50 unique systems', async () => {
             const name = 'remediation with too many systems';


### PR DESCRIPTION
## Summary by Sourcery

Enforce configurable size limits on remediation plan execution and update related tests and configuration.

New Features:
- Introduce configurable maximum systems and issues limits for remediation plan playbook execution, with a feature-flag-based bypass option.

Enhancements:
- Apply plan size validation before executing FiFi playbook runs to prevent overly large remediation plans from running.

Build:
- Add plan size limit configuration (systems, issues, bypass feature flag) to the application config.

Tests:
- Add integration tests covering plan size limit enforcement, bypass behavior via feature flag, and adjust large-remediation creation test to use 19k systems with an extended timeout.