### PR TITLE
RHINENG-28559: Replace uuid dependency with crypto.randomUUID (foreman-3.16)

### DIFF
--- a/db/seeders/20240326162729-scalability.js
+++ b/db/seeders/20240326162729-scalability.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const UUID = require('uuid');
 const { account_number, tenant_org_id, username: created_by } = require('../../src/connectors/users/mock').MOCK_USERS.fifi;
 const { systems } = require('../../src/connectors/inventory/impl.unit.data');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,8 +43,7 @@
         "sequelize": "6.37",
         "sequelize-cli": "^6.5.2",
         "swagger-ui-express": "^5.0.0",
-        "urijs": "^1.19.11",
-        "uuid": "^7.0.3"
+        "urijs": "^1.19.11"
       },
       "devDependencies": {
         "eslint": "9.26",
@@ -16068,14 +16067,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
@@ -28138,11 +28129,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-    },
-    "uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
     },
     "v8-to-istanbul": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "sequelize": "6.37",
     "sequelize-cli": "^6.5.2",
     "swagger-ui-express": "^5.0.0",
-    "urijs": "^1.19.11",
-    "uuid": "^7.0.3"
+    "urijs": "^1.19.11"
   },
   "devDependencies": {
     "eslint": "9.26",

--- a/src/connectors/inventory/systemGenerator.js
+++ b/src/connectors/inventory/systemGenerator.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require("lodash");
-const UUID = require("uuid");
 
 const NON_EXISTENT_SYSTEM = '1040856f-b772-44c7-83a9-eeeeeeeeeeee';
 const DISCONNECTED_SATELLITE = '409dd231-6297-43a6-a726-5ce56923d624';

--- a/src/connectors/receptor/mock.js
+++ b/src/connectors/receptor/mock.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { randomUUID } = require('crypto');
 const Connector = require('../Connector');
-const uuid = require('uuid');
 
 const CONNECTION_STATUS = {status: 'connected'};
 
@@ -19,7 +19,7 @@ module.exports = new class extends Connector {
     }
 
     async postInitialRequest () {
-        return {id: uuid.v4()};
+        return {id: randomUUID()};
     }
 
     async ping () {

--- a/src/middleware/reqId.js
+++ b/src/middleware/reqId.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const uuid = require('uuid');
+const { randomUUID } = require('crypto');
 const HEADER = 'x-rh-insights-request-id';
 
 /* eslint-disable security/detect-object-injection */
 module.exports = function (req, res, next) {
     if (typeof req.headers[HEADER] === 'undefined') {
-        req.headers[HEADER] = uuid.v4();
+        req.headers[HEADER] = randomUUID();
     }
 
     next();

--- a/src/remediations/controller.write.js
+++ b/src/remediations/controller.write.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const uuid = require('uuid');
+const { randomUUID } = require('crypto');
 const _ = require('lodash');
 const P = require('bluebird');
 
@@ -149,7 +149,7 @@ exports.create = errors.async(async function (req, res) {
         await storeSystemDetails(systemsById);
     }
 
-    const id = uuid.v4();
+    const id = randomUUID();
 
     const result = await db.s.transaction(async transaction => {
         const remediation = await db.remediation.create({

--- a/src/remediations/fifi.integration.js
+++ b/src/remediations/fifi.integration.js
@@ -1,5 +1,6 @@
 /*eslint-disable max-len*/
 'use strict';
+const { randomUUID } = require('crypto');
 const P = require('bluebird');
 const _ = require('lodash');
 const URI = require('urijs');
@@ -1051,15 +1052,13 @@ describe('FiFi', function () {
 
             test('post playbook run and store dispatcher runs', async () => {
                 const sandbox = base.getSandbox();
-                const { v4: uuidv4 } = require('uuid');
-
                 const remediationId = '0ecb5db7-2f1a-441b-8220-e5ce45066f50';
-                const fakeRunId = uuidv4();
-                sandbox.stub(fifi_2, 'uuidv4').returns(fakeRunId);
+                const fakeRunId = randomUUID();
+                sandbox.stub(fifi_2, 'generatePlaybookRunId').returns(fakeRunId);
 
                 const dispatcherResponse = [
-                    { code: 200, id: uuidv4() },
-                    { code: 200, id: uuidv4() }
+                    { code: 200, id: randomUUID() },
+                    { code: 200, id: randomUUID() }
                 ];
 
                 sandbox.stub(dispatcher, 'postV2PlaybookRunRequests').resolves(dispatcherResponse);
@@ -1093,22 +1092,20 @@ describe('FiFi', function () {
 
             test('post playbook run with dispatcher partial failure - saves all runs and returns 201', async function () {
                 const sandbox = base.getSandbox();
-                const { v4: uuidv4 } = require('uuid');
-
                 const remediationId = '0ecb5db7-2f1a-441b-8220-e5ce45066f50';
-                const fakeRunId = uuidv4();
-                sandbox.stub(fifi_2, 'uuidv4').returns(fakeRunId);
+                const fakeRunId = randomUUID();
+                sandbox.stub(fifi_2, 'generatePlaybookRunId').returns(fakeRunId);
 
                 const dispatcherResponse = [
-                    { code: 200, id: uuidv4() },
-                    { code: 200, id: uuidv4() },
-                    { code: 400, id: uuidv4() },
-                    { code: 200, id: uuidv4() },
-                    { code: 500, id: uuidv4() },
-                    { code: 200, id: uuidv4() },
-                    { code: 200, id: uuidv4() },
-                    { code: 200, id: uuidv4() },
-                    { code: 200, id: uuidv4() }
+                    { code: 200, id: randomUUID() },
+                    { code: 200, id: randomUUID() },
+                    { code: 400, id: randomUUID() },
+                    { code: 200, id: randomUUID() },
+                    { code: 500, id: randomUUID() },
+                    { code: 200, id: randomUUID() },
+                    { code: 200, id: randomUUID() },
+                    { code: 200, id: randomUUID() },
+                    { code: 200, id: randomUUID() }
                 ];
 
                 sandbox.stub(dispatcher, 'postV2PlaybookRunRequests').resolves(dispatcherResponse);
@@ -1298,8 +1295,8 @@ describe('FiFi', function () {
                 // do not create db record
                 base.getSandbox().stub(queries, 'insertRHCPlaybookRun').returns();
 
-                // force uuid for snapshot test
-                base.getSandbox().stub(fifi_2, 'uuidv4').returns('b995e750-c1d3-4c5b-a3ec-eee897ee9065');
+                // fixed playbook run ID for snapshot test
+                base.getSandbox().stub(fifi_2, 'generatePlaybookRunId').returns('b995e750-c1d3-4c5b-a3ec-eee897ee9065');
 
                 const spy = base.getSandbox().spy(dispatcher, 'postV2PlaybookRunRequests');
 
@@ -1341,8 +1338,8 @@ describe('FiFi', function () {
                 // do not create db record
                 base.getSandbox().stub(queries, 'insertRHCPlaybookRun').returns();
 
-                // force uuid for snapshot test
-                base.getSandbox().stub(fifi_2, 'uuidv4').returns('b995e750-c1d3-4c5b-a3ec-eee897ee9065');
+                // fixed playbook run ID for snapshot test
+                base.getSandbox().stub(fifi_2, 'generatePlaybookRunId').returns('b995e750-c1d3-4c5b-a3ec-eee897ee9065');
 
                 const spy = base.getSandbox().spy(dispatcher, 'postV2PlaybookRunRequests');
 
@@ -1926,16 +1923,14 @@ describe('FiFi', function () {
     describe('syncDispatcherRunsForPlaybookRuns', function () {
         test('syncDispatcherRunsForPlaybookRuns backfill', async () => {
             const sandbox = base.getSandbox();
-            const { v4: uuidv4 } = require('uuid');
-
             // Use an existing playbook run that has no dispatcher_runs
             const playbookRunId = '88d0ba73-0015-4e7d-a6d6-4b530cbfb5bc';
 
             // Mock dispatcher API response
             sandbox.stub(dispatcher, 'fetchPlaybookRuns').resolves({
                 data: [
-                    { id: uuidv4(), status: 'success' },
-                    { id: uuidv4(), status: 'pending' }
+                    { id: randomUUID(), status: 'success' },
+                    { id: randomUUID(), status: 'pending' }
                 ]
             });
 
@@ -1969,14 +1964,12 @@ describe('FiFi', function () {
 
         test('syncDispatcherRunsForPlaybookRuns status update', async () => {
             const sandbox = base.getSandbox();
-            const { v4: uuidv4 } = require('uuid');
-
             // Use an existing playbook run
             const playbookRunId = '88d0ba73-0015-4e7d-a6d6-4b530cbfb6bc';
 
             // Create some incomplete dispatcher_runs first
-            const dispatcherRunId1 = uuidv4();
-            const dispatcherRunId2 = uuidv4();
+            const dispatcherRunId1 = randomUUID();
+            const dispatcherRunId2 = randomUUID();
             
             await db.dispatcher_runs.bulkCreate([
                 {
@@ -2027,15 +2020,13 @@ describe('FiFi', function () {
 
         test('syncDispatcherRunsForPlaybookRuns skip failed', async () => {
             const sandbox = base.getSandbox();
-            const { v4: uuidv4 } = require('uuid');
-
             // Use an existing playbook run
             const playbookRunId = '11f7f24a-346b-405c-8dcc-c953511fb21c';
 
             // Create dispatcher_runs with one failed status
             await db.dispatcher_runs.bulkCreate([
                 {
-                    dispatcher_run_id: uuidv4(),
+                    dispatcher_run_id: randomUUID(),
                     remediations_run_id: playbookRunId,
                     status: 'failure',
                     created_at: new Date(),
@@ -2043,7 +2034,7 @@ describe('FiFi', function () {
                     pd_response_code: null
                 },
                 {
-                    dispatcher_run_id: uuidv4(),
+                    dispatcher_run_id: randomUUID(),
                     remediations_run_id: playbookRunId,
                     status: 'pending',
                     created_at: new Date(),

--- a/src/remediations/fifi.js
+++ b/src/remediations/fifi.js
@@ -3,7 +3,6 @@
 
 const _ = require('lodash');
 const P = require('bluebird');
-const {v4: uuidv4} = require('uuid');
 
 const config = require('../config');
 const errors = require('../errors');

--- a/src/remediations/fifi.unit.js
+++ b/src/remediations/fifi.unit.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const base = require('../test');
-const {v4: uuid} = require('uuid');
+const { randomUUID } = require('crypto');
 const fifi = require('./fifi');
 const fifi2 = require('./fifi_2');
 const db = require('../db');
@@ -34,21 +34,21 @@ const REMEDIATIONISSUES = [
         issue_id: 'ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_disabled',
         resolution: null,
         systems: [
-            {system_id: uuid()}, {system_id: uuid()}, {system_id: SYSTEMS[0].id}
+            {system_id: randomUUID()}, {system_id: randomUUID()}, {system_id: SYSTEMS[0].id}
         ]
     },
     {
         issue_id: 'ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_enabled',
         resolution: null,
         systems: [
-            {system_id: uuid()}, {system_id: uuid()}, {system_id: uuid()}
+            {system_id: randomUUID()}, {system_id: randomUUID()}, {system_id: randomUUID()}
         ]
     },
     {
         issue_id: 'ssg:rhel7|standard|xccdf_org.ssgproject.content_rule_service_autofs_connected',
         resolution: null,
         systems: [
-            {system_id: SYSTEMS[0].id}, {system_id: SYSTEMS[1].id}, {system_id: uuid()}
+            {system_id: SYSTEMS[0].id}, {system_id: SYSTEMS[1].id}, {system_id: randomUUID()}
         ]
     },
     {
@@ -83,9 +83,9 @@ describe('playbook run functions', function () {
 });
 
 describe('syncDispatcherRunsForPlaybookRuns', function () {
-    const mockPlaybookRunId1 = uuid();
-    const mockPlaybookRunId2 = uuid();
-    const mockPlaybookRunId3 = uuid();
+    const mockPlaybookRunId1 = randomUUID();
+    const mockPlaybookRunId2 = randomUUID();
+    const mockPlaybookRunId3 = randomUUID();
 
     test('should return empty array when no playbook run IDs provided', async () => {
         const result = await fifi2.syncDispatcherRunsForPlaybookRuns([]);
@@ -228,8 +228,8 @@ describe('syncDispatcherRunsForPlaybookRuns', function () {
     });
 
     test('should return only successfully synced playbook runs in mixed scenarios', async () => {
-        const mockPlaybookRunId4 = uuid();
-        const mockPlaybookRunId5 = uuid();
+        const mockPlaybookRunId4 = randomUUID();
+        const mockPlaybookRunId5 = randomUUID();
         
         // Mock queries.getPlaybookRunsWithDispatcherCounts - both need backfill
         base.sandbox.stub(queries, 'getPlaybookRunsWithDispatcherCounts').resolves([

--- a/src/remediations/fifi_2.js
+++ b/src/remediations/fifi_2.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { randomUUID } = require('crypto');
 const _ = require("lodash");
-const uuid = require("uuid");
 
 const format = require("./remediations.format_2");
 const errors = require("../errors");
@@ -37,9 +37,9 @@ exports.checkRhcEnabled = async function () {
 
 //======================================================================================================================
 
-// This is just so we can stub uuid.v4 to force a uuid for snapshot testing
-exports.uuidv4 = function () {
-    return uuid.v4();
+// Exported so tests can stub a fixed playbook run ID (snapshots, DB assertions)
+exports.generatePlaybookRunId = function () {
+    return randomUUID();
 };
 
 //--------------------------------------------
@@ -77,7 +77,7 @@ exports.uuidv4 = function () {
 //--------------------------------------------
 exports.createPlaybookRun = async function (recipients, exclude, remediation, username) {
     // create UUID for this run
-    const playbook_run_id = exports.uuidv4();
+    const playbook_run_id = exports.generatePlaybookRunId();
 
     // check if excludes contains anything NOT in targets
     validateExcludes(exclude, recipients);

--- a/src/remediations/read.integration.js
+++ b/src/remediations/read.integration.js
@@ -11,7 +11,7 @@ const impl = require('../connectors/dispatcher/impl');
 const dispatcher = require('../connectors/dispatcher');
 const fifi2 = require('./fifi_2');
 const db = require('../db');
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 
 function test400 (name, url, code, title) {
     test(name, async () => {
@@ -57,7 +57,7 @@ describe('remediations', function () {
         });
 
         test('v1 SSG issue id fails with INVALID_ISSUE_IDENTIFIER', async () => {
-            const remId = uuidv4();
+            const remId = randomUUID();
             createdIds.push(remId);
 
             await db.remediation.create({
@@ -93,7 +93,7 @@ describe('remediations', function () {
         });
 
         test('v2 SSG issue id succeeds', async () => {
-            const remId = uuidv4();
+            const remId = randomUUID();
             createdIds.push(remId);
 
             await db.remediation.create({
@@ -284,7 +284,6 @@ describe('remediations', function () {
                 let isolatedDispatcherRunIds = [];
 
                 beforeEach(async () => {
-                    const { v4: uuidv4 } = require('uuid');
                     const now = new Date();
                     const { username: created_by } = require('../connectors/users/mock').MOCK_USERS.fifi;
                     
@@ -309,7 +308,7 @@ describe('remediations', function () {
                         });
 
                         // Create a fresh playbook_run for r178 to use for running status
-                        const r178PlaybookRunId = uuidv4();
+                        const r178PlaybookRunId = randomUUID();
                         await db.playbook_runs.create({
                             id: r178PlaybookRunId,
                             status: 'running',
@@ -320,9 +319,9 @@ describe('remediations', function () {
                         }, { transaction });
 
                         // Create isolated dispatcher_runs with unique IDs we can track
-                        const runningDispatcherRun1 = uuidv4();
-                        const runningDispatcherRun2 = uuidv4();
-                        const failureDispatcherRun = uuidv4();
+                        const runningDispatcherRun1 = randomUUID();
+                        const runningDispatcherRun2 = randomUUID();
+                        const failureDispatcherRun = randomUUID();
                         
                         isolatedDispatcherRunIds = [runningDispatcherRun1, runningDispatcherRun2, failureDispatcherRun, r178PlaybookRunId];
 
@@ -664,7 +663,7 @@ describe('remediations', function () {
         // The seeded 'unknown issues' plan includes a v1 SSG id that now returns 400 (invalid identifier), so we can't use it here.
         test('get remediation with unknown issues', async () => {
             const { account_number, tenant_org_id, username: created_by } = require('../connectors/users/mock').MOCK_USERS.testReadSingleUser;
-            const remId = uuidv4();
+            const remId = randomUUID();
 
             try {
                 await db.remediation.create({

--- a/src/remediations/write.integration.js
+++ b/src/remediations/write.integration.js
@@ -5,7 +5,7 @@ const config = require('../config');
 const rbac = require('../connectors/rbac');
 const { request, reqId, auth, getSandbox, buildRbacResponse } = require('../test');
 const { NON_EXISTENT_SYSTEM } = require('../connectors/inventory/mock');
-const uuid = require('uuid');
+const { randomUUID } = require('crypto');
 const db = require('../db');
 
 function testIssue (remediation, id, resolution, systems) {
@@ -204,7 +204,7 @@ describe('remediations', function () {
 
         test('creates a new remediation with 20k systems', async () => {
             const name = `new remediation with issues 2`;
-            const systems = _.times(20000, () => uuid.v4());
+            const systems = _.times(20000, () => randomUUID());
 
             const {body: {id}} = await request
             .post('/v1/remediations')

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -3,7 +3,7 @@
 require('should');
 const sinon = require('sinon');
 const supertest = require('supertest');
-const uuid = require('uuid');
+const { randomUUID } = require('crypto');
 
 const app = require('../app');
 const config = require('../config');
@@ -156,7 +156,7 @@ exports.throw404 = () => {
 };
 
 exports.reqId = () => {
-    const id = uuid.v4();
+    const id = randomUUID();
 
     return {
         header: {


### PR DESCRIPTION
## Summary by Sourcery

Replace usage of the external uuid library with Node.js built-in crypto.randomUUID across remediations, middleware, connectors, and tests, and expose a dedicated playbook run ID generator for easier stubbing in tests.

Enhancements:
- Introduce a generatePlaybookRunId helper in fifi_2 to encapsulate playbook run ID creation and make it easier to stub in tests.
- Refactor receptor connector mock and request ID middleware to rely on crypto.randomUUID instead of the uuid package.

Build:
- Remove the uuid dependency from package.json now that ID generation uses the built-in crypto module.

Tests:
- Update integration and unit tests to stub generatePlaybookRunId and to use crypto.randomUUID-generated IDs instead of the uuid library.