### PR TITLE
RHINENG-28446: Clear cache when updating remediation plan

### DIFF
--- a/src/remediations/controller.write.js
+++ b/src/remediations/controller.write.js
@@ -8,12 +8,24 @@ const config = require('../config');
 const errors = require('../errors');
 const issues = require('../issues');
 const db = require('../db');
+const cache = require('../cache');
 const format = require('./remediations.format');
 const inventory = require('../connectors/inventory');
 const identifiers = require('../util/identifiers');
 const disambiguator = require('../resolutions/disambiguator');
+const log = require('../util/log');
 
 const notFound = res => res.status(404).json();
+
+async function clearRemediationsCache (id) {
+    if (config.redis.enabled) {
+        try {
+            await cache.get().del(`remediations|db-cache|remediation|${id}`);
+        } catch (err) {
+            log.warn(err, 'failed to clear remediations cache');
+        }
+    }
+}
 
 async function validateResolution (id, resolutionId) {
     const identifier = identifiers.parse(id);
@@ -245,12 +257,16 @@ exports.patch = errors.async(async function (req, res) {
         return true;
     });
 
-    // Cache system details after remediation is successfully updated
-    if (result && systemsById) {
-        await storeSystemDetails(systemsById);
-    }
+    if (result) {
+        await clearRemediationsCache(id);
 
-    result && res.status(200).end();
+        // Cache system details after remediation is successfully updated
+        if (systemsById) {
+            await storeSystemDetails(systemsById);
+        }
+
+        res.status(200).end();
+    }
 });
 
 exports.patchIssue = errors.async(async function (req, res) {
@@ -274,6 +290,7 @@ exports.patchIssue = errors.async(async function (req, res) {
     });
 
     if (result) {
+        await clearRemediationsCache(req.params.id);
         return res.status(200).end();
     }
 });
@@ -321,8 +338,9 @@ function findAndDestroy (req, entity, query, res) {
 
             return true;
         }
-    }).then(result => {
+    }).then(async result => {
         if (result) {
+            await clearRemediationsCache(req.params.id);
             return res.status(204).end();
         }
 
@@ -351,7 +369,13 @@ function findAllAndDestroy (req, entity, query, res) {
         }
 
         return 0;
-    })
+    }).then(async count => {
+        if (count > 0) {
+            await clearRemediationsCache(req.params.id);
+        }
+
+        return count;
+    });
 }
 
 exports.remove = errors.async(function (req, res) {
@@ -372,7 +396,8 @@ exports.bulkRemove = errors.async((req, res) => {
     // delete all specified remediations
     return db.remediation.destroy({where: {id: ids, tenant_org_id, created_by}})
 
-    .then(result => {
+    .then(async result => {
+        await P.map(ids, id => clearRemediationsCache(id));
         return res.status(200).json({deleted_count: result});
     });
 });
@@ -405,7 +430,8 @@ exports.bulkRemoveIssues = errors.async(async function (req, res) {
 
         // remove the specified issues.  This will cascade delete any issue_systems as well.
         return db.issue.destroy({where: {issue_id: issue_ids, remediation_id}})
-        .then(count => {
+        .then(async count => {
+            await clearRemediationsCache(remediation_id);
             return res.status(200).json({deleted_count: count});
         });
     });

--- a/src/remediations/write.integration.js
+++ b/src/remediations/write.integration.js
@@ -8,6 +8,7 @@ const { request, reqId, auth, getSandbox, buildRbacResponse } = require('../test
 const { NON_EXISTENT_SYSTEM } = require('../connectors/inventory/mock');
 const { randomUUID } = require('crypto');
 const db = require('../db');
+const cache = require('../cache');
 
 function testIssue (remediation, id, resolution, systems) {
     const issue = _.find(remediation.issues, {id});
@@ -965,6 +966,30 @@ describe('remediations', function () {
 
     describe('update', function () {
         describe('remediation', function () {
+            test('clears remediation playbook cache on patch', async () => {
+                const mockRedis = {
+                    status: 'ready',
+                    del: getSandbox().stub().resolves(1)
+                };
+                getSandbox().stub(config.redis, 'enabled').value(true);
+                getSandbox().stub(cache, 'get').returns(mockRedis);
+
+                const {body: created} = await request
+                .post('/v1/remediations')
+                .set(auth.testWrite)
+                .send({name: 'cache-invalidation-plan'})
+                .expect(201);
+
+                await request
+                .patch(`/v1/remediations/${created.id}`)
+                .send({name: 'cache-invalidation-plan-renamed'})
+                .set(auth.testWrite)
+                .expect(200);
+
+                mockRedis.del.should.have.been.calledOnce;
+                mockRedis.del.args[0][0].should.equal(`remediations|db-cache|remediation|${created.id}`);
+            });
+
             test('adding actions to empty remediation', async () => {
                 const url = '/v1/remediations/3c1877a0-bbcd-498a-8349-272129dc0b88';
                 const systems = ['56db4b54-6273-48dc-b0be-41eb4dc87c7f', 'f5ce853a-c922-46f7-bd82-50286b7d8459'];


### PR DESCRIPTION
## Summary by Sourcery

Invalidate remediation cache in Redis when remediation plans or issues are updated or deleted.

Enhancements:
- Introduce a reusable helper to clear remediation cache entries when a remediation or its issues are patched or removed.

Tests:
- Add integration test verifying remediation cache invalidation on remediation patch operations.