### PR TITLE
Update registry.access.redhat.com/ubi9/ubi-minimal Docker tag to v9.8-1785906621

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Default value for BASE_IMAGE
-BASE_IMAGE ?= registry.access.redhat.com/ubi9/ubi-minimal:9.6-1758184547
+BASE_IMAGE ?= registry.access.redhat.com/ubi9/ubi-minimal:9.8-1785906621
 # Default value for CONTAINERFILE
 CONTAINERFILE ?= Dockerfile
 
@@ -61,7 +61,7 @@ generate-rpms-in-yaml:
 
 # Generate rpms.lock.yaml using rpm-lockfile-prototype container
 # Usage: make generate-rpm-lockfile [BASE_IMAGE=<image>]
-# Example: make generate-rpm-lockfile BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:9.6-1758184547
+# Example: make generate-rpm-lockfile BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:9.8-1785906621
 #          make generate-rpm-lockfile (uses default BASE_IMAGE)
 .PHONY: generate-rpm-lockfile-containerized
 generate-rpm-lockfile-containerized: rpms.in.yaml

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 #----------------------- base -----------------------
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:1785339196 AS base
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1785906621 AS base
 
 RUN microdnf module enable -y nodejs:22 && \
     microdnf install -y shadow-utils jq nodejs npm --nodocs && \

--- a/build/Dockerfile.test
+++ b/build/Dockerfile.test
@@ -1,1 +1,1 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:1785339196 AS base
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1785906621 AS base

--- a/build/Dockerfile.upstream
+++ b/build/Dockerfile.upstream
@@ -1,6 +1,6 @@
 #----------------------- base -----------------------
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:1785339196 AS base
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1785906621 AS base
 
 RUN microdnf module enable -y nodejs:22 && \
     microdnf install -y shadow-utils jq nodejs npm --nodocs && \

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -4,41 +4,41 @@ lockfileVendor: redhat
 arches:
 - arch: x86_64
   packages:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/nodejs-22.22.2-1.module+el9.7.0+24157+8ddb2461.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/nodejs-22.23.1-2.module+el9.8.0+24538+3f176d52.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 2392597
-    checksum: sha256:9bd07b86de1b32ab5c9bcc189f489906235550ef8fe90f5dc65953329d260af1
+    size: 2396412
+    checksum: sha256:e77b55238f02baf44787f2b1e377ada5e7e42c919f397dc16312a057d1648369
     name: nodejs
-    evr: 1:22.22.2-1.module+el9.7.0+24157+8ddb2461
-    sourcerpm: nodejs-22.22.2-1.module+el9.7.0+24157+8ddb2461.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/nodejs-docs-22.22.2-1.module+el9.7.0+24157+8ddb2461.noarch.rpm
+    evr: 1:22.23.1-2.module+el9.8.0+24538+3f176d52
+    sourcerpm: nodejs-22.23.1-2.module+el9.8.0+24538+3f176d52.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/nodejs-docs-22.23.1-2.module+el9.8.0+24538+3f176d52.noarch.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 9697379
-    checksum: sha256:a05a841a36332d6c37b7bfad11a364121b1ed8a6a7a3aed5ed26d1bf19285edd
+    size: 9701312
+    checksum: sha256:c7f9a8b6e8d53ed52acc4ab421a3d8a4e057cba1c11a67d0b47b35b593686516
     name: nodejs-docs
-    evr: 1:22.22.2-1.module+el9.7.0+24157+8ddb2461
-    sourcerpm: nodejs-22.22.2-1.module+el9.7.0+24157+8ddb2461.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/nodejs-full-i18n-22.22.2-1.module+el9.7.0+24157+8ddb2461.x86_64.rpm
+    evr: 1:22.23.1-2.module+el9.8.0+24538+3f176d52
+    sourcerpm: nodejs-22.23.1-2.module+el9.8.0+24538+3f176d52.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/nodejs-full-i18n-22.23.1-2.module+el9.8.0+24538+3f176d52.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 9307454
-    checksum: sha256:6997ffc4b1b4c173f754c948ecc5c4e2556081e61cb68364bf4739355d4ffa46
+    size: 9307989
+    checksum: sha256:780f712da5f13fbb46748ca26e2d9250a270d48634c27a78044e15b5ad8ad0bc
     name: nodejs-full-i18n
-    evr: 1:22.22.2-1.module+el9.7.0+24157+8ddb2461
-    sourcerpm: nodejs-22.22.2-1.module+el9.7.0+24157+8ddb2461.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/nodejs-libs-22.22.2-1.module+el9.7.0+24157+8ddb2461.x86_64.rpm
+    evr: 1:22.23.1-2.module+el9.8.0+24538+3f176d52
+    sourcerpm: nodejs-22.23.1-2.module+el9.8.0+24538+3f176d52.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/nodejs-libs-22.23.1-2.module+el9.8.0+24538+3f176d52.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 21516839
-    checksum: sha256:798d481fa711081e5de0935441804d0d7ab7ebf03276493edd41cc6b1297ed6e
+    size: 21551464
+    checksum: sha256:2ca708cc615680cfb99ece0c1e3735151b704b563d0724b248c1cca5ffa9aa8c
     name: nodejs-libs
-    evr: 1:22.22.2-1.module+el9.7.0+24157+8ddb2461
-    sourcerpm: nodejs-22.22.2-1.module+el9.7.0+24157+8ddb2461.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/npm-10.9.7-1.22.22.2.1.module+el9.7.0+24157+8ddb2461.x86_64.rpm
+    evr: 1:22.23.1-2.module+el9.8.0+24538+3f176d52
+    sourcerpm: nodejs-22.23.1-2.module+el9.8.0+24538+3f176d52.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/n/npm-10.9.8-1.22.23.1.2.module+el9.8.0+24538+3f176d52.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 2604983
-    checksum: sha256:69bc1c72dbc7bbea22bf63af79c9718d637e84d5b87c40818678940473c0114a
+    size: 2607829
+    checksum: sha256:792e6f01eba9934a03ecbd9b44d14c6ecf3dde8323f7612b257f0f557c7dba50
     name: npm
-    evr: 1:10.9.7-1.22.22.2.1.module+el9.7.0+24157+8ddb2461
-    sourcerpm: nodejs-22.22.2-1.module+el9.7.0+24157+8ddb2461.src.rpm
+    evr: 1:10.9.8-1.22.23.1.2.module+el9.8.0+24538+3f176d52
+    sourcerpm: nodejs-22.23.1-2.module+el9.8.0+24538+3f176d52.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/oniguruma-6.9.6-1.el9.5.x86_64.rpm
     repoid: ubi-9-for-x86_64-appstream-rpms
     size: 226331
@@ -60,23 +60,46 @@ arches:
     name: libbrotli
     evr: 1.0.9-9.el9_7
     sourcerpm: brotli-1.0.9-9.el9_7.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-3.5.5-2.el9_8.x86_64.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-3.5.5-6.el9_8.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 1563757
-    checksum: sha256:26055bafcbb940413352fefaf53c3944b95f9420474bf33670be625a01b7b70e
+    size: 1564334
+    checksum: sha256:1c502507f42674119318b66b111448f618efe2767a55edde5fadddcecb47ac64
     name: openssl
-    evr: 1:3.5.5-2.el9_8
-    sourcerpm: openssl-3.5.5-2.el9_8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssl-libs-3.5.5-2.el9_8.x86_64.rpm
-    repoid: ubi-9-for-x86_64-baseos-rpms
-    size: 2424631
-    checksum: sha256:7d7b72a2767cf95d7de49c1b17bad32e974970c947b1d6b5f133918088379fed
-    name: openssl-libs
-    evr: 1:3.5.5-2.el9_8
-    sourcerpm: openssl-3.5.5-2.el9_8.src.rpm
-  source: []
+    evr: 1:3.5.5-6.el9_8
+    sourcerpm: openssl-3.5.5-6.el9_8.src.rpm
+  source:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/n/nodejs-22.23.1-2.module+el9.8.0+24538+3f176d52.src.rpm
+    repoid: ubi-9-for-x86_64-appstream-source-rpms
+    size: 96697297
+    checksum: sha256:e2474475abc433d2b04d27c1599567b974f30c2a89f39f8a38363f8d31ec5af8
+    name: nodejs
+    evr: 1:22.23.1-2.module+el9.8.0+24538+3f176d52
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/source/SRPMS/Packages/o/oniguruma-6.9.6-1.el9.5.src.rpm
+    repoid: ubi-9-for-x86_64-appstream-source-rpms
+    size: 934541
+    checksum: sha256:cba17754ccaffd886995aec7f152aadbc5d9932a2a2cdf1d983291c7b2838404
+    name: oniguruma
+    evr: 6.9.6-1.el9.5
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/b/brotli-1.0.9-9.el9_7.src.rpm
+    repoid: ubi-9-for-x86_64-baseos-source-rpms
+    size: 517498
+    checksum: sha256:814868e0bec831c79d3e12ff76d31e06e5e62c462a1a4b6607b1f3cab7014438
+    name: brotli
+    evr: 1.0.9-9.el9_7
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/j/jq-1.6-19.el9_8.2.src.rpm
+    repoid: ubi-9-for-x86_64-baseos-source-rpms
+    size: 1512470
+    checksum: sha256:abe953ef93fb49db17177190dc0698ab649f18a0bfaef4bb0ef0cd94644d1ec3
+    name: jq
+    evr: 1.6-19.el9_8.2
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/source/SRPMS/Packages/o/openssl-3.5.5-6.el9_8.src.rpm
+    repoid: ubi-9-for-x86_64-baseos-source-rpms
+    size: 53369050
+    checksum: sha256:b79f08d2d04536fdb6801b6ba7da7174942d174dd2b7969316402c737689d735
+    name: openssl
+    evr: 1:3.5.5-6.el9_8
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/ff56dd8c70306f679ff16d6b3698664d8ce0142c5966758f31bd7ef716118043-modules.yaml.gz
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/repodata/ba2509e948df92bcd624645302c245188ede99512339730b4c443c7e30d8def3-modules.yaml.gz
     repoid: ubi-9-for-x86_64-appstream-rpms
-    size: 8522
-    checksum: sha256:ff56dd8c70306f679ff16d6b3698664d8ce0142c5966758f31bd7ef716118043
+    size: 8062
+    checksum: sha256:ba2509e948df92bcd624645302c245188ede99512339730b4c443c7e30d8def3

--- a/ubi.repo
+++ b/ubi.repo
@@ -1,60 +1,60 @@
-[ubi-9-for-$basearch-baseos-rpms]
+[ubi-9-for-x86_64-baseos-rpms]
 name = Red Hat Universal Base Image 9 (RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-for-$basearch-baseos-debug-rpms]
+[ubi-9-baseos-debug-rpms]
 name = Red Hat Universal Base Image 9 (Debug RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-for-$basearch-baseos-source-rpms]
+[ubi-9-for-x86_64-baseos-source-rpms]
 name = Red Hat Universal Base Image 9 (Source RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/source/SRPMS
-enabled = 0
+enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-for-$basearch-appstream-rpms]
+[ubi-9-for-x86_64-appstream-rpms]
 name = Red Hat Universal Base Image 9 (RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-for-$basearch-appstream-debug-rpms]
+[ubi-9-appstream-debug-rpms]
 name = Red Hat Universal Base Image 9 (Debug RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-9-for-$basearch-appstream-source-rpms]
+[ubi-9-for-x86_64-appstream-source-rpms]
 name = Red Hat Universal Base Image 9 (Source RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/source/SRPMS
-enabled = 0
+enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[codeready-builder-for-ubi-9-$basearch-rpms]
+[ubi-9-codeready-builder-rpms]
 name = Red Hat Universal Base Image 9 (RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[codeready-builder-for-ubi-9-$basearch-debug-rpms]
+[ubi-9-codeready-builder-debug-rpms]
 name = Red Hat Universal Base Image 9 (Debug RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[codeready-builder-for-ubi-9-$basearch-source-rpms]
+[ubi-9-codeready-builder-source-rpms]
 name = Red Hat Universal Base Image 9 (Source RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/source/SRPMS
 enabled = 0


### PR DESCRIPTION
## Summary by Sourcery

Update the UBI9 base image and associated RPM lockfile for Node.js and OpenSSL to the latest 9.8-based artifacts.

Enhancements:
- Refresh Node.js 22 and npm RPMs to newer 9.8 module builds and add corresponding source RPM references in rpms.lock.yaml.
- Update OpenSSL RPM entries and module metadata in rpms.lock.yaml to align with the new base image contents.

Build:
- Bump the default ubi9/ubi-minimal base image tag to 9.8-1785906621 in the Makefile and Docker build files.