### PR TITLE
[RHCLOUD-49129] Upgrade kessel version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@godaddy/terminus": "^4.4.1",
-        "@project-kessel/kessel-sdk": "^3.2.0",
+        "@project-kessel/kessel-sdk": "^3.8.0",
         "app-common-js": "^2.2.4",
         "bluebird": "^3.7.2",
         "body-parser": "^1.20.3",
@@ -1652,12 +1652,12 @@
       }
     },
     "node_modules/@project-kessel/kessel-sdk": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@project-kessel/kessel-sdk/-/kessel-sdk-3.7.0.tgz",
-      "integrity": "sha512-GM1KCjrVNtXFrqHsJV5r+H/kERwKDVOeJLYqI4TLvd5vNxTyUB49U1juyP5Gh6q5DdWpBdQqeGYuejIIsFoR8A==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@project-kessel/kessel-sdk/-/kessel-sdk-3.8.0.tgz",
+      "integrity": "sha512-4hz4quMJpJvZzaCSJEsVkfEahJKdEsdP0y25ANZP7/wTRVG7kLv8YhnwZ0pO8KsKs465GTTLx1Zxp+v7vGGOLw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.13.4"
+        "@grpc/grpc-js": "^1.14.4"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@godaddy/terminus": "^4.4.1",
-    "@project-kessel/kessel-sdk": "^3.2.0",
+    "@project-kessel/kessel-sdk": "^3.8.0",
     "app-common-js": "^2.2.4",
     "bluebird": "^3.7.2",
     "body-parser": "^1.20.3",


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHCLOUD-49129
RBAC require explicit parameter to bypass the permission check when fetching default workspace

## Summary by Sourcery

Build:
- Update the @project-kessel/kessel-sdk package dependency from ^3.2.0 to ^3.8.0.