### PR TITLE
chore: update image base and rpm lock (foreman-3.16)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 #----------------------- base -----------------------
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782366411 AS base
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1784092902 AS base
 
 RUN microdnf module enable -y nodejs:22 && \
     microdnf install -y shadow-utils jq nodejs npm --nodocs && \

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -4,41 +4,41 @@ lockfileVendor: redhat
 arches:
 - arch: x86_64
   packages:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/nodejs-22.22.2-1.module+el9.7.0+24157+8ddb2461.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/nodejs-22.23.1-1.module+el9.8.0+24457+996af7aa.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 2392597
-    checksum: sha256:9bd07b86de1b32ab5c9bcc189f489906235550ef8fe90f5dc65953329d260af1
+    size: 2393237
+    checksum: sha256:0687f854e38bcb7382884a786f9d728afc1fd95c4d904c76a2212a497cba0d66
     name: nodejs
-    evr: 1:22.22.2-1.module+el9.7.0+24157+8ddb2461
-    sourcerpm: nodejs-22.22.2-1.module+el9.7.0+24157+8ddb2461.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/nodejs-docs-22.22.2-1.module+el9.7.0+24157+8ddb2461.noarch.rpm
+    evr: 1:22.23.1-1.module+el9.8.0+24457+996af7aa
+    sourcerpm: nodejs-22.23.1-1.module+el9.8.0+24457+996af7aa.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/nodejs-docs-22.23.1-1.module+el9.8.0+24457+996af7aa.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 9697379
-    checksum: sha256:a05a841a36332d6c37b7bfad11a364121b1ed8a6a7a3aed5ed26d1bf19285edd
+    size: 9700893
+    checksum: sha256:6f5d6b98f4ee15a9609626f57d89eb0b19cf9fd8d16a29662f4559f5b54491e6
     name: nodejs-docs
-    evr: 1:22.22.2-1.module+el9.7.0+24157+8ddb2461
-    sourcerpm: nodejs-22.22.2-1.module+el9.7.0+24157+8ddb2461.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/nodejs-full-i18n-22.22.2-1.module+el9.7.0+24157+8ddb2461.x86_64.rpm
+    evr: 1:22.23.1-1.module+el9.8.0+24457+996af7aa
+    sourcerpm: nodejs-22.23.1-1.module+el9.8.0+24457+996af7aa.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/nodejs-full-i18n-22.23.1-1.module+el9.8.0+24457+996af7aa.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 9307454
-    checksum: sha256:6997ffc4b1b4c173f754c948ecc5c4e2556081e61cb68364bf4739355d4ffa46
+    size: 9307815
+    checksum: sha256:0f3ff55b2177f88a93a4a4899e051d472b0ced2380784f0e8260ffac186c4728
     name: nodejs-full-i18n
-    evr: 1:22.22.2-1.module+el9.7.0+24157+8ddb2461
-    sourcerpm: nodejs-22.22.2-1.module+el9.7.0+24157+8ddb2461.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/nodejs-libs-22.22.2-1.module+el9.7.0+24157+8ddb2461.x86_64.rpm
+    evr: 1:22.23.1-1.module+el9.8.0+24457+996af7aa
+    sourcerpm: nodejs-22.23.1-1.module+el9.8.0+24457+996af7aa.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/nodejs-libs-22.23.1-1.module+el9.8.0+24457+996af7aa.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 21516839
-    checksum: sha256:798d481fa711081e5de0935441804d0d7ab7ebf03276493edd41cc6b1297ed6e
+    size: 21551441
+    checksum: sha256:ae5b162e321ba768499dbfad5f7608a4cc4dc49f9b420df7aabb1c19ef90522c
     name: nodejs-libs
-    evr: 1:22.22.2-1.module+el9.7.0+24157+8ddb2461
-    sourcerpm: nodejs-22.22.2-1.module+el9.7.0+24157+8ddb2461.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/npm-10.9.7-1.22.22.2.1.module+el9.7.0+24157+8ddb2461.x86_64.rpm
+    evr: 1:22.23.1-1.module+el9.8.0+24457+996af7aa
+    sourcerpm: nodejs-22.23.1-1.module+el9.8.0+24457+996af7aa.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/npm-10.9.8-1.22.23.1.1.module+el9.8.0+24457+996af7aa.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 2604983
-    checksum: sha256:69bc1c72dbc7bbea22bf63af79c9718d637e84d5b87c40818678940473c0114a
+    size: 2605462
+    checksum: sha256:eb35eac7022ac186842d85ad250713b8a90010e66f485944d0cb6c6d77a8a53b
     name: npm
-    evr: 1:10.9.7-1.22.22.2.1.module+el9.7.0+24157+8ddb2461
-    sourcerpm: nodejs-22.22.2-1.module+el9.7.0+24157+8ddb2461.src.rpm
+    evr: 1:10.9.8-1.22.23.1.1.module+el9.8.0+24457+996af7aa
+    sourcerpm: nodejs-22.23.1-1.module+el9.8.0+24457+996af7aa.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/oniguruma-6.9.6-1.el9.5.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 226331
@@ -60,16 +60,16 @@ arches:
     name: libbrotli
     evr: 1.0.9-9.el9_7
     sourcerpm: brotli-1.0.9-9.el9_7.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-3.5.5-4.el9_8.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-3.5.5-5.el9_8.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 1564134
-    checksum: sha256:e0e2c1f901d3f6245ff43f194ac11ba133cf99c630307239722c07a2282a1356
+    size: 1563716
+    checksum: sha256:7d6537b3a4e4e5a1fe0dc17b0d7794e466b3dd20f9dc34356dbbfe12b4ac2d44
     name: openssl
-    evr: 1:3.5.5-4.el9_8
-    sourcerpm: openssl-3.5.5-4.el9_8.src.rpm
+    evr: 1:3.5.5-5.el9_8
+    sourcerpm: openssl-3.5.5-5.el9_8.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/9cfecf89b5815144033d54bad8637384c4ad6ec28dc4a0f512cec26ad346d598-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/6a7f59fb17cc7757d218b9f093147e1b81ea98307f2094728c8d13314f186edc-modules.yaml.gz
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 8642
-    checksum: sha256:9cfecf89b5815144033d54bad8637384c4ad6ec28dc4a0f512cec26ad346d598
+    size: 8512
+    checksum: sha256:6a7f59fb17cc7757d218b9f093147e1b81ea98307f2094728c8d13314f186edc


### PR DESCRIPTION
## Summary by Sourcery

Update pinned UBI9 RPMs for Foreman 3.16 to newer Node.js, npm, and OpenSSL builds, refreshing associated module metadata in rpms.lock.yaml.

Build:
- Refresh rpms.lock.yaml to track updated UBI9 appstream/baseos RPM artifacts for Node.js, npm, and OpenSSL.

Chores:
- Align rpm lockfile with latest compatible upstream UBI9 repositories for Foreman 3.16.